### PR TITLE
cloud-hypervisor: Switch to crates.io kvm-ioctls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "arch_gen 0.1.0",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.1.0 (git+https://github.com/rust-vmm/kvm-ioctls)",
+ "kvm-ioctls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
 ]
@@ -117,7 +117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "kvm-ioctls"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/kvm-ioctls#e0d6aefd28097446ee8fcd66160c583f165b5116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -174,7 +174,7 @@ dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
  "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.1.0 (git+https://github.com/rust-vmm/kvm-ioctls)",
+ "kvm-ioctls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-allocator 0.1.0",
@@ -458,7 +458,7 @@ dependencies = [
  "devices 0.1.0",
  "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.1.0 (git+https://github.com/rust-vmm/kvm-ioctls)",
+ "kvm-ioctls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "linux-loader 0.1.0 (git+https://github.com/bjzhjing/linux-loader)",
  "net_util 0.1.0",
@@ -510,7 +510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3f0680f2a6f2a17fa7a8668a27c54e45e1ad1cf8a632f56a7c19b9e4e3bbe8a"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c223e8703d2eb76d990c5f58e29c85b0f6f50e24b823babde927948e7c71fc03"
-"checksum kvm-ioctls 0.1.0 (git+https://github.com/rust-vmm/kvm-ioctls)" = "<none>"
+"checksum kvm-ioctls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f87b0c7322658f94e9fcf661146c9761a487813f3154e6a67a24fc59c68f5306"
 "checksum libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)" = "c6785aa7dd976f5fbf3b71cfd9cd49d7f783c1ff565a858d71031c6c313aa5c6"
 "checksum linux-loader 0.1.0 (git+https://github.com/bjzhjing/linux-loader)" = "<none>"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -6,9 +6,8 @@ authors = ["The Chromium OS Authors"]
 [dependencies]
 byteorder = "=1.2.1"
 kvm-bindings = "0.1"
+kvm-ioctls = "0.1.0"
 libc = ">=0.2.39"
-
-kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls" }
 
 arch_gen = { path = "../arch_gen" }
 

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 vm-allocator = { path = "../vm-allocator" }
 byteorder = "*"
 devices = { path = "../devices" }
-kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls" }
 kvm-bindings = "0.1"
+kvm-ioctls = "0.1.0"
 libc = ">=0.2.39"
 log = "*"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -9,7 +9,7 @@ arch = { path = "../arch" }
 devices = { path = "../devices" }
 epoll = "=4.0.1"
 kvm-bindings = "0.1"
-kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls" }
+kvm-ioctls = "0.1.0"
 libc = ">=0.2.39"
 net_util = { path = "../net_util" }
 pci = {path = "../pci"}


### PR DESCRIPTION
Fixes: #15

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>