### PR TITLE
Revert "main: Fix --net behavior"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,14 +80,9 @@ fn main() {
         .map(std::string::ToString::to_string)
         .unwrap_or_else(String::new);
 
-    let mut net_params = None;
-    if cmd_arguments.is_present("net") {
-        if let Some(net) = cmd_arguments.value_of("net") {
-            net_params = Some(net.to_string());
-        } else {
-            net_params = Some(String::new())
-        }
-    }
+    let net_params = cmd_arguments
+        .value_of("net")
+        .map(std::string::ToString::to_string);
 
     let rng_path = match cmd_arguments.occurrences_of("rng") {
         0 => None,


### PR DESCRIPTION
Reverts intel/cloud-hypervisor#20

I am positive that this change introduces no change in logic but makes the code less readable. The second branch of the else is an unreachable piece of code.

See my minimal example: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=4e88d273ee891a55f209f8e0f33818d5

Signed-off-by: Logan Saso <logansaso@gmail.com>