### PR TITLE
vmm: Simplify the vcpu run switch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "kvm-ioctls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "linux-loader 0.1.0 (git+https://github.com/bjzhjing/linux-loader)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net_util 0.1.0",
  "pci 0.1.0",
  "qcow 0.1.0",

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -11,6 +11,7 @@ epoll = "=4.0.1"
 kvm-bindings = "0.1"
 kvm-ioctls = "0.1.0"
 libc = ">=0.2.39"
+log = "*"
 net_util = { path = "../net_util" }
 pci = {path = "../pci"}
 qcow = { path = "../qcow" }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -4,6 +4,8 @@
 //
 
 extern crate kvm_ioctls;
+#[macro_use]
+extern crate log;
 
 use kvm_ioctls::*;
 use std::fmt::{self, Display};


### PR DESCRIPTION
Use a catchall case for all reasons that we do not handle, and
move the vCPU run switch into its own function.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>