### PR TITLE
arch: Remove the 32-bit PCI hole

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -21,6 +21,6 @@ pub fn configure_system(
 }
 
 /// Stub function that needs to be implemented when aarch64 functionality is added.
-pub fn get_reserved_mem_addr() -> usize {
-    0
+pub fn get_reserved_mem_addr() -> Option<usize> {
+    None
 }

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -49,6 +49,6 @@ pub mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
-    arch_memory_regions, configure_system, get_32bit_gap_start as get_reserved_mem_addr,
-    layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START,
+    arch_memory_regions, configure_system, get_reserved_mem_addr, layout::CMDLINE_MAX_SIZE,
+    layout::CMDLINE_START,
 };


### PR DESCRIPTION
We only want to support modern, 64-bit PCI devices, we
don't need a 32-bit PCI hole.

Our e820 map is simpler, and so is our list of memory regions.
Moreover, we change the get_reserved_mem_addr() prototype to optionally
return a guest address. In some cases like cloud-hypervisor, there is
no reserved device memory range.

Fixes: #22

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>