### PR TITLE
Add a resource freeing API for vm-allocator

### DIFF
--- a/vm-allocator/src/lib.rs
+++ b/vm-allocator/src/lib.rs
@@ -6,6 +6,7 @@
 // found in the LICENSE-BSD-3-Clause file.
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+#![deny(missing_docs)]
 
 //! Manages system resources that can be allocated to VMs and their devices.
 

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -100,4 +100,18 @@ impl SystemAllocator {
     ) -> Option<GuestAddress> {
         self.mmio_address_space.allocate(address, size)
     }
+
+    /// Free an IO address range.
+    /// We can only free a range if it matches exactly an already allocated range.
+    pub fn free_io_addresses(&mut self, address: GuestAddress, size: GuestUsize) {
+        if let Some(io_address) = self.io_address_space.as_mut() {
+            io_address.free(address, size)
+        }
+    }
+
+    /// Free an MMIO address range.
+    /// We can only free a range if it matches exactly an already allocated range.
+    pub fn free_mmio_addresses(&mut self, address: GuestAddress, size: GuestUsize) {
+        self.mmio_address_space.free(address, size)
+    }
 }


### PR DESCRIPTION
We can only free address ranges for now, and only when they match exactly one that was allocated.
In other words, we can't partially free and address range.

