### PR TITLE
vmm: Repair the port IO memory alignment

### DIFF
--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -62,7 +62,7 @@ impl SystemAllocator {
         let page_size = pagesize() as u64;
         Some(SystemAllocator {
             io_address_space: if let (Some(b), Some(s)) = (io_base, io_size) {
-                Some(AddressAllocator::new(b, s, Some(0x400))?)
+                Some(AddressAllocator::new(b, s, Some(0x1))?)
             } else {
                 None
             },


### PR DESCRIPTION
The IO memory alignment should be set as 4 instead of 0x400 which is copied
from crosvm. Take 0xcf8, 0xcfc for pci bus as examples.

Signed-off-by: Jing Liu <jing2.liu@linux.intel.com>