### PR TITLE
Refine pci topology

### DIFF
--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -90,11 +90,11 @@ pub trait PciDevice: BusDevice {
     /// Reads from a BAR region mapped in to the device.
     /// * `addr` - The guest address inside the BAR.
     /// * `data` - Filled with the data from `addr`.
-    fn read_bar(&mut self, base: u64, offset: u64, data: &mut [u8]);
+    fn read_bar(&mut self, _base: u64, _offset: u64, _data: &mut [u8]) {}
     /// Writes to a BAR region mapped in to the device.
     /// * `addr` - The guest address inside the BAR.
     /// * `data` - The data to write.
-    fn write_bar(&mut self, base: u64, offset: u64, data: &[u8]);
+    fn write_bar(&mut self, _base: u64, _offset: u64, _data: &[u8]) {}
     /// Invoked when the device is sandboxed.
     fn on_device_sandboxed(&mut self) {}
 }

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -10,20 +10,21 @@ extern crate kvm_ioctls;
 extern crate vm_memory;
 extern crate vmm_sys_util;
 
+mod bus;
 mod configuration;
 mod device;
 mod msix;
-mod root;
 
+pub use self::bus::{PciConfigIo, PciConfigMmio, PciRoot, PciRootError};
 pub use self::configuration::{
     PciBarConfiguration, PciBarPrefetchable, PciBarRegionType, PciCapability, PciCapabilityID,
     PciClassCode, PciConfiguration, PciHeaderType, PciMassStorageSubclass,
     PciNetworkControllerSubclass, PciProgrammingInterface, PciSerialBusSubClass, PciSubclass,
 };
-pub use self::device::Error as PciDeviceError;
-pub use self::device::{InterruptDelivery, InterruptParameters, PciDevice};
+pub use self::device::{
+    Error as PciDeviceError, InterruptDelivery, InterruptParameters, PciDevice,
+};
 pub use self::msix::{MsixCap, MsixConfig, MsixTableEntry};
-pub use self::root::{PciConfigIo, PciConfigMmio, PciRoot, PciRootError};
 
 /// PCI has four interrupt pins A->D.
 #[derive(Copy, Clone)]


### PR DESCRIPTION
@sameo @chao-p @rbradford @sboeuf 

This refines PCI emulated hierarchy to make VMExit resolving and handling clean and easy.