### PR TITLE
irq: Fix pin based interrupt for virtio-pci

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
 [[package]]
 name = "linux-loader"
 version = "0.1.0"
-source = "git+https://github.com/bjzhjing/linux-loader#ed36dbf364e90e3e27d5bd521d297b89aa6ed4bd"
+source = "git+https://github.com/bjzhjing/linux-loader#c43b923ef7bea7afbcf7a1f33adf504b90026a17"
 dependencies = [
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
 ]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -429,9 +429,10 @@ impl DeviceManager {
         mmio_bus: &mut devices::Bus,
         msi_capable: bool,
     ) -> DeviceManagerResult<()> {
-        let mut virtio_pci_device =
-            VirtioPciDevice::new(memory, virtio_device, DEFAULT_MSIX_VEC_NUM)
-                .map_err(DeviceManagerError::VirtioDevice)?;
+        let msix_num = if msi_capable { DEFAULT_MSIX_VEC_NUM } else { 0 };
+
+        let mut virtio_pci_device = VirtioPciDevice::new(memory, virtio_device, msix_num)
+            .map_err(DeviceManagerError::VirtioDevice)?;
 
         let bars = virtio_pci_device
             .allocate_bars(allocator)


### PR DESCRIPTION
When the KVM capability KVM_CAP_SIGNAL_MSI is not present, the VMM
falls back from MSI-X onto pin based interrupts. Unfortunately, this
was not working as expected because the VirtioPciDevice object was
always creating an MSI-X capability structure in the PCI configuration
space. This was causing the guest drivers to expect MSI-X interrupts
instead of the pin based generated ones.

This patch takes care of avoiding the creation of a dedicated MSI-X
capability structure when MSI is not supported by KVM.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>