### PR TITLE
vmm: Set the APIC ID in the extended topology

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,13 @@ mod tests {
             .unwrap()
     }
 
+    fn get_initial_apicid() -> u32 {
+        ssh_command("grep \"initial apicid\" /proc/cpuinfo | grep -o \"[0-9]*\"")
+            .trim()
+            .parse()
+            .unwrap()
+    }
+
     fn get_total_memory() -> u32 {
         ssh_command("grep MemTotal /proc/meminfo | grep -o \"[0-9]*\"")
             .trim()
@@ -232,6 +239,7 @@ mod tests {
             thread::sleep(std::time::Duration::new(10, 0));
 
             aver_eq!(tb, get_cpu_count(), 1);
+            aver_eq!(tb, get_initial_apicid(), 0);
             aver!(tb, get_total_memory() > 496_000);
             aver!(tb, get_entropy() >= 1000);
 


### PR DESCRIPTION
KVM exposes CPUID 0BH when host supports that, but the APIC ID that KVM
provides is the host APIC ID so we need replace that with ours.

Without this Linux guest reports something like:
[Firmware Bug]: CPU1: APIC id mismatch. Firmware: 1 APIC: 21

Fixes #42

Signed-off-by: Chao Peng <chao.p.peng@linux.intel.com>