### PR TITLE
Add support for userspace IOAPIC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -102,6 +102,11 @@ dependencies = [
 [[package]]
 name = "byteorder"
 version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cast"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -167,7 +172,10 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm-ioctls 0.1.0 (git+https://github.com/rust-vmm/kvm-ioctls)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
 ]
@@ -217,7 +225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -234,7 +242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "kvm-ioctls"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/kvm-ioctls#e7a0ccc463ab8d311aec2f7b2560fa18ed47a0eb"
+source = "git+https://github.com/rust-vmm/kvm-ioctls#b7e33cfa4a1d039df35c5ee24e66d06f32c94602"
 dependencies = [
  "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -507,12 +515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -550,7 +558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.35"
+version = "0.15.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -565,7 +573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -578,13 +586,13 @@ dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "termion"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -636,8 +644,9 @@ dependencies = [
 [[package]]
 name = "vm-memory"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vm-memory#682f10b36d6a48e656d45143fb64621bc8fe4b8e"
+source = "git+https://github.com/rust-vmm/vm-memory#8816aa2dbbb48ac15db2d8396fa3075980ccaa3e"
 dependencies = [
+ "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -721,6 +730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
+"checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b8c532887f1a292d17de05ae858a8fe50a301e196f9ef0ddb7ccd0d1d00f180"
@@ -761,16 +771,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
 "checksum remain 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "725c14cd936029b13547500781bd45284848e8e3970b7ef4179ecb202a150d64"
-"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "32746bf0f26eab52f06af0d0aa1984f641341d06d8d673c693871da2d188c9be"
 "checksum ssh2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "dee822d619a700f98c4de3b5931f272ecc7cf2e924ceb2df47b61df4ae033a0c"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
-"checksum syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)" = "641e117d55514d6d918490e47102f7e08d096fdde360247e4a10f7a91a8478d3"
+"checksum syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)" = "8b4f551a91e2e3848aeef8751d0d4eec9489b6474c720fd4c55958d8d31a430c"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
-"checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
+"checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -6,7 +6,10 @@ authors = ["The Chromium OS Authors"]
 [dependencies]
 byteorder = ">=1.2.1"
 epoll = "=4.0.1"
+kvm-bindings = "0.1"
+kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master" }
 libc = ">=0.2.39"
+log = "*"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
 vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
 

--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -1,0 +1,346 @@
+// Copyright 2019 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+//
+// Implementation of an intel 82093AA Input/Output Advanced Programmable Interrupt Controller
+// See https://pdos.csail.mit.edu/6.828/2016/readings/ia32/ioapic.pdf for a specification.
+
+use crate::BusDevice;
+use byteorder::{ByteOrder, LittleEndian};
+use kvm_bindings::kvm_msi;
+use kvm_ioctls::VmFd;
+use std::sync::Arc;
+use std::{io, result};
+
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to send an interrupt.
+    InterruptFailed(io::Error),
+    /// Invalid destination mode.
+    InvalidDestinationMode,
+    /// Invalid trigger mode.
+    InvalidTriggerMode,
+    /// Invalid delivery mode.
+    InvalidDeliveryMode,
+}
+
+type Result<T> = result::Result<T, Error>;
+
+// I/O REDIRECTION TABLE REGISTER
+//
+// There are 24 I/O Redirection Table entry registers. Each register is a
+// dedicated entry for each interrupt input signal. Each register is 64 bits
+// split between two 32 bits registers as follow:
+//
+// 63-56: Destination Field - R/W
+// 55-17: Reserved
+// 16:    Interrupt Mask - R/W
+// 15:    Trigger Mode - R/W
+// 14:    Remote IRR - RO
+// 13:    Interrupt Input Pin Polarity - R/W
+// 12:    Delivery Status - RO
+// 11:    Destination Mode - R/W
+// 10-8:  Delivery Mode - R/W
+// 7-0:   Interrupt Vector - R/W
+pub type RedirectionTableEntry = u64;
+
+fn vector(entry: RedirectionTableEntry) -> u8 {
+    (entry & 0xffu64) as u8
+}
+fn delivery_mode(entry: RedirectionTableEntry) -> u8 {
+    ((entry >> 8) & 0x7u64) as u8
+}
+fn destination_mode(entry: RedirectionTableEntry) -> u8 {
+    ((entry >> 11) & 0x1u64) as u8
+}
+fn remote_irr(entry: RedirectionTableEntry) -> u8 {
+    ((entry >> 14) & 0x1u64) as u8
+}
+fn trigger_mode(entry: RedirectionTableEntry) -> u8 {
+    ((entry >> 15) & 0x1u64) as u8
+}
+fn interrupt_mask(entry: RedirectionTableEntry) -> u8 {
+    ((entry >> 16) & 0x1u64) as u8
+}
+fn destination_field_physical(entry: RedirectionTableEntry) -> u8 {
+    ((entry >> 56) & 0xfu64) as u8
+}
+fn destination_field_logical(entry: RedirectionTableEntry) -> u8 {
+    ((entry >> 56) & 0xffu64) as u8
+}
+fn set_delivery_status(entry: &mut RedirectionTableEntry, val: u8) {
+    // Clear bit 12
+    *entry &= 0xffff_ffff_ffff_efff;
+    // Set it with the expected value
+    *entry |= u64::from(val & 0x1) << 12;
+}
+fn set_remote_irr(entry: &mut RedirectionTableEntry, val: u8) {
+    // Clear bit 14
+    *entry &= 0xffff_ffff_ffff_bfff;
+    // Set it with the expected value
+    *entry |= u64::from(val & 0x1) << 14;
+}
+
+pub struct MsiMessage {
+    // Message Address Register
+    //   31-20: Base address. Fixed value (0x0FEE)
+    //   19-12: Destination ID
+    //   11-4:  Reserved
+    //   3:     Redirection Hint indication
+    //   2:     Destination Mode
+    //   1-0:   Reserved
+    pub addr: u32,
+    // Message Data Register
+    //   32-16: Reserved
+    //   15:    Trigger Mode. 0 = Edge, 1 = Level
+    //   14:    Level. 0 = Deassert, 1 = Assert
+    //   13-11: Reserved
+    //   10-8:  Delivery Mode
+    //   7-0:   Vector
+    pub data: u32,
+}
+
+pub const NUM_IOAPIC_PINS: usize = 24;
+const IOAPIC_VERSION_ID: u32 = 0x0017_0011;
+
+// Constants for IOAPIC direct register offset
+const IOAPIC_REG_ID: u8 = 0x00;
+const IOAPIC_REG_VERSION: u8 = 0x01;
+const IOAPIC_REG_ARBITRATION_ID: u8 = 0x02;
+
+// Register offsets
+const IOREGSEL_OFF: u8 = 0x0;
+const IOWIN_OFF: u8 = 0x10;
+const IOWIN_SCALE: u8 = 0x2;
+const REG_MAX_OFFSET: u8 = IOWIN_OFF + (NUM_IOAPIC_PINS as u8 * 2) - 1;
+
+#[repr(u8)]
+enum DestinationMode {
+    Physical = 0,
+    Logical = 1,
+}
+
+#[repr(u8)]
+enum TriggerMode {
+    Edge = 0,
+    Level = 1,
+}
+
+#[repr(u8)]
+enum DeliveryMode {
+    Fixed = 0b000,
+    Lowest = 0b001,
+    SMI = 0b010,        // System management interrupt
+    RemoteRead = 0b011, // This is no longer supported by intel.
+    NMI = 0b100,        // Non maskable interrupt
+    Init = 0b101,
+    Startup = 0b110,
+    External = 0b111,
+}
+
+/// Given an offset that was read from/written to, return a tuple of the relevant IRQ and whether
+/// the offset refers to the high bits of that register.
+fn decode_irq_from_selector(selector: u8) -> (usize, bool) {
+    (
+        ((selector - IOWIN_OFF) / IOWIN_SCALE) as usize,
+        selector & 1 != 0,
+    )
+}
+
+pub struct Ioapic {
+    id: u32,
+    reg_sel: u32,
+    reg_entries: [RedirectionTableEntry; NUM_IOAPIC_PINS],
+    vm_fd: Arc<VmFd>,
+}
+
+impl BusDevice for Ioapic {
+    fn read(&mut self, offset: u64, data: &mut [u8]) {
+        assert!(data.len() == 4);
+
+        debug!("IOAPIC_R @ offset 0x{:x}", offset);
+
+        let value: u32 = match offset as u8 {
+            IOREGSEL_OFF => self.reg_sel,
+            IOWIN_OFF => self.ioapic_read(),
+            _ => {
+                error!("IOAPIC: failed reading at offset {}", offset);
+                return;
+            }
+        };
+
+        LittleEndian::write_u32(data, value);
+    }
+
+    fn write(&mut self, offset: u64, data: &[u8]) {
+        assert!(data.len() == 4);
+
+        debug!("IOAPIC_W @ offset 0x{:x}", offset);
+
+        let value = LittleEndian::read_u32(data);
+
+        match offset as u8 {
+            IOREGSEL_OFF => self.reg_sel = value,
+            IOWIN_OFF => self.ioapic_write(value),
+            _ => {
+                error!("IOAPIC: failed writing at offset {}", offset);
+                return;
+            }
+        }
+    }
+}
+
+impl Ioapic {
+    pub fn new(vm_fd: Arc<VmFd>) -> Ioapic {
+        Ioapic {
+            id: 0,
+            reg_sel: 0,
+            reg_entries: [0; NUM_IOAPIC_PINS],
+            vm_fd,
+        }
+    }
+
+    // The ioapic must be informed about EOIs in order to deassert interrupts
+    // already sent.
+    pub fn end_of_interrupt(&mut self, vec: u8) {
+        for i in 0..NUM_IOAPIC_PINS {
+            let entry = &mut self.reg_entries[i];
+            // Clear Remote IRR bit
+            if vector(*entry) == vec && trigger_mode(*entry) == 1 {
+                set_remote_irr(entry, 0);
+            }
+        }
+    }
+
+    // This should be called anytime an interrupt needs to be injected into the
+    // running guest.
+    pub fn service_irq(&mut self, irq: usize) -> Result<()> {
+        let entry = &mut self.reg_entries[irq];
+
+        // Don't inject the interrupt if the IRQ is masked
+        if interrupt_mask(*entry) == 1 {
+            return Ok(());
+        }
+
+        // Validate Destination Mode value, and retrieve Destination ID
+        let destination_mode = destination_mode(*entry);
+        let destination_id: u8 = match destination_mode {
+            x if x == DestinationMode::Physical as u8 => destination_field_physical(*entry),
+            x if x == DestinationMode::Logical as u8 => destination_field_logical(*entry),
+            _ => return Err(Error::InvalidDestinationMode),
+        };
+
+        // When this bit is set, the message is directed to the processor with
+        // the lowest interrupt priority among processors that can receive the
+        // interrupt.
+        let redirection_hint: u8 = 1;
+
+        // Generate MSI message address
+        let address_lo: u32 = 0xfee0_0000
+            | u32::from(destination_id) << 12
+            | u32::from(redirection_hint) << 3
+            | u32::from(destination_mode) << 2;
+
+        // Validate Trigger Mode value
+        let trigger_mode = trigger_mode(*entry);
+        match trigger_mode {
+            x if (x == TriggerMode::Edge as u8) || (x == TriggerMode::Level as u8) => {}
+            _ => return Err(Error::InvalidTriggerMode),
+        }
+
+        // Validate Delivery Mode value
+        let delivery_mode = delivery_mode(*entry);
+        match delivery_mode {
+            x if (x == DeliveryMode::Fixed as u8)
+                || (x == DeliveryMode::Lowest as u8)
+                || (x == DeliveryMode::SMI as u8)
+                || (x == DeliveryMode::RemoteRead as u8)
+                || (x == DeliveryMode::NMI as u8)
+                || (x == DeliveryMode::Init as u8)
+                || (x == DeliveryMode::Startup as u8)
+                || (x == DeliveryMode::External as u8) => {}
+            _ => return Err(Error::InvalidDeliveryMode),
+        }
+
+        // Generate MSI message data
+        let data: u32 = u32::from(trigger_mode) << 15
+            | u32::from(remote_irr(*entry)) << 14
+            | u32::from(delivery_mode) << 8
+            | u32::from(vector(*entry));
+
+        let msi = kvm_msi {
+            address_lo,
+            address_hi: 0x0,
+            data,
+            flags: 0u32,
+            devid: 0u32,
+            pad: [0u8; 12],
+        };
+
+        match self.vm_fd.signal_msi(msi) {
+            Ok(ret) => {
+                if ret > 0 {
+                    debug!("MSI message successfully delivered");
+                    // If trigger mode is level sensitive, set the Remote IRR bit.
+                    // It will be cleared when the EOI is received.
+                    if trigger_mode == 1 {
+                        set_remote_irr(entry, 1);
+                    }
+                    // Clear the Delivery Status bit
+                    set_delivery_status(entry, 0);
+                } else {
+                    warn!("failed to deliver MSI message, blocked by guest");
+                }
+                Ok(())
+            }
+            Err(e) => Err(Error::InterruptFailed(e)),
+        }
+    }
+
+    fn ioapic_write(&mut self, val: u32) {
+        debug!("IOAPIC_W reg 0x{:x}, val 0x{:x}", self.reg_sel, val);
+
+        match self.reg_sel as u8 {
+            IOAPIC_REG_ID => self.id = (val >> 24) & 0xf,
+            IOWIN_OFF..=REG_MAX_OFFSET => {
+                let (index, is_high_bits) = decode_irq_from_selector(self.reg_sel as u8);
+                if is_high_bits {
+                    self.reg_entries[index] &= 0xffff_ffff;
+                    self.reg_entries[index] |= u64::from(val) << 32;
+                } else {
+                    // Ensure not to override read-only bits:
+                    // - Delivery Status (bit 12)
+                    // - Remote IRR (bit 14)
+                    self.reg_entries[index] &= 0xffff_ffff_0000_5000;
+                    self.reg_entries[index] |= u64::from(val) & 0xffff_afff;
+                }
+            }
+            _ => error!("IOAPIC: invalid write to register offset"),
+        }
+    }
+
+    fn ioapic_read(&self) -> u32 {
+        debug!("IOAPIC_R reg 0x{:x}", self.reg_sel);
+
+        match self.reg_sel as u8 {
+            IOAPIC_REG_VERSION => IOAPIC_VERSION_ID,
+            IOAPIC_REG_ID | IOAPIC_REG_ARBITRATION_ID => (self.id & 0xf) << 24,
+            IOWIN_OFF..=REG_MAX_OFFSET => {
+                let (index, is_high_bits) = decode_irq_from_selector(self.reg_sel as u8);
+                if is_high_bits {
+                    (self.reg_entries[index] >> 32) as u32
+                } else {
+                    (self.reg_entries[index] & 0xffff_ffff) as u32
+                }
+            }
+            _ => {
+                error!("IOAPIC: invalid read from register offset");
+                0
+            }
+        }
+    }
+}

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -8,8 +8,11 @@
 //! Emulates virtual and hardware devices.
 extern crate byteorder;
 extern crate epoll;
+extern crate kvm_bindings;
+extern crate kvm_ioctls;
 extern crate libc;
-
+#[macro_use]
+extern crate log;
 extern crate vm_memory;
 extern crate vmm_sys_util;
 
@@ -17,6 +20,7 @@ use std::fs::File;
 use std::{io, result};
 
 mod bus;
+pub mod ioapic;
 pub mod legacy;
 
 pub use self::bus::{Bus, BusDevice, Error as BusError};

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -14,7 +14,7 @@ extern crate vm_memory;
 extern crate vmm_sys_util;
 
 use std::fs::File;
-use std::io;
+use std::{io, result};
 
 mod bus;
 pub mod legacy;
@@ -57,4 +57,8 @@ pub enum Error {
         event: DeviceEventT,
     },
     IoError(io::Error),
+}
+
+pub trait Interrupt: Send {
+    fn deliver(&self) -> result::Result<(), std::io::Error>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -416,4 +416,44 @@ mod tests {
             Ok(())
         });
     }
+
+    #[test]
+    fn test_split_irqchip() {
+        test_block!(tb, "", {
+            let (disks, fw_path) = prepare_files();
+            let mut child = Command::new("target/debug/cloud-hypervisor")
+                .args(&["--cpus", "1"])
+                .args(&["--memory", "512"])
+                .args(&["--kernel", fw_path.as_str()])
+                .args(&["--disk", disks[0], disks[1]])
+                .args(&["--net", "tap=,mac=,ip=192.168.2.1,mask=255.255.255.0"])
+                .spawn()
+                .unwrap();
+
+            thread::sleep(std::time::Duration::new(10, 0));
+
+            aver_eq!(
+                tb,
+                ssh_command("cat /proc/interrupts | grep 'IO-APIC' | grep -c 'timer'")
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap(),
+                0
+            );
+            aver_eq!(
+                tb,
+                ssh_command("cat /proc/interrupts | grep 'IO-APIC' | grep -c 'cascade'")
+                    .trim()
+                    .parse::<u32>()
+                    .unwrap(),
+                0
+            );
+
+            ssh_command("sudo reboot");
+            thread::sleep(std::time::Duration::new(10, 0));
+            let _ = child.kill();
+            let _ = child.wait();
+            Ok(())
+        });
+    }
 }


### PR DESCRIPTION
This pull request implements a userspace IOAPIC and plumbs
it into the cloud-hypervisor VMM to allow getting rid of the in
kernel emulation provided by `KVM_CREATE_IRQCHIP`.
It allows for what is called a "split" irqchip, which means that
only the local APIC is emulated in kernel.

Fixes #13 