### PR TITLE
README: Use a permanent Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ etc, are all equal and welcome means of contribution. See the [CONTRIBUTING](CON
 
 ## Join us
 
-Get an [invite to our Slack channel](https://join.slack.com/t/cloud-hypervisor/shared_invite/enQtNjE5MzU2OTU2NjU5LTllNzIzYzNmYTc2ZjA4Mjg2YWQ2M2Q0MzE3ZDk2NTVhMjIwZGIwYjE4NGY3YTI2MzU3NTBjNDJhYTNlMjdiMmM)
+Get an [invite to our Slack channel](https://join.slack.com/t/cloud-hypervisor/shared_invite/enQtNjY3MTE3MDkwNDQ4LTc0YzlmYzQxZDkxNDVhYzZjZjA5MTkxMGY3NTI3YzMzYTFkM2IyY2E0YTIxMzkyYTEwYzdlMzBhMWYxYzVmNDI)
 and [join us on Slack](https://cloud-hypervisor.slack.com/).
 
 # 6. Security


### PR DESCRIPTION
The previous one was mistakenly set to expire after 30 days.

Fixes: #59

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>