### PR TITLE
CI: Fix the Ubuntu VM update stuck on an interactive window

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,8 @@ stage ("Builds") {
 			checkout scm
 		}
 		stage ('Install system packages') {
-			sh "sudo apt-get -y install build-essential mtools libssl-dev pkg-config"
-			sh 'sudo apt-get -y install flex bison libelf-dev'
+			sh "sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq build-essential mtools libssl-dev pkg-config"
+			sh "sudo apt-get install -yq flex bison libelf-dev"
 		}
 		stage ('Install Rust') {
 			sh "nohup curl https://sh.rustup.rs -sSf | sh -s -- -y"


### PR DESCRIPTION
We need to export the variable DEBIAN_FRONTEND=noninteractive from the
Jenkinsfile if we want to make sure the VM update won't get stuck into
an interactive window.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>