### PR TITLE
device: Improvement for BusDevice trait and PciDevice trait

### DIFF
--- a/devices/src/bus.rs
+++ b/devices/src/bus.rs
@@ -24,16 +24,6 @@ pub trait BusDevice: Send {
     fn write(&mut self, offset: u64, data: &[u8]) {}
     /// Triggers the `irq_mask` interrupt on this device
     fn interrupt(&self, irq_mask: u32) {}
-
-    /// Sets a register in the configuration space. Only used by PCI.
-    /// * `reg_idx` - The index of the config register to modify.
-    /// * `offset` - Offset in to the register.
-    fn write_config_register(&mut self, reg_idx: usize, offset: u64, data: &[u8]) {}
-    /// Gets a register from the configuration space. Only used by PCI.
-    /// * `reg_idx` - The index of the config register to read.
-    fn read_config_register(&self, reg_idx: usize) -> u32 {
-        0
-    }
 }
 
 #[derive(Debug)]

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -80,6 +80,13 @@ pub trait PciDevice: BusDevice {
     fn ioeventfds(&self) -> Vec<(&EventFd, u64, u64)> {
         Vec::new()
     }
+    /// Sets a register in the configuration space.
+    /// * `reg_idx` - The index of the config register to modify.
+    /// * `offset` - Offset in to the register.
+    fn write_config_register(&mut self, reg_idx: usize, offset: u64, data: &[u8]);
+    /// Gets a register from the configuration space.
+    /// * `reg_idx` - The index of the config register to read.
+    fn read_config_register(&self, reg_idx: usize) -> u32;
     /// Reads from a BAR region mapped in to the device.
     /// * `addr` - The guest address inside the BAR.
     /// * `data` - Filled with the data from `addr`.

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -397,6 +397,15 @@ impl PciDevice for VirtioPciDevice {
         }
     }
 
+    fn write_config_register(&mut self, reg_idx: usize, offset: u64, data: &[u8]) {
+        self.configuration
+            .write_config_register(reg_idx, offset, data);
+    }
+
+    fn read_config_register(&self, reg_idx: usize) -> u32 {
+        self.configuration.read_reg(reg_idx)
+    }
+
     fn ioeventfds(&self) -> Vec<(&EventFd, u64, u64)> {
         let bar0 = self
             .configuration
@@ -588,14 +597,5 @@ impl BusDevice for VirtioPciDevice {
 
     fn write(&mut self, offset: u64, data: &[u8]) {
         self.write_bar(offset, data)
-    }
-
-    fn write_config_register(&mut self, reg_idx: usize, offset: u64, data: &[u8]) {
-        self.configuration
-            .write_config_register(reg_idx, offset, data);
-    }
-
-    fn read_config_register(&self, reg_idx: usize) -> u32 {
-        self.configuration.read_config_register(reg_idx)
     }
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -692,7 +692,11 @@ impl DeviceManager {
         let virtio_pci_device = Arc::new(Mutex::new(virtio_pci_device));
 
         pci_root
-            .add_device(virtio_pci_device.clone(), mmio_bus, bars)
+            .add_device(virtio_pci_device.clone())
+            .map_err(DeviceManagerError::AddPciDevice)?;
+
+        pci_root
+            .register_mapping(virtio_pci_device.clone(), mmio_bus, bars)
             .map_err(DeviceManagerError::AddPciDevice)?;
 
         Ok(())


### PR DESCRIPTION
BusDevice includes two methods which are only for PCI devices, which should
be as members of PciDevice trait for a better clean high level APIs.

Signed-off-by: Jing Liu <jing2.liu@linux.intel.com>