### PR TITLE
Fix the network and storage PCI class and sub-class

### DIFF
--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -124,6 +124,50 @@ impl PciSubclass for PciSerialBusSubClass {
     }
 }
 
+/// Mass Storage Sub Classes
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub enum PciMassStorageSubclass {
+    SCSIStorage = 0x00,
+    IDEInterface = 0x01,
+    FloppyController = 0x02,
+    IPIController = 0x03,
+    RAIDController = 0x04,
+    ATAController = 0x05,
+    SATAController = 0x06,
+    SerialSCSIController = 0x07,
+    NVMController = 0x08,
+    MassStorage = 0x80,
+}
+
+impl PciSubclass for PciMassStorageSubclass {
+    fn get_register_value(&self) -> u8 {
+        *self as u8
+    }
+}
+
+/// Network Controller Sub Classes
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub enum PciNetworkControllerSubclass {
+    EthernetController = 0x00,
+    TokenRingController = 0x01,
+    FDDIController = 0x02,
+    ATMController = 0x03,
+    ISDNController = 0x04,
+    WorldFipController = 0x05,
+    PICMGController = 0x06,
+    InfinibandController = 0x07,
+    FabricController = 0x08,
+    NetworkController = 0x80,
+}
+
+impl PciSubclass for PciNetworkControllerSubclass {
+    fn get_register_value(&self) -> u8 {
+        *self as u8
+    }
+}
+
 /// A PCI class programming interface. Each combination of `PciClassCode` and
 /// `PciSubclass` can specify a set of register-level programming interfaces.
 /// This trait is implemented by each programming interface.

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -17,8 +17,8 @@ mod root;
 
 pub use self::configuration::{
     PciBarConfiguration, PciBarPrefetchable, PciBarRegionType, PciCapability, PciCapabilityID,
-    PciClassCode, PciConfiguration, PciHeaderType, PciProgrammingInterface, PciSerialBusSubClass,
-    PciSubclass,
+    PciClassCode, PciConfiguration, PciHeaderType, PciMassStorageSubclass,
+    PciNetworkControllerSubclass, PciProgrammingInterface, PciSerialBusSubClass, PciSubclass,
 };
 pub use self::device::Error as PciDeviceError;
 pub use self::device::{InterruptDelivery, InterruptParameters, PciDevice};

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -63,6 +63,25 @@ enum VirtioDeviceType {
     TYPE_VSOCK = 19,
     TYPE_FS = 26,
     TYPE_PMEM = 27,
+    TYPE_UNKNOWN = 0xFF,
+}
+
+impl From<u32> for VirtioDeviceType {
+    fn from(t: u32) -> Self {
+        match t {
+            1 => VirtioDeviceType::TYPE_NET,
+            2 => VirtioDeviceType::TYPE_BLOCK,
+            4 => VirtioDeviceType::TYPE_RNG,
+            5 => VirtioDeviceType::TYPE_BALLOON,
+            9 => VirtioDeviceType::TYPE_9P,
+            16 => VirtioDeviceType::TYPE_GPU,
+            18 => VirtioDeviceType::TYPE_INPUT,
+            19 => VirtioDeviceType::TYPE_VSOCK,
+            26 => VirtioDeviceType::TYPE_FS,
+            27 => VirtioDeviceType::TYPE_PMEM,
+            _ => VirtioDeviceType::TYPE_UNKNOWN,
+        }
+    }
 }
 
 // In order to use the `{}` marker, the trait `fmt::Display` must be implemented


### PR DESCRIPTION
Use the virtio device type to generate the righ class and subclass.
    
Fixes: #83