### PR TITLE
pci: Use device PCI header type for our root bridge

### DIFF
--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -45,7 +45,7 @@ impl PciRoot {
                     PciClassCode::BridgeDevice,
                     &PciBridgeSubclass::HostBridge,
                     None,
-                    PciHeaderType::Bridge,
+                    PciHeaderType::Device,
                     0,
                     0,
                     None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,6 +286,12 @@ mod tests {
             .unwrap()
     }
 
+    fn get_pci_bridge_class() -> String {
+        ssh_command("cat /sys/bus/pci/devices/0000:00:00.0/class")
+            .trim()
+            .to_string()
+    }
+
     #[test]
     fn test_simple_launch() {
         test_block!(tb, "", {
@@ -308,6 +314,7 @@ mod tests {
             aver_eq!(tb, get_initial_apicid(), 0);
             aver!(tb, get_total_memory() > 496_000);
             aver!(tb, get_entropy() >= 1000);
+            aver_eq!(tb, get_pci_bridge_class(), "0x060000");
 
             ssh_command("sudo reboot");
             thread::sleep(std::time::Duration::new(10, 0));


### PR DESCRIPTION
The Bridge header type is really meant to be for PCI-to-PCI bridges.

Fixes: #85

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>