### PR TITLE
Add support for multiple IO regions devices

### DIFF
--- a/devices/src/bus.rs
+++ b/devices/src/bus.rs
@@ -97,11 +97,11 @@ impl Bus {
         Some((*range, dev))
     }
 
-    pub fn get_device(&self, addr: u64) -> Option<(u64, &Mutex<BusDevice>)> {
+    pub fn resolve(&self, addr: u64) -> Option<(u64, u64, &Mutex<BusDevice>)> {
         if let Some((range, dev)) = self.first_before(addr) {
             let offset = addr - range.base;
             if offset < range.len {
-                return Some((offset, dev));
+                return Some((range.base, offset, dev));
             }
         }
         None
@@ -137,7 +137,7 @@ impl Bus {
     ///
     /// Returns true on success, otherwise `data` is untouched.
     pub fn read(&self, addr: u64, data: &mut [u8]) -> bool {
-        if let Some((offset, dev)) = self.get_device(addr) {
+        if let Some((_base, offset, dev)) = self.resolve(addr) {
             // OK to unwrap as lock() failing is a serious error condition and should panic.
             dev.lock()
                 .expect("Failed to acquire device lock")
@@ -152,7 +152,7 @@ impl Bus {
     ///
     /// Returns true on success, otherwise `data` is untouched.
     pub fn write(&self, addr: u64, data: &[u8]) -> bool {
-        if let Some((offset, dev)) = self.get_device(addr) {
+        if let Some((_base, offset, dev)) = self.resolve(addr) {
             // OK to unwrap as lock() failing is a serious error condition and should panic.
             dev.lock()
                 .expect("Failed to acquire device lock")

--- a/devices/src/bus.rs
+++ b/devices/src/bus.rs
@@ -19,9 +19,9 @@ use std::sync::{Arc, Mutex};
 #[allow(unused_variables)]
 pub trait BusDevice: Send {
     /// Reads at `offset` from this device
-    fn read(&mut self, offset: u64, data: &mut [u8]) {}
+    fn read(&mut self, base: u64, offset: u64, data: &mut [u8]) {}
     /// Writes at `offset` into this device
-    fn write(&mut self, offset: u64, data: &[u8]) {}
+    fn write(&mut self, base: u64, offset: u64, data: &[u8]) {}
     /// Triggers the `irq_mask` interrupt on this device
     fn interrupt(&self, irq_mask: u32) {}
 }
@@ -137,11 +137,11 @@ impl Bus {
     ///
     /// Returns true on success, otherwise `data` is untouched.
     pub fn read(&self, addr: u64, data: &mut [u8]) -> bool {
-        if let Some((_base, offset, dev)) = self.resolve(addr) {
+        if let Some((base, offset, dev)) = self.resolve(addr) {
             // OK to unwrap as lock() failing is a serious error condition and should panic.
             dev.lock()
                 .expect("Failed to acquire device lock")
-                .read(offset, data);
+                .read(base, offset, data);
             true
         } else {
             false
@@ -152,11 +152,11 @@ impl Bus {
     ///
     /// Returns true on success, otherwise `data` is untouched.
     pub fn write(&self, addr: u64, data: &[u8]) -> bool {
-        if let Some((_base, offset, dev)) = self.resolve(addr) {
+        if let Some((base, offset, dev)) = self.resolve(addr) {
             // OK to unwrap as lock() failing is a serious error condition and should panic.
             dev.lock()
                 .expect("Failed to acquire device lock")
-                .write(offset, data);
+                .write(base, offset, data);
             true
         } else {
             false

--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -159,7 +159,7 @@ pub struct Ioapic {
 }
 
 impl BusDevice for Ioapic {
-    fn read(&mut self, offset: u64, data: &mut [u8]) {
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         assert!(data.len() == 4);
 
         debug!("IOAPIC_R @ offset 0x{:x}", offset);
@@ -176,7 +176,7 @@ impl BusDevice for Ioapic {
         LittleEndian::write_u32(data, value);
     }
 
-    fn write(&mut self, offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
         assert!(data.len() == 4);
 
         debug!("IOAPIC_W @ offset 0x{:x}", offset);

--- a/devices/src/legacy/i8042.rs
+++ b/devices/src/legacy/i8042.rs
@@ -22,7 +22,7 @@ impl I8042Device {
 // registers: port 0x61 (I8042_PORT_B_REG, offset 0 from base of 0x61), and
 // port 0x64 (I8042_COMMAND_REG, offset 3 from base of 0x61).
 impl BusDevice for I8042Device {
-    fn read(&mut self, offset: u64, data: &mut [u8]) {
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         if data.len() == 1 && offset == 3 {
             data[0] = 0x0;
         } else if data.len() == 1 && offset == 0 {
@@ -32,7 +32,7 @@ impl BusDevice for I8042Device {
         }
     }
 
-    fn write(&mut self, offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
         if data.len() == 1 && data[0] == 0xfe && offset == 3 {
             if let Err(e) = self.reset_evt.write(1) {
                 println!("Error triggering i8042 reset event: {}", e);

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -189,7 +189,7 @@ impl Serial {
 }
 
 impl BusDevice for Serial {
-    fn read(&mut self, offset: u64, data: &mut [u8]) {
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         if data.len() != 1 {
             return;
         }
@@ -219,7 +219,7 @@ impl BusDevice for Serial {
         };
     }
 
-    fn write(&mut self, offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
         if data.len() != 1 {
             return;
         }

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -90,11 +90,11 @@ pub trait PciDevice: BusDevice {
     /// Reads from a BAR region mapped in to the device.
     /// * `addr` - The guest address inside the BAR.
     /// * `data` - Filled with the data from `addr`.
-    fn read_bar(&mut self, addr: u64, data: &mut [u8]);
+    fn read_bar(&mut self, base: u64, offset: u64, data: &mut [u8]);
     /// Writes to a BAR region mapped in to the device.
     /// * `addr` - The guest address inside the BAR.
     /// * `data` - The data to write.
-    fn write_bar(&mut self, addr: u64, data: &[u8]);
+    fn write_bar(&mut self, base: u64, offset: u64, data: &[u8]);
     /// Invoked when the device is sandboxed.
     fn on_device_sandboxed(&mut self) {}
 }

--- a/pci/src/root.rs
+++ b/pci/src/root.rs
@@ -198,7 +198,7 @@ impl PciConfigIo {
 }
 
 impl BusDevice for PciConfigIo {
-    fn read(&mut self, offset: u64, data: &mut [u8]) {
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         // `offset` is relative to 0xcf8
         let value = match offset {
             0...3 => self.config_address,
@@ -220,7 +220,7 @@ impl BusDevice for PciConfigIo {
         }
     }
 
-    fn write(&mut self, offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
         // `offset` is relative to 0xcf8
         match offset {
             o @ 0...3 => self.set_config_address(o, data),
@@ -255,7 +255,7 @@ impl PciConfigMmio {
 }
 
 impl BusDevice for PciConfigMmio {
-    fn read(&mut self, offset: u64, data: &mut [u8]) {
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         // Only allow reads to the register boundary.
         let start = offset as usize % 4;
         let end = start + data.len();
@@ -272,7 +272,7 @@ impl BusDevice for PciConfigMmio {
         }
     }
 
-    fn write(&mut self, offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
         if offset > u64::from(u32::max_value()) {
             return;
         }

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -607,11 +607,11 @@ impl PciDevice for VirtioPciDevice {
 }
 
 impl BusDevice for VirtioPciDevice {
-    fn read(&mut self, offset: u64, data: &mut [u8]) {
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         self.read_bar(offset, data)
     }
 
-    fn write(&mut self, offset: u64, data: &[u8]) {
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
         self.write_bar(offset, data)
     }
 }

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -480,7 +480,7 @@ impl PciDevice for VirtioPciDevice {
         Ok(ranges)
     }
 
-    fn read_bar(&mut self, offset: u64, data: &mut [u8]) {
+    fn read_bar(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         match offset {
             o if o < COMMON_CONFIG_BAR_OFFSET + COMMON_CONFIG_SIZE => self.common_config.read(
                 o - COMMON_CONFIG_BAR_OFFSET,
@@ -524,7 +524,7 @@ impl PciDevice for VirtioPciDevice {
         }
     }
 
-    fn write_bar(&mut self, offset: u64, data: &[u8]) {
+    fn write_bar(&mut self, _base: u64, offset: u64, data: &[u8]) {
         match offset {
             o if o < COMMON_CONFIG_BAR_OFFSET + COMMON_CONFIG_SIZE => self.common_config.write(
                 o - COMMON_CONFIG_BAR_OFFSET,
@@ -607,11 +607,11 @@ impl PciDevice for VirtioPciDevice {
 }
 
 impl BusDevice for VirtioPciDevice {
-    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
-        self.read_bar(offset, data)
+    fn read(&mut self, base: u64, offset: u64, data: &mut [u8]) {
+        self.read_bar(base, offset, data)
     }
 
-    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
-        self.write_bar(offset, data)
+    fn write(&mut self, base: u64, offset: u64, data: &[u8]) {
+        self.write_bar(base, offset, data)
     }
 }


### PR DESCRIPTION
We extend the `Bus` and `PciDevice` traits so that their IO callbacks carry the base IO region address that the callback need to handle.

Fixes: #87 