### PR TITLE
tests: Use custom kernel for all tests

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -32,38 +32,22 @@ if [ ! -f "$OS_RAW_IMAGE" ]; then
     popd
 fi
 
-# Build generic kernel
+
+# Build custom kernel based on virtio-pmem and virtio-fs upstream patches
 VMLINUX_IMAGE="$WORKLOADS_DIR/vmlinux"
 BZIMAGE_IMAGE="$WORKLOADS_DIR/bzImage"
 
-if [ ! -f "$VMLINUX_IMAGE" ]; then
-    SRCDIR=$PWD
-    pushd $WORKLOADS_DIR
-    wget --quiet https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.0.21.tar.xz
-    tar xf linux-5.0.21.tar.xz
-    pushd linux-5.0.21
-    cp $SRCDIR/resources/linux-5.0-config .config
-    make bzImage -j `nproc`
-    cp vmlinux $VMLINUX_IMAGE
-    cp arch/x86/boot/bzImage $BZIMAGE_IMAGE
-    popd
-    rm linux-5.0.21.tar.xz
-    rm -r linux-5.0.21
-    popd
-fi
-
-# Build custom kernel based on virtio-pmem and virtio-fs upstream patches
-VMLINUX_CUSTOM_IMAGE="$WORKLOADS_DIR/vmlinux-custom"
 LINUX_CUSTOM_DIR="linux-custom"
 
-if [ ! -f "$VMLINUX_CUSTOM_IMAGE" ]; then
+if [ ! -f "$VMLINUX_IMAGE" ]; then
     SRCDIR=$PWD
     pushd $WORKLOADS_DIR
     git clone --depth 1 "https://github.com/sboeuf/linux.git" -b "virtio-pmem_and_virtio-fs" $LINUX_CUSTOM_DIR
     pushd $LINUX_CUSTOM_DIR
     cp $SRCDIR/resources/linux-virtio-pmem-and-virtio-fs-config .config
     make bzImage -j `nproc`
-    cp vmlinux $VMLINUX_CUSTOM_IMAGE
+    cp vmlinux $VMLINUX_IMAGE
+    cp arch/x86/boot/bzImage $BZIMAGE_IMAGE
     popd
     rm -r $LINUX_CUSTOM_DIR
     popd

--- a/src/main.rs
+++ b/src/main.rs
@@ -655,7 +655,7 @@ mod tests {
             workload_path.push("workloads");
 
             let mut kernel_path = workload_path.clone();
-            kernel_path.push("vmlinux-custom");
+            kernel_path.push("vmlinux");
 
             let mut child = Command::new("target/debug/cloud-hypervisor")
                 .args(&["--cpus", "1"])
@@ -710,7 +710,7 @@ mod tests {
             workload_path.push("workloads");
 
             let mut kernel_path = workload_path.clone();
-            kernel_path.push("vmlinux-custom");
+            kernel_path.push("vmlinux");
 
             let pmem_backend_path = guest.tmp_dir.path().join("/tmp/pmem-file");
             let mut pmem_backend_file = OpenOptions::new()
@@ -790,7 +790,7 @@ mod tests {
             workload_path.push("workloads");
 
             let mut kernel_path = workload_path.clone();
-            kernel_path.push("vmlinux-custom");
+            kernel_path.push("vmlinux");
 
             let mut child = Command::new("target/debug/cloud-hypervisor")
                 .args(&["--cpus", "1"])

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,7 +424,7 @@ mod tests {
             aver_eq!(tb, guest.get_cpu_count(), 1);
             aver_eq!(tb, guest.get_initial_apicid(), 0);
             aver!(tb, guest.get_total_memory() > 496_000);
-            aver!(tb, guest.get_entropy() >= 1000);
+            aver!(tb, guest.get_entropy() >= 900);
             aver_eq!(tb, guest.get_pci_bridge_class(), "0x060000");
 
             guest.ssh_command("sudo reboot");
@@ -542,7 +542,7 @@ mod tests {
 
             aver_eq!(tb, guest.get_cpu_count(), 1);
             aver!(tb, guest.get_total_memory() > 496_000);
-            aver!(tb, guest.get_entropy() >= 1000);
+            aver!(tb, guest.get_entropy() >= 900);
             aver_eq!(
                 tb,
                 guest
@@ -585,7 +585,7 @@ mod tests {
 
             aver_eq!(tb, guest.get_cpu_count(), 1);
             aver!(tb, guest.get_total_memory() > 496_000);
-            aver!(tb, guest.get_entropy() >= 1000);
+            aver!(tb, guest.get_entropy() >= 900);
             aver_eq!(
                 tb,
                 guest


### PR DESCRIPTION
This should reduce the integration testing time considerably. When a
custom kernel is no longer required we can pull kernel from tarball
again.

Fixes: #100

Signed-off-by: Rob Bradford <robert.bradford@intel.com>