### PR TITLE
build: Ensure caps needed for unit test are set

### DIFF
--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -2,13 +2,17 @@
 
 source $HOME/.cargo/env
 
-cargo test --all --no-run
+# More effective than just cargo test --all as it captures crates within crates
+for f in $(find . -name Cargo.toml -printf '%h\n' | sort -u); do
+  pushd $f > /dev/null;
+  cargo test --no-run || exit 1;
+  popd > /dev/null;
+done
 
 pushd target/debug
-ls  | grep net_util | grep -v "\.d" | xargs sudo setcap cap_net_admin,cap_net_raw+ep
+ls  | grep net_util | grep -v "\.d" | xargs -n 1 sudo setcap cap_net_admin,cap_net_raw+ep
 popd
 
-# More effective than just cargo test --all as it captures crates within crates
 for f in $(find . -name Cargo.toml -printf '%h\n' | sort -u); do
   pushd $f > /dev/null;
   cargo test || exit 1;


### PR DESCRIPTION
In some situations it is possible for the setting of the capabilities to
fail due to the variable naming of the build artifacts resulting in the
first parameter to setcap being rejected and thus the whole command
failing.

Use xargs -n 1 to ensure that every potential target independently has
its caps set.

Further it was observed that in some situations the binary produced by
cargo test --all --no-run would not be used and instead a new binary
would be produced when the test was run using the second method. This
again would result in test failures as that binary did not have the
desired capabilities set. Therefore build the test binaries with the
same methodology used to run them.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>