### PR TITLE
vm-allocator fixes and improvements

### DIFF
--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -6,8 +6,8 @@ pub mod layout;
 use memory_model::{GuestAddress, GuestMemory};
 
 /// Stub function that needs to be implemented when aarch64 functionality is added.
-pub fn arch_memory_regions(size: usize) -> Vec<(GuestAddress, usize)> {
-    vec![(GuestAddress(0), size)]
+pub fn arch_memory_regions(size: usize) -> Vec<(GuestAddress, usize, RegionType)> {
+    vec![(GuestAddress(0), size, RegionType::Ram)]
 }
 
 /// Stub function that needs to be implemented when aarch64 functionality is added.

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -33,6 +33,15 @@ pub enum Error {
 }
 pub type Result<T> = result::Result<T, Error>;
 
+#[derive(PartialEq)]
+pub enum RegionType {
+    /// RAM type
+    Ram,
+    /// Reserved type. Designate a region which should not be considered as
+    /// RAM. Useful to specify a PCI hole for instance.
+    Reserved,
+}
+
 // 1MB.  We don't put anything above here except the kernel itself.
 pub const HIMEM_START: GuestAddress = GuestAddress(0x100000);
 

--- a/vm-allocator/src/address.rs
+++ b/vm-allocator/src/address.rs
@@ -90,7 +90,7 @@ impl AddressAllocator {
         }
 
         // The aligned address should be within the address space range.
-        if aligned_address >= self.end || aligned_address <= self.base {
+        if aligned_address >= self.end || aligned_address < self.base {
             return Err(Error::Overflow);
         }
 

--- a/vm-allocator/src/address.rs
+++ b/vm-allocator/src/address.rs
@@ -28,46 +28,34 @@ pub type Result<T> = result::Result<T, Error>;
 /// ```
 /// # use vm_allocator::AddressAllocator;
 /// # use vm_memory::{Address, GuestAddress, GuestUsize};
-///   AddressAllocator::new(GuestAddress(0x1000), 0x10000, Some(0x100)).map(|mut pool| {
-///       assert_eq!(pool.allocate(None, 0x110), Some(GuestAddress(0x10e00)));
-///       assert_eq!(pool.allocate(None, 0x100), Some(GuestAddress(0x10c00)));
+///   AddressAllocator::new(GuestAddress(0x1000), 0x10000).map(|mut pool| {
+///       assert_eq!(pool.allocate(None, 0x110, Some(0x100)), Some(GuestAddress(0x10e00)));
+///       assert_eq!(pool.allocate(None, 0x100, Some(0x100)), Some(GuestAddress(0x10c00)));
 ///   });
 /// ```
 #[derive(Debug, Eq, PartialEq)]
 pub struct AddressAllocator {
     base: GuestAddress,
     end: GuestAddress,
-    alignment: GuestUsize,
     ranges: BTreeMap<GuestAddress, GuestUsize>,
 }
 
 impl AddressAllocator {
     /// Creates a new `AddressAllocator` for managing a range of addresses.
-    /// Can return `None` if `pool_base` + `pool_size` overflows a u64 or if alignment isn't a power
-    /// of two.
+    /// Can return `None` if `base` + `size` overflows a u64.
     ///
-    /// * `pool_base` - The starting address of the range to manage.
-    /// * `pool_size` - The size of the address range in bytes.
-    /// * `align_size` - The minimum size of an address region to align to, defaults to four.
-    pub fn new(
-        base: GuestAddress,
-        size: GuestUsize,
-        align_size: Option<GuestUsize>,
-    ) -> Option<Self> {
+    /// * `base` - The starting address of the range to manage.
+    /// * `size` - The size of the address range in bytes.
+    pub fn new(base: GuestAddress, size: GuestUsize) -> Option<Self> {
         if size == 0 {
             return None;
         }
 
         let end = base.checked_add(size - 1)?;
-        let alignment = align_size.unwrap_or(4);
-        if !alignment.is_power_of_two() || alignment == 0 {
-            return None;
-        }
 
         let mut allocator = AddressAllocator {
             base,
             end,
-            alignment,
             ranges: BTreeMap::new(),
         };
 
@@ -78,9 +66,9 @@ impl AddressAllocator {
         Some(allocator)
     }
 
-    fn align_address(&self, address: GuestAddress) -> GuestAddress {
-        let align_adjust = if address.raw_value() % self.alignment != 0 {
-            self.alignment - (address.raw_value() % self.alignment)
+    fn align_address(&self, address: GuestAddress, alignment: GuestUsize) -> GuestAddress {
+        let align_adjust = if address.raw_value() % alignment != 0 {
+            alignment - (address.raw_value() % alignment)
         } else {
             0
         };
@@ -92,8 +80,9 @@ impl AddressAllocator {
         &self,
         req_address: GuestAddress,
         req_size: GuestUsize,
+        alignment: GuestUsize,
     ) -> Result<GuestAddress> {
-        let aligned_address = self.align_address(req_address);
+        let aligned_address = self.align_address(req_address, alignment);
 
         // The requested address should be aligned.
         if aligned_address != req_address {
@@ -133,7 +122,11 @@ impl AddressAllocator {
         Err(Error::Overflow)
     }
 
-    fn first_available_range(&self, req_size: GuestUsize) -> Option<GuestAddress> {
+    fn first_available_range(
+        &self,
+        req_size: GuestUsize,
+        alignment: GuestUsize,
+    ) -> Option<GuestAddress> {
         let mut prev_end_address = self.base;
 
         for (address, size) in self.ranges.iter() {
@@ -143,11 +136,13 @@ impl AddressAllocator {
             // we will tend to always allocate new ranges there as well. In other words,
             // ranges accumulate at the end of the address space.
             if address
-                .unchecked_sub(self.align_address(prev_end_address).raw_value())
+                .unchecked_sub(self.align_address(prev_end_address, alignment).raw_value())
                 .raw_value()
                 >= req_size
             {
-                return Some(self.align_address(address.unchecked_sub(req_size + self.alignment)));
+                return Some(
+                    self.align_address(address.unchecked_sub(req_size + alignment), alignment),
+                );
             }
 
             prev_end_address = address.unchecked_add(*size);
@@ -157,24 +152,31 @@ impl AddressAllocator {
     }
 
     /// Allocates a range of addresses from the managed region. Returns `Some(allocated_address)`
-    /// when successful, or `None` if an area of `size` can't be allocated.
+    /// when successful, or `None` if an area of `size` can't be allocated or if alignment isn't
+    /// a power of two.
     pub fn allocate(
         &mut self,
         address: Option<GuestAddress>,
         size: GuestUsize,
+        align_size: Option<GuestUsize>,
     ) -> Option<GuestAddress> {
         if size == 0 {
             return None;
         }
 
+        let alignment = align_size.unwrap_or(4);
+        if !alignment.is_power_of_two() || alignment == 0 {
+            return None;
+        }
+
         let new_addr = match address {
-            Some(req_address) => match self.available_range(req_address, size) {
+            Some(req_address) => match self.available_range(req_address, size, alignment) {
                 Ok(addr) => addr,
                 Err(_) => {
                     return None;
                 }
             },
-            None => self.first_available_range(size)?,
+            None => self.first_available_range(size, alignment)?,
         };
 
         self.ranges.insert(new_addr, size);
@@ -200,154 +202,183 @@ mod tests {
     #[test]
     fn new_fails_overflow() {
         assert_eq!(
-            AddressAllocator::new(GuestAddress(u64::max_value()), 0x100, None),
+            AddressAllocator::new(GuestAddress(u64::max_value()), 0x100),
             None
         );
     }
 
     #[test]
     fn new_fails_size_zero() {
-        assert_eq!(AddressAllocator::new(GuestAddress(0x1000), 0, None), None);
+        assert_eq!(AddressAllocator::new(GuestAddress(0x1000), 0), None);
     }
 
     #[test]
-    fn new_fails_alignment_zero() {
+    fn allocate_fails_alignment_zero() {
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x10000).unwrap();
         assert_eq!(
-            AddressAllocator::new(GuestAddress(0x1000), 0x10000, Some(0)),
+            pool.allocate(Some(GuestAddress(0x1000)), 0x100, Some(0)),
             None
         );
     }
 
     #[test]
-    fn new_fails_alignment_non_power_of_two() {
+    fn allocate_fails_alignment_non_power_of_two() {
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x10000).unwrap();
         assert_eq!(
-            AddressAllocator::new(GuestAddress(0x1000), 0x10000, Some(200)),
+            pool.allocate(Some(GuestAddress(0x1000)), 0x100, Some(200)),
             None
         );
     }
 
     #[test]
     fn allocate_fails_not_enough_space() {
-        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, Some(0x100)).unwrap();
-        assert_eq!(pool.allocate(None, 0x800), Some(GuestAddress(0x1700)));
-        assert_eq!(pool.allocate(None, 0x900), None);
-        assert_eq!(pool.allocate(None, 0x400), Some(GuestAddress(0x1200)));
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000).unwrap();
+        assert_eq!(
+            pool.allocate(None, 0x800, Some(0x100)),
+            Some(GuestAddress(0x1700))
+        );
+        assert_eq!(pool.allocate(None, 0x900, Some(0x100)), None);
+        assert_eq!(
+            pool.allocate(None, 0x400, Some(0x100)),
+            Some(GuestAddress(0x1200))
+        );
     }
 
     #[test]
     fn allocate_alignment() {
-        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x10000, Some(0x100)).unwrap();
-        assert_eq!(pool.allocate(None, 0x110), Some(GuestAddress(0x10e00)));
-        assert_eq!(pool.allocate(None, 0x100), Some(GuestAddress(0x10c00)));
-        assert_eq!(pool.allocate(None, 0x10), Some(GuestAddress(0x10b00)));
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x10000).unwrap();
+        assert_eq!(
+            pool.allocate(None, 0x110, Some(0x100)),
+            Some(GuestAddress(0x10e00))
+        );
+        assert_eq!(
+            pool.allocate(None, 0x100, Some(0x100)),
+            Some(GuestAddress(0x10c00))
+        );
+        assert_eq!(
+            pool.allocate(None, 0x10, Some(0x100)),
+            Some(GuestAddress(0x10b00))
+        );
     }
 
     #[test]
     fn allocate_address() {
-        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, None).unwrap();
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000).unwrap();
         assert_eq!(
-            pool.allocate(Some(GuestAddress(0x1200)), 0x800),
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800, None),
             Some(GuestAddress(0x1200))
         );
 
         assert_eq!(
-            pool.allocate(Some(GuestAddress(0x1a00)), 0x100),
+            pool.allocate(Some(GuestAddress(0x1a00)), 0x100, None),
             Some(GuestAddress(0x1a00))
         );
     }
 
     #[test]
     fn allocate_address_alignment() {
-        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, Some(0x100)).unwrap();
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000).unwrap();
         assert_eq!(
-            pool.allocate(Some(GuestAddress(0x1200)), 0x800),
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800, Some(0x100)),
             Some(GuestAddress(0x1200))
         );
 
         // Unaligned request
-        assert_eq!(pool.allocate(Some(GuestAddress(0x1210)), 0x800), None);
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1210)), 0x800, Some(0x100)),
+            None
+        );
 
         // Aligned request
         assert_eq!(
-            pool.allocate(Some(GuestAddress(0x1b00)), 0x100),
+            pool.allocate(Some(GuestAddress(0x1b00)), 0x100, Some(0x100)),
             Some(GuestAddress(0x1b00))
         );
     }
 
     #[test]
     fn allocate_address_not_enough_space() {
-        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, Some(0x100)).unwrap();
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000).unwrap();
 
         // First range is [0x1200:0x1a00]
         assert_eq!(
-            pool.allocate(Some(GuestAddress(0x1200)), 0x800),
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800, Some(0x100)),
             Some(GuestAddress(0x1200))
         );
 
         // Second range is [0x1c00:0x1e00]
         assert_eq!(
-            pool.allocate(Some(GuestAddress(0x1c00)), 0x200),
+            pool.allocate(Some(GuestAddress(0x1c00)), 0x200, Some(0x100)),
             Some(GuestAddress(0x1c00))
         );
 
         // There is 0x200 between the first 2 ranges.
         // We ask for an available address but the range is too big
-        assert_eq!(pool.allocate(Some(GuestAddress(0x1b00)), 0x800), None);
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1b00)), 0x800, Some(0x100)),
+            None
+        );
 
         // We ask for an available address, with a small enough range
         assert_eq!(
-            pool.allocate(Some(GuestAddress(0x1b00)), 0x100),
+            pool.allocate(Some(GuestAddress(0x1b00)), 0x100, Some(0x100)),
             Some(GuestAddress(0x1b00))
         );
     }
 
     #[test]
     fn allocate_address_free_and_realloc() {
-        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, Some(0x100)).unwrap();
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000).unwrap();
 
         // First range is [0x1200:0x1a00]
         assert_eq!(
-            pool.allocate(Some(GuestAddress(0x1200)), 0x800),
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800, Some(0x100)),
             Some(GuestAddress(0x1200))
         );
 
         pool.free(GuestAddress(0x1200), 0x800);
 
         assert_eq!(
-            pool.allocate(Some(GuestAddress(0x1200)), 0x800),
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800, Some(0x100)),
             Some(GuestAddress(0x1200))
         );
     }
 
     #[test]
     fn allocate_address_free_fail_and_realloc() {
-        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, Some(0x100)).unwrap();
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000).unwrap();
 
         // First range is [0x1200:0x1a00]
         assert_eq!(
-            pool.allocate(Some(GuestAddress(0x1200)), 0x800),
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800, Some(0x100)),
             Some(GuestAddress(0x1200))
         );
 
         // We try to free a range smaller than the allocated one.
         pool.free(GuestAddress(0x1200), 0x100);
 
-        assert_eq!(pool.allocate(Some(GuestAddress(0x1200)), 0x800), None);
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800, Some(0x100)),
+            None
+        );
     }
 
     #[test]
     fn allocate_address_fail_free_and_realloc() {
-        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000, Some(0x100)).unwrap();
+        let mut pool = AddressAllocator::new(GuestAddress(0x1000), 0x1000).unwrap();
 
         // First allocation fails
-        assert_eq!(pool.allocate(Some(GuestAddress(0x1200)), 0x2000), None);
+        assert_eq!(
+            pool.allocate(Some(GuestAddress(0x1200)), 0x2000, Some(0x100)),
+            None
+        );
 
         // We try to free a range that was not allocated.
         pool.free(GuestAddress(0x1200), 0x2000);
 
         // Now we try an allocation that should succeed.
         assert_eq!(
-            pool.allocate(Some(GuestAddress(0x1200)), 0x800),
+            pool.allocate(Some(GuestAddress(0x1200)), 0x800, Some(0x100)),
             Some(GuestAddress(0x1200))
         );
     }

--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -1,0 +1,84 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::collections::btree_map::BTreeMap;
+use std::result;
+
+#[derive(Debug)]
+pub enum Error {
+    Overflow,
+}
+
+pub type Result<T> = result::Result<T, Error>;
+
+/// GsiApic
+#[derive(Copy, Clone)]
+pub struct GsiApic {
+    base: u32,
+    irqs: u32,
+}
+
+impl GsiApic {
+    /// New GSI APIC
+    pub fn new(base: u32, irqs: u32) -> Self {
+        GsiApic { base, irqs }
+    }
+}
+
+/// GsiAllocator
+pub struct GsiAllocator {
+    apics: BTreeMap<u32, u32>,
+    next_irq: u32,
+    next_gsi: u32,
+}
+
+impl GsiAllocator {
+    /// New GSI allocator
+    pub fn new(apics: Vec<GsiApic>) -> Self {
+        let mut allocator = GsiAllocator {
+            apics: BTreeMap::new(),
+            next_irq: 0xffff_ffff,
+            next_gsi: 0,
+        };
+
+        for apic in &apics {
+            if apic.base < allocator.next_irq {
+                allocator.next_irq = apic.base;
+            }
+
+            if apic.base + apic.irqs > allocator.next_gsi {
+                allocator.next_gsi = apic.base + apic.irqs;
+            }
+
+            allocator.apics.insert(apic.base, apic.irqs);
+        }
+
+        allocator
+    }
+
+    /// Allocate a GSI
+    pub fn allocate_gsi(&mut self) -> Result<u32> {
+        self.next_gsi = self.next_gsi.checked_add(1).ok_or(Error::Overflow)?;
+
+        Ok(self.next_gsi - 1)
+    }
+
+    /// Allocate an IRQ
+    pub fn allocate_irq(&mut self) -> Result<u32> {
+        let mut irq: u32 = 0;
+        for (base, irqs) in self.apics.iter() {
+            // HACKHACK - This only works with 1 single IOAPIC...
+            if self.next_irq >= *base && self.next_irq < *base + *irqs {
+                irq = self.next_irq;
+                self.next_irq += 1;
+            }
+        }
+
+        if irq == 0 {
+            return Err(Error::Overflow);
+        }
+
+        Ok(irq)
+    }
+}

--- a/vm-allocator/src/lib.rs
+++ b/vm-allocator/src/lib.rs
@@ -14,7 +14,9 @@ extern crate libc;
 extern crate vm_memory;
 
 mod address;
+mod gsi;
 mod system;
 
 pub use crate::address::AddressAllocator;
+pub use crate::gsi::{GsiAllocator, GsiApic};
 pub use crate::system::SystemAllocator;

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -33,7 +33,7 @@ fn pagesize() -> usize {
 ///           5).unwrap();
 ///    assert_eq!(allocator.allocate_irq(), Some(5));
 ///    assert_eq!(allocator.allocate_irq(), Some(6));
-///    assert_eq!(allocator.allocate_mmio_addresses(None, 0x1000), Some(GuestAddress(0x1fffe000)));
+///    assert_eq!(allocator.allocate_mmio_addresses(None, 0x1000, Some(0x1000)), Some(GuestAddress(0x1fffe000)));
 ///
 /// ```
 pub struct SystemAllocator {
@@ -44,8 +44,7 @@ pub struct SystemAllocator {
 
 impl SystemAllocator {
     /// Creates a new `SystemAllocator` for managing addresses and irq numvers.
-    /// Can return `None` if `base` + `size` overflows a u64 or if alignment isn't a power
-    /// of two.
+    /// Can return `None` if `base` + `size` overflows a u64
     ///
     /// * `io_base` - The starting address of IO memory.
     /// * `io_size` - The size of IO memory.
@@ -59,10 +58,9 @@ impl SystemAllocator {
         mmio_size: GuestUsize,
         first_irq: u32,
     ) -> Option<Self> {
-        let page_size = pagesize() as u64;
         Some(SystemAllocator {
-            io_address_space: AddressAllocator::new(io_base, io_size, Some(0x1))?,
-            mmio_address_space: AddressAllocator::new(mmio_base, mmio_size, Some(page_size))?,
+            io_address_space: AddressAllocator::new(io_base, io_size)?,
+            mmio_address_space: AddressAllocator::new(mmio_base, mmio_size)?,
             next_irq: first_irq,
         })
     }
@@ -82,8 +80,10 @@ impl SystemAllocator {
         &mut self,
         address: Option<GuestAddress>,
         size: GuestUsize,
+        align_size: Option<GuestUsize>,
     ) -> Option<GuestAddress> {
-        self.io_address_space.allocate(address, size)
+        self.io_address_space
+            .allocate(address, size, Some(align_size.unwrap_or(0x1)))
     }
 
     /// Reserves a section of `size` bytes of MMIO address space.
@@ -91,8 +91,13 @@ impl SystemAllocator {
         &mut self,
         address: Option<GuestAddress>,
         size: GuestUsize,
+        align_size: Option<GuestUsize>,
     ) -> Option<GuestAddress> {
-        self.mmio_address_space.allocate(address, size)
+        self.mmio_address_space.allocate(
+            address,
+            size,
+            Some(align_size.unwrap_or(pagesize() as u64)),
+        )
     }
 
     /// Free an IO address range.

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -28,7 +28,7 @@ fn pagesize() -> usize {
 /// # use vm_allocator::SystemAllocator;
 /// # use vm_memory::{Address, GuestAddress, GuestUsize};
 ///   let mut allocator = SystemAllocator::new(
-///           Some(GuestAddress(0x1000)), Some(0x10000),
+///           GuestAddress(0x1000), 0x10000,
 ///           GuestAddress(0x10000000), 0x10000000,
 ///           5).unwrap();
 ///    assert_eq!(allocator.allocate_irq(), Some(5));
@@ -37,7 +37,7 @@ fn pagesize() -> usize {
 ///
 /// ```
 pub struct SystemAllocator {
-    io_address_space: Option<AddressAllocator>,
+    io_address_space: AddressAllocator,
     mmio_address_space: AddressAllocator,
     next_irq: u32,
 }
@@ -53,19 +53,15 @@ impl SystemAllocator {
     /// * `mmio_size` - The size of MMIO memory.
     /// * `first_irq` - The first irq number to give out.
     pub fn new(
-        io_base: Option<GuestAddress>,
-        io_size: Option<GuestUsize>,
+        io_base: GuestAddress,
+        io_size: GuestUsize,
         mmio_base: GuestAddress,
         mmio_size: GuestUsize,
         first_irq: u32,
     ) -> Option<Self> {
         let page_size = pagesize() as u64;
         Some(SystemAllocator {
-            io_address_space: if let (Some(b), Some(s)) = (io_base, io_size) {
-                Some(AddressAllocator::new(b, s, Some(0x1))?)
-            } else {
-                None
-            },
+            io_address_space: AddressAllocator::new(io_base, io_size, Some(0x1))?,
             mmio_address_space: AddressAllocator::new(mmio_base, mmio_size, Some(page_size))?,
             next_irq: first_irq,
         })
@@ -84,12 +80,10 @@ impl SystemAllocator {
     /// Reserves a section of `size` bytes of IO address space.
     pub fn allocate_io_addresses(
         &mut self,
-        address: GuestAddress,
+        address: Option<GuestAddress>,
         size: GuestUsize,
     ) -> Option<GuestAddress> {
-        self.io_address_space
-            .as_mut()?
-            .allocate(Some(address), size)
+        self.io_address_space.allocate(address, size)
     }
 
     /// Reserves a section of `size` bytes of MMIO address space.
@@ -104,9 +98,7 @@ impl SystemAllocator {
     /// Free an IO address range.
     /// We can only free a range if it matches exactly an already allocated range.
     pub fn free_io_addresses(&mut self, address: GuestAddress, size: GuestUsize) {
-        if let Some(io_address) = self.io_address_space.as_mut() {
-            io_address.free(address, size)
-        }
+        self.io_address_space.free(address, size)
     }
 
     /// Free an MMIO address range.

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -449,7 +449,7 @@ impl PciDevice for VirtioPciDevice {
         // Allocate the virtio-pci capability BAR.
         // See http://docs.oasis-open.org/virtio/virtio/v1.0/cs04/virtio-v1.0-cs04.html#x1-740004
         let virtio_pci_bar_addr = allocator
-            .allocate_mmio_addresses(None, CAPABILITY_BAR_SIZE)
+            .allocate_mmio_addresses(None, CAPABILITY_BAR_SIZE, None)
             .ok_or(PciDeviceError::IoAllocationFailed(CAPABILITY_BAR_SIZE))?;
         let config = PciBarConfiguration::default()
             .set_register_index(0)
@@ -468,7 +468,7 @@ impl PciDevice for VirtioPciDevice {
         // Allocate the device specific BARs.
         for config in self.device.get_device_bars() {
             let device_bar_addr = allocator
-                .allocate_mmio_addresses(None, config.get_size())
+                .allocate_mmio_addresses(None, config.get_size(), None)
                 .ok_or_else(|| PciDeviceError::IoAllocationFailed(config.get_size()))?;
             config.set_address(device_bar_addr.raw_value());
             let _device_bar = self.configuration.add_pci_bar(&config).map_err(|e| {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1053,8 +1053,8 @@ impl<'a> Vm<'a> {
 
         // Let's allocate 64 GiB of addressable MMIO space, starting at 0.
         let mut allocator = SystemAllocator::new(
-            None,
-            None,
+            GuestAddress(0),
+            1 << 16 as GuestUsize,
             GuestAddress(0),
             1 << 36 as GuestUsize,
             X86_64_IRQ_BASE,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -658,7 +658,7 @@ impl DeviceManager {
                 let size = pmem_cfg.size;
 
                 let pmem_guest_addr = allocator
-                    .allocate_mmio_addresses(None, size as GuestUsize)
+                    .allocate_mmio_addresses(None, size as GuestUsize, None)
                     .ok_or(DeviceManagerError::PmemRangeAllocation)?;
 
                 let (custom_flags, set_len) = if pmem_cfg.file.is_dir() {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -22,6 +22,7 @@ extern crate vm_virtio;
 extern crate vmm_sys_util;
 
 use crate::config::{SerialOutputMode, VmConfig};
+use arch::RegionType;
 use devices::ioapic;
 use kvm_bindings::{
     kvm_enable_cap, kvm_msi, kvm_pit_config, kvm_userspace_memory_region, KVM_CAP_SPLIT_IRQCHIP,
@@ -65,6 +66,10 @@ const HYPERVISOR_ECX_BIT: u8 = 31; // Hypervisor ecx bit.
 
 // 64 bit direct boot entry offset for bzImage
 const KERNEL_64BIT_ENTRY_OFFSET: u64 = 0x200;
+
+// IOAPIC address range
+const IOAPIC_RANGE_ADDR: u64 = 0xfec0_0000;
+const IOAPIC_RANGE_SIZE: u64 = 0x20;
 
 /// Errors associated with VM management
 #[derive(Debug)]
@@ -160,6 +165,12 @@ pub enum Error {
 
     /// Failed to set shared file length.
     SharedFileSetLen(io::Error),
+
+    /// Failed to allocate a memory range.
+    MemoryRangeAllocation,
+
+    /// Failed to allocate the IOAPIC memory range.
+    IoapicRangeAllocation,
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -657,8 +668,10 @@ impl DeviceManager {
             for pmem_cfg in pmem_list_cfg.iter() {
                 let size = pmem_cfg.size;
 
+                // The memory needs to be 2MiB aligned in order to support
+                // hugepages.
                 let pmem_guest_addr = allocator
-                    .allocate_mmio_addresses(None, size as GuestUsize, None)
+                    .allocate_mmio_addresses(None, size as GuestUsize, Some(0x0020_0000))
                     .ok_or(DeviceManagerError::PmemRangeAllocation)?;
 
                 let (custom_flags, set_len) = if pmem_cfg.file.is_dir() {
@@ -855,7 +868,7 @@ impl DeviceManager {
         if let Some(ioapic) = &self.ioapic {
             // Insert IOAPIC
             self.mmio_bus
-                .insert(ioapic.clone(), 0xfec0_0000, 0x20)
+                .insert(ioapic.clone(), IOAPIC_RANGE_ADDR, IOAPIC_RANGE_SIZE)
                 .map_err(Error::BusError)?;
         }
 
@@ -948,10 +961,31 @@ impl<'a> Vm<'a> {
         // Init guest memory
         let arch_mem_regions = arch::arch_memory_regions(config.memory.size);
 
+        let ram_regions: Vec<(GuestAddress, usize)> = arch_mem_regions
+            .iter()
+            .filter(|r| r.2 == RegionType::Ram)
+            .map(|r| (r.0, r.1))
+            .collect();
+        let reserved_regions: Vec<(GuestAddress, usize)> = arch_mem_regions
+            .iter()
+            .filter(|r| r.2 == RegionType::Reserved)
+            .map(|r| (r.0, r.1))
+            .collect();
+
+        // Check the number of reserved regions, and only take the first one
+        // that's acrtually a 32-bit hole.
+        let mut mem_hole = (GuestAddress(0), 0);
+        for region in reserved_regions.iter() {
+            if region.0.unchecked_add(region.1 as u64).raw_value() <= 0x1_0000_0000 {
+                mem_hole = (region.0, region.1);
+                break;
+            }
+        }
+
         let guest_memory = match config.memory.file {
             Some(file) => {
                 let mut mem_regions = Vec::<(GuestAddress, usize, Option<FileOffset>)>::new();
-                for region in arch_mem_regions.iter() {
+                for region in ram_regions.iter() {
                     let file = OpenOptions::new()
                         .read(true)
                         .write(true)
@@ -967,7 +1001,7 @@ impl<'a> Vm<'a> {
 
                 GuestMemoryMmap::with_files(&mem_regions).map_err(Error::GuestMemory)?
             }
-            None => GuestMemoryMmap::new(&arch_mem_regions).map_err(Error::GuestMemory)?,
+            None => GuestMemoryMmap::new(&ram_regions).map_err(Error::GuestMemory)?,
         };
 
         guest_memory
@@ -1062,9 +1096,37 @@ impl<'a> Vm<'a> {
             1 << 16 as GuestUsize,
             GuestAddress(0),
             1 << 36 as GuestUsize,
+            mem_hole.0,
+            mem_hole.1 as GuestUsize,
             vec![ioapic],
         )
         .ok_or(Error::CreateSystemAllocator)?;
+
+        // Allocate RAM and Reserved address ranges.
+        for region in arch_mem_regions.iter() {
+            allocator
+                .allocate_mmio_addresses(Some(region.0), region.1 as GuestUsize, None)
+                .ok_or(Error::MemoryRangeAllocation)?;
+        }
+
+        // Allocate IOAPIC address in the memory hole if necessary.
+        if IOAPIC_RANGE_ADDR >= mem_hole.0.raw_value() && IOAPIC_RANGE_SIZE < mem_hole.1 as u64 {
+            allocator
+                .allocate_mmio_hole_addresses(
+                    Some(GuestAddress(IOAPIC_RANGE_ADDR)),
+                    IOAPIC_RANGE_SIZE as GuestUsize,
+                    None,
+                )
+                .ok_or(Error::IoapicRangeAllocation)?;
+        } else {
+            allocator
+                .allocate_mmio_addresses(
+                    Some(GuestAddress(IOAPIC_RANGE_ADDR)),
+                    IOAPIC_RANGE_SIZE as GuestUsize,
+                    None,
+                )
+                .ok_or(Error::IoapicRangeAllocation)?;
+        }
 
         let device_manager = DeviceManager::new(
             guest_memory.clone(),

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -44,7 +44,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::ptr::null_mut;
 use std::sync::{Arc, Barrier, Mutex};
 use std::{result, str, thread};
-use vm_allocator::SystemAllocator;
+use vm_allocator::{GsiApic, SystemAllocator};
 use vm_memory::guest_memory::FileOffset;
 use vm_memory::{
     Address, Bytes, Error as MmapError, GuestAddress, GuestMemory, GuestMemoryMmap,
@@ -1051,13 +1051,18 @@ impl<'a> Vm<'a> {
 
         CpuidPatch::patch_cpuid(&mut cpuid, cpuid_patches);
 
+        let ioapic = GsiApic::new(
+            X86_64_IRQ_BASE,
+            ioapic::NUM_IOAPIC_PINS as u32 - X86_64_IRQ_BASE,
+        );
+
         // Let's allocate 64 GiB of addressable MMIO space, starting at 0.
         let mut allocator = SystemAllocator::new(
             GuestAddress(0),
             1 << 16 as GuestUsize,
             GuestAddress(0),
             1 << 36 as GuestUsize,
-            X86_64_IRQ_BASE,
+            vec![ioapic],
         )
         .ok_or(Error::CreateSystemAllocator)?;
 


### PR DESCRIPTION
In the context of the VFIO initial support PR (#60), we need to fix and improve the `vm-allocator` crate in several ways:

- Allow for allocation time alignment requirements: Not all address range allocation will have the same alignment requirements, so the vm-allocator API need to take that into account.
- Support the 32-bit hole: We want to vm-allocator crate to handle the 32-bit hole as a distinct sub MMIO range, as some allocations (e.g. IOAPIC range, 32-bit PCI BARs) must take place there.
- Extend the IRQ allocation API to support GSI and take IOAPIC IRQ ranges into account.
- A few fixes that surfaced when adding the 32-bit hole as a MMIO sub-region