### PR TITLE
PCI fixes and improvements

### DIFF
--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -178,7 +178,10 @@ pub trait PciProgrammingInterface {
 }
 
 /// Types of PCI capabilities.
-#[derive(PartialEq)]
+#[derive(PartialEq, Copy, Clone)]
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+#[repr(C)]
 pub enum PciCapabilityID {
     ListID = 0,
     PowerManagement = 0x01,
@@ -201,6 +204,35 @@ pub enum PciCapabilityID {
     SATADataIndexConf = 0x12,
     PCIAdvancedFeatures = 0x13,
     PCIEnhancedAllocation = 0x14,
+}
+
+impl From<u8> for PciCapabilityID {
+    fn from(c: u8) -> Self {
+        match c {
+            0 => PciCapabilityID::ListID,
+            0x01 => PciCapabilityID::PowerManagement,
+            0x02 => PciCapabilityID::AcceleratedGraphicsPort,
+            0x03 => PciCapabilityID::VitalProductData,
+            0x04 => PciCapabilityID::SlotIdentification,
+            0x05 => PciCapabilityID::MessageSignalledInterrupts,
+            0x06 => PciCapabilityID::CompactPCIHotSwap,
+            0x07 => PciCapabilityID::PCIX,
+            0x08 => PciCapabilityID::HyperTransport,
+            0x09 => PciCapabilityID::VendorSpecific,
+            0x0A => PciCapabilityID::Debugport,
+            0x0B => PciCapabilityID::CompactPCICentralResourceControl,
+            0x0C => PciCapabilityID::PCIStandardHotPlugController,
+            0x0D => PciCapabilityID::BridgeSubsystemVendorDeviceID,
+            0x0E => PciCapabilityID::AGPTargetPCIPCIbridge,
+            0x0F => PciCapabilityID::SecureDevice,
+            0x10 => PciCapabilityID::PCIExpress,
+            0x11 => PciCapabilityID::MSIX,
+            0x12 => PciCapabilityID::SATADataIndexConf,
+            0x13 => PciCapabilityID::PCIAdvancedFeatures,
+            0x14 => PciCapabilityID::PCIEnhancedAllocation,
+            _ => PciCapabilityID::ListID,
+        }
+    }
 }
 
 /// A PCI capability list. Devices can optionally specify capabilities in their configuration space.

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -632,6 +632,11 @@ impl PciBarConfiguration {
     pub fn get_size(&self) -> u64 {
         self.size
     }
+
+    pub fn set_region_type(mut self, region_type: PciBarRegionType) -> Self {
+        self.region_type = region_type;
+        self
+    }
 }
 
 #[cfg(test)]

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
-use crate::configuration;
+use crate::configuration::{self, PciBarRegionType};
 use crate::msix::MsixTableEntry;
 use crate::PciInterruptPin;
 use devices::BusDevice;
@@ -66,7 +66,7 @@ pub trait PciDevice: BusDevice {
     fn allocate_bars(
         &mut self,
         _allocator: &mut SystemAllocator,
-    ) -> Result<Vec<(GuestAddress, GuestUsize)>> {
+    ) -> Result<Vec<(GuestAddress, GuestUsize, PciBarRegionType)>> {
         Ok(Vec::new())
     }
 

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -13,6 +13,7 @@ extern crate vmm_sys_util;
 mod bus;
 mod configuration;
 mod device;
+mod msi;
 mod msix;
 
 pub use self::bus::{PciConfigIo, PciConfigMmio, PciRoot, PciRootError};
@@ -24,6 +25,7 @@ pub use self::configuration::{
 pub use self::device::{
     Error as PciDeviceError, InterruptDelivery, InterruptParameters, PciDevice,
 };
+pub use self::msi::MsiCap;
 pub use self::msix::{MsixCap, MsixConfig, MsixTableEntry, MSIX_TABLE_ENTRY_SIZE};
 
 /// PCI has four interrupt pins A->D.

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -24,7 +24,7 @@ pub use self::configuration::{
 pub use self::device::{
     Error as PciDeviceError, InterruptDelivery, InterruptParameters, PciDevice,
 };
-pub use self::msix::{MsixCap, MsixConfig, MsixTableEntry};
+pub use self::msix::{MsixCap, MsixConfig, MsixTableEntry, MSIX_TABLE_ENTRY_SIZE};
 
 /// PCI has four interrupt pins A->D.
 #[derive(Copy, Clone)]

--- a/pci/src/msi.rs
+++ b/pci/src/msi.rs
@@ -1,0 +1,153 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+//
+
+extern crate byteorder;
+extern crate vm_memory;
+
+use byteorder::{ByteOrder, LittleEndian};
+
+// MSI control masks
+const MSI_CTL_ENABLE: u16 = 0x1;
+const MSI_CTL_MULTI_MSG_ENABLE: u16 = 0x70;
+const MSI_CTL_64_BITS: u16 = 0x80;
+const MSI_CTL_PER_VECTOR: u16 = 0x100;
+
+// MSI message offsets
+const MSI_MSG_CTL_OFFSET: u64 = 0x2;
+const MSI_MSG_ADDR_LO_OFFSET: u64 = 0x4;
+
+// MSI message masks
+const MSI_MSG_ADDR_LO_MASK: u32 = 0xffff_fffc;
+
+#[derive(Clone, Copy, Default)]
+pub struct MsiCap {
+    // Message Control Register
+    //   0:     MSI enable.
+    //   3-1;   Multiple message capable.
+    //   6-4:   Multiple message enable.
+    //   7:     64 bits address capable.
+    //   8:     Per-vector masking capable.
+    //   15-9:  Reserved.
+    pub msg_ctl: u16,
+    // Message Address (LSB)
+    //   1-0:  Reserved.
+    //   31-2: Message address.
+    pub msg_addr_lo: u32,
+    // Message Upper Address (MSB)
+    //   31-0: Message address.
+    pub msg_addr_hi: u32,
+    // Message Data
+    //   15-0: Message data.
+    pub msg_data: u16,
+    // Mask Bits
+    //   31-0: Mask bits.
+    pub mask_bits: u32,
+    // Pending Bits
+    //   31-0: Pending bits.
+    pub pending_bits: u32,
+}
+
+impl MsiCap {
+    fn addr_64_bits(&self) -> bool {
+        self.msg_ctl & MSI_CTL_64_BITS == MSI_CTL_64_BITS
+    }
+
+    fn per_vector_mask(&self) -> bool {
+        self.msg_ctl & MSI_CTL_PER_VECTOR == MSI_CTL_PER_VECTOR
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.msg_ctl & MSI_CTL_ENABLE == MSI_CTL_ENABLE
+    }
+
+    pub fn num_enabled_vectors(&self) -> usize {
+        let field = (self.msg_ctl >> 4) & 0x7;
+
+        if field > 5 {
+            return 0;
+        }
+
+        1 << field
+    }
+
+    pub fn vector_masked(&self, vector: usize) -> bool {
+        if !self.per_vector_mask() {
+            return false;
+        }
+
+        (self.mask_bits >> vector) & 0x1 == 0x1
+    }
+
+    pub fn size(&self) -> u64 {
+        let mut size: u64 = 0xa;
+
+        if self.addr_64_bits() {
+            size += 0x4;
+        }
+        if self.per_vector_mask() {
+            size += 0xa;
+        }
+
+        size
+    }
+
+    pub fn update(&mut self, offset: u64, data: &[u8]) {
+        // Calculate message data offset depending on the address being 32 or
+        // 64 bits.
+        // Calculate upper address offset if the address is 64 bits.
+        // Calculate mask bits offset based on the address being 32 or 64 bits
+        // and based on the per vector masking being enabled or not.
+        let (msg_data_offset, addr_hi_offset, mask_bits_offset): (u64, Option<u64>, Option<u64>) =
+            if self.addr_64_bits() {
+                let mask_bits = if self.per_vector_mask() {
+                    Some(0x10)
+                } else {
+                    None
+                };
+                (0xc, Some(0x8), mask_bits)
+            } else {
+                let mask_bits = if self.per_vector_mask() {
+                    Some(0xc)
+                } else {
+                    None
+                };
+                (0x8, None, mask_bits)
+            };
+
+        // Update cache without overriding the read-only bits.
+        match data.len() {
+            2 => {
+                let value = LittleEndian::read_u16(data);
+                match offset {
+                    MSI_MSG_CTL_OFFSET => {
+                        self.msg_ctl = (self.msg_ctl & !(MSI_CTL_ENABLE | MSI_CTL_MULTI_MSG_ENABLE))
+                            | (value & (MSI_CTL_ENABLE | MSI_CTL_MULTI_MSG_ENABLE))
+                    }
+                    x if x == msg_data_offset => self.msg_data = value,
+                    _ => error!("invalid offset"),
+                }
+            }
+            4 => {
+                let value = LittleEndian::read_u32(data);
+                match offset {
+                    MSI_MSG_CTL_OFFSET => {
+                        self.msg_ctl = (self.msg_ctl & !(MSI_CTL_ENABLE | MSI_CTL_MULTI_MSG_ENABLE))
+                            | ((value >> 16) as u16 & (MSI_CTL_ENABLE | MSI_CTL_MULTI_MSG_ENABLE))
+                    }
+                    MSI_MSG_ADDR_LO_OFFSET => self.msg_addr_lo = value & MSI_MSG_ADDR_LO_MASK,
+                    x if x == msg_data_offset => self.msg_data = value as u16,
+                    x if addr_hi_offset.is_some() && x == addr_hi_offset.unwrap() => {
+                        self.msg_addr_hi = value
+                    }
+                    x if mask_bits_offset.is_some() && x == mask_bits_offset.unwrap() => {
+                        self.mask_bits = value
+                    }
+                    _ => error!("invalid offset"),
+                }
+            }
+            _ => error!("invalid data length"),
+        }
+    }
+}

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -354,6 +354,7 @@ impl VirtioPciDevice {
                 settings_bar,
                 self.msix_num,
                 MSIX_TABLE_BAR_OFFSET as u32,
+                settings_bar,
                 MSIX_PBA_BAR_OFFSET as u32,
             );
             self.configuration
@@ -401,7 +402,7 @@ impl PciDevice for VirtioPciDevice {
                 // device should not inject the interrupt.
                 // Instead, the Pending Bit Array table is updated to reflect there
                 // is a pending interrupt for this specific vector.
-                if config.is_masked() || entry.is_masked() {
+                if config.masked() || entry.masked() {
                     config.set_pba_bit(queue.vector, false);
                     return Ok(());
                 }


### PR DESCRIPTION
In order to build our initial VFIO support (see #60), we had to fix and improve the PCI crate:

- Improve the MSI-X support to use it directly from the VFIO code.
- Add MSI support to the PCI crate
- Support IO (PIO based) BARs
- Fix the PCI configuration write emulation 