### PR TITLE
[DNM] vfio: Don't create KVM VFIO device

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -949,17 +949,6 @@ impl DeviceManager {
         Ok(())
     }
 
-    fn create_kvm_device(vm: &Arc<VmFd>) -> DeviceManagerResult<DeviceFd> {
-        let mut vfio_dev = kvm_bindings::kvm_create_device {
-            type_: kvm_bindings::kvm_device_type_KVM_DEV_TYPE_VFIO,
-            fd: 0,
-            flags: 0,
-        };
-
-        vm.create_device(&mut vfio_dev)
-            .map_err(DeviceManagerError::CreateKvmDevice)
-    }
-
     fn add_vfio_devices(
         memory: GuestMemoryMmap,
         allocator: &mut SystemAllocator,
@@ -971,14 +960,9 @@ impl DeviceManager {
     ) -> DeviceManagerResult<()> {
         let mut mem_slot = mem_slots;
         if let Some(device_list_cfg) = &vm_cfg.devices {
-            // Create the KVM VFIO device
-            let device_fd = DeviceManager::create_kvm_device(vm_fd)?;
-            let device_fd = Arc::new(device_fd);
-
             for device_cfg in device_list_cfg.iter() {
-                let vfio_device =
-                    VfioDevice::new(device_cfg.path, device_fd.clone(), memory.clone())
-                        .map_err(DeviceManagerError::VfioCreate)?;
+                let vfio_device = VfioDevice::new(device_cfg.path, memory.clone())
+                    .map_err(DeviceManagerError::VfioCreate)?;
 
                 let mut vfio_pci_device = VfioPciDevice::new(vm_fd, allocator, vfio_device)
                     .map_err(DeviceManagerError::VfioPciCreate)?;


### PR DESCRIPTION
We experienced some very important slowdown when using VFIO on several
machines with some real hardware (NIC and Card reader PCI devices) that
we were not seeing on the nested setup with virtio devices.

By slow, we mean the VM was taking around 20s to boot to userspace when
it took roughly 1s to run the same in the nested environment, or even
without VFIO.

The root cause comes from the KVM VFIO device setup. As soon as the
device is set with the group KVM_DEV_VFIO_GROUP and the attribute
KVM_DEV_VFIO_GROUP_ADD, the entire VM runs very slowly.

Because the point of having the KVM VFIO device was simply to be able to
setup those attributes, there is no longer a need for the device at all.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>