### PR TITLE
vm-virtio: Add support for notifying about virtio config update

### DIFF
--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -8,12 +8,20 @@
 
 use super::*;
 use pci::{PciBarConfiguration, PciCapability};
-use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use vm_memory::GuestMemoryMmap;
 use vmm_sys_util::EventFd;
 
-pub type VirtioInterrupt = Box<Fn(&Queue) -> std::result::Result<(), std::io::Error> + Send + Sync>;
+pub enum VirtioInterruptType {
+    Config,
+    Queue,
+}
+
+pub type VirtioInterrupt = Box<
+    Fn(&VirtioInterruptType, Option<&Queue>) -> std::result::Result<(), std::io::Error>
+        + Send
+        + Sync,
+>;
 
 /// Trait for virtio devices to be driven by a virtio transport.
 ///
@@ -49,7 +57,6 @@ pub trait VirtioDevice: Send {
         &mut self,
         mem: GuestMemoryMmap,
         interrupt_evt: Arc<VirtioInterrupt>,
-        status: Arc<AtomicUsize>,
         queues: Vec<Queue>,
         queue_evts: Vec<EventFd>,
     ) -> ActivateResult;


### PR DESCRIPTION
As per the VIRTIO specification, every virtio device configuration can
be updated while the guest is running. The guest needs to be notified
when this happens, and it can be done in two different ways, depending
on the type of interrupt being used for those devices.

In case the device uses INTx, the allocated IRQ pin is shared between
queues and configuration updates. The way for the guest to differentiate
between an interrupt meant for a virtqueue or meant for a configuration
update is tied to the value of the ISR status field. This field is a
simple 32 bits bitmask where only bit 0 and 1 can be changed, the rest
is reserved.

In case the device uses MSI/MSI-X, the driver should allocate a
dedicated vector for configuration updates. This case is much simpler as
it only requires the device to send the appropriate MSI vector.

The cloud-hypervisor codebase was not supporting the update of a virtio
device configuration. This patch extends the existing VirtioInterrupt
closure to accept a type that can be Config or Queue, so that based on
this type, the closure implementation can make the right choice about
which interrupt pin or vector to trigger.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>