### PR TITLE
arch: x86_64: Set MTRR default memory type as WB

### DIFF
--- a/arch/src/x86_64/regs.rs
+++ b/arch/src/x86_64/regs.rs
@@ -18,6 +18,10 @@ const PML4_START: GuestAddress = GuestAddress(0x9000);
 const PDPTE_START: GuestAddress = GuestAddress(0xa000);
 const PDE_START: GuestAddress = GuestAddress(0xb000);
 
+// MTRR constants
+const MTRR_ENABLE: u64 = 0x800; // IA32_MTRR_DEF_TYPE MSR: E (MTRRs enabled) flag, bit 11
+const MTRR_MEM_TYPE_WB: u64 = 0x6;
+
 #[derive(Debug)]
 pub enum Error {
     /// Failed to get SREGs for this CPU.
@@ -267,6 +271,11 @@ fn create_msr_entries() -> Vec<kvm_msr_entry> {
     entries.push(kvm_msr_entry {
         index: msr_index::MSR_IA32_MISC_ENABLE,
         data: msr_index::MSR_IA32_MISC_ENABLE_FAST_STRING as u64,
+        ..Default::default()
+    });
+    entries.push(kvm_msr_entry {
+        index: msr_index::MSR_MTRRdefType,
+        data: MTRR_ENABLE | MTRR_MEM_TYPE_WB,
         ..Default::default()
     });
 


### PR DESCRIPTION
In the context of VFIO, we use Vt-d, which means we rely on an IOMMU. Depending on the IOMMU capability, and in particular if it is not able to perform SC (Snooping Control), the memory will not be tagged as WB by KVM, but instead the vCPU will rely on its MTRR/PAT MSRs to find the appropriate way of interact with specific memory regions.

Because when Vt-d is not involved KVM sets the memory as WB (write-back) the VMM should set the memory default as WB. That's why this patch sets the MSR MTRRdefType with the default memory type being WB.

One thing that it is worth noting is that we might have to specifically create some UC (uncacheable) regions if we see some issues with the ranges corresponding to the MMIO ranges that should trap.