### PR TITLE
Don't break from epoll loop on EINTR

### DIFF
--- a/vm-virtio/src/block.rs
+++ b/vm-virtio/src/block.rs
@@ -422,8 +422,22 @@ impl<T: DiskFile> BlockEpollHandler<T> {
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 
         'epoll: loop {
-            let num_events =
-                epoll::wait(epoll_fd, -1, &mut events[..]).map_err(DeviceError::EpollWait)?;
+            let num_events = match epoll::wait(epoll_fd, -1, &mut events[..]) {
+                Ok(res) => res,
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::Interrupted {
+                        // It's well defined from the epoll_wait() syscall
+                        // documentation that the epoll loop can be interrupted
+                        // before any of the requested events occurred or the
+                        // timeout expired. In both those cases, epoll_wait()
+                        // returns an error of type EINTR, but this should not
+                        // be considered as a regular error. Instead it is more
+                        // appropriate to retry, by calling into epoll_wait().
+                        continue;
+                    }
+                    return Err(DeviceError::EpollWait(e));
+                }
+            };
 
             for event in events.iter().take(num_events) {
                 let ev_type = event.data as u16;

--- a/vm-virtio/src/fs.rs
+++ b/vm-virtio/src/fs.rs
@@ -121,8 +121,22 @@ impl FsEpollHandler {
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 
         'epoll: loop {
-            let num_events =
-                epoll::wait(epoll_fd, -1, &mut events[..]).map_err(DeviceError::EpollWait)?;
+            let num_events = match epoll::wait(epoll_fd, -1, &mut events[..]) {
+                Ok(res) => res,
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::Interrupted {
+                        // It's well defined from the epoll_wait() syscall
+                        // documentation that the epoll loop can be interrupted
+                        // before any of the requested events occurred or the
+                        // timeout expired. In both those cases, epoll_wait()
+                        // returns an error of type EINTR, but this should not
+                        // be considered as a regular error. Instead it is more
+                        // appropriate to retry, by calling into epoll_wait().
+                        continue;
+                    }
+                    return Err(DeviceError::EpollWait(e));
+                }
+            };
 
             for event in events.iter().take(num_events) {
                 let ev_type = event.data as usize;

--- a/vm-virtio/src/net.rs
+++ b/vm-virtio/src/net.rs
@@ -333,8 +333,22 @@ impl NetEpollHandler {
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 
         'epoll: loop {
-            let num_events =
-                epoll::wait(epoll_fd, -1, &mut events[..]).map_err(DeviceError::EpollWait)?;
+            let num_events = match epoll::wait(epoll_fd, -1, &mut events[..]) {
+                Ok(res) => res,
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::Interrupted {
+                        // It's well defined from the epoll_wait() syscall
+                        // documentation that the epoll loop can be interrupted
+                        // before any of the requested events occurred or the
+                        // timeout expired. In both those cases, epoll_wait()
+                        // returns an error of type EINTR, but this should not
+                        // be considered as a regular error. Instead it is more
+                        // appropriate to retry, by calling into epoll_wait().
+                        continue;
+                    }
+                    return Err(DeviceError::EpollWait(e));
+                }
+            };
 
             for event in events.iter().take(num_events) {
                 let ev_type = event.data as u16;

--- a/vm-virtio/src/pmem.rs
+++ b/vm-virtio/src/pmem.rs
@@ -237,8 +237,22 @@ impl PmemEpollHandler {
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 
         'epoll: loop {
-            let num_events =
-                epoll::wait(epoll_fd, -1, &mut events[..]).map_err(DeviceError::EpollWait)?;
+            let num_events = match epoll::wait(epoll_fd, -1, &mut events[..]) {
+                Ok(res) => res,
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::Interrupted {
+                        // It's well defined from the epoll_wait() syscall
+                        // documentation that the epoll loop can be interrupted
+                        // before any of the requested events occurred or the
+                        // timeout expired. In both those cases, epoll_wait()
+                        // returns an error of type EINTR, but this should not
+                        // be considered as a regular error. Instead it is more
+                        // appropriate to retry, by calling into epoll_wait().
+                        continue;
+                    }
+                    return Err(DeviceError::EpollWait(e));
+                }
+            };
 
             for event in events.iter().take(num_events) {
                 let ev_type = event.data as u16;

--- a/vm-virtio/src/rng.rs
+++ b/vm-virtio/src/rng.rs
@@ -105,8 +105,22 @@ impl RngEpollHandler {
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
 
         'epoll: loop {
-            let num_events =
-                epoll::wait(epoll_fd, -1, &mut events[..]).map_err(DeviceError::EpollWait)?;
+            let num_events = match epoll::wait(epoll_fd, -1, &mut events[..]) {
+                Ok(res) => res,
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::Interrupted {
+                        // It's well defined from the epoll_wait() syscall
+                        // documentation that the epoll loop can be interrupted
+                        // before any of the requested events occurred or the
+                        // timeout expired. In both those cases, epoll_wait()
+                        // returns an error of type EINTR, but this should not
+                        // be considered as a regular error. Instead it is more
+                        // appropriate to retry, by calling into epoll_wait().
+                        continue;
+                    }
+                    return Err(DeviceError::EpollWait(e));
+                }
+            };
 
             for event in events.iter().take(num_events) {
                 let ev_type = event.data as u16;


### PR DESCRIPTION
The existing code taking care of the epoll loop was too restrictive as                                                                                                                                                                                                
it was propagating the error returned from the epoll_wait() syscall, no                                                                                                                                                                                               
matter what was the error. This causes the epoll loop to be broken,                                                                                                                                                                                                   
leading to the VM termination or non-functional virtio device.                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                      
This PR enforces the parsing of the returned error and prevent from                                                                                                                                                                                                
the error propagation in case it is EINTR, which stands for Interrupted.                                                                                                                                                                                              
In case the epoll loop is interrupted, it is appropriate to retry.