### PR TITLE
vfio: Fix MSI-X erroneous implementation

### DIFF
--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -359,11 +359,11 @@ impl MsixCap {
     }
 
     pub fn table_offset(&self) -> u32 {
-        self.table >> 3
+        self.table & 0xffff_fff8
     }
 
     pub fn pba_offset(&self) -> u32 {
-        self.pba >> 3
+        self.pba & 0xffff_fff8
     }
 
     pub fn table_bir(&self) -> u32 {

--- a/vfio/src/vfio_pci.rs
+++ b/vfio/src/vfio_pci.rs
@@ -207,12 +207,14 @@ impl Interrupt {
 
     fn msix_write_table(&mut self, offset: u64, data: &[u8]) {
         if let Some(ref mut msix) = &mut self.msix {
+            let offset = offset - u64::from(msix.cap.table_offset());
             msix.bar.write_table(offset, data)
         }
     }
 
     fn msix_read_table(&self, offset: u64, data: &mut [u8]) {
         if let Some(msix) = &self.msix {
+            let offset = offset - u64::from(msix.cap.table_offset());
             msix.bar.read_table(offset, data)
         }
     }


### PR DESCRIPTION
This pull request fixes errors in the VFIO and associated MSI-X code that were not discovered until now. The reason is that all devices tested so far had their MSI-X table placed on a BAR at the offset 0x0. As soon as we started testing with devices where the MSI-X table was placed at an offset different from 0x0, we could identify those implementation flaws.