### PR TITLE
build, misc: Bump vmm-sys-util dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 [[package]]
 name = "vmm-sys-util"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vmm-sys-util#cb33925bfd1eb314e5384c58c78874d2c98d6182"
+source = "git+https://github.com/rust-vmm/vmm-sys-util#71b5b25dd5b5bc5c8ce7f08f39f2e594b53d12fc"
 dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/devices/src/legacy/i8042.rs
+++ b/devices/src/legacy/i8042.rs
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
-use vmm_sys_util::EventFd;
+use vmm_sys_util::eventfd::EventFd;
 
 use BusDevice;
 

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -8,7 +8,7 @@
 use crate::{BusDevice, Interrupt};
 use std::collections::VecDeque;
 use std::{io, result};
-use vmm_sys_util::Result;
+use vmm_sys_util::errno::Result;
 
 const LOOP_SIZE: usize = 0x40;
 
@@ -233,7 +233,7 @@ mod tests {
     use super::*;
     use std::io;
     use std::sync::{Arc, Mutex};
-    use vmm_sys_util::EventFd;
+    use vmm_sys_util::eventfd::EventFd;
 
     struct TestInterrupt {
         event_fd: EventFd,

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -11,7 +11,7 @@ use std::fmt::{self, Display};
 use std::sync::Arc;
 use vm_allocator::SystemAllocator;
 use vm_memory::{GuestAddress, GuestUsize};
-use vmm_sys_util::EventFd;
+use vmm_sys_util::eventfd::EventFd;
 
 pub struct InterruptParameters<'a> {
     pub msix: Option<&'a MsixTableEntry>,

--- a/qcow/src/qcow.rs
+++ b/qcow/src/qcow.rs
@@ -12,7 +12,10 @@ mod vec_cache;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use libc::{EINVAL, ENOSPC, ENOTSUP};
 use remain::sorted;
-use vmm_sys_util::{FileSetLen, FileSync, PunchHole, SeekHole, WriteZeroes};
+use vmm_sys_util::{
+    file_traits::FileSetLen, file_traits::FileSync, seek_hole::SeekHole, write_zeroes::PunchHole,
+    write_zeroes::WriteZeroes,
+};
 
 use std::cmp::{max, min};
 use std::fmt::{self, Display};

--- a/qcow/src/qcow_raw_file.rs
+++ b/qcow/src/qcow_raw_file.rs
@@ -7,7 +7,7 @@ use std::io::{self, BufWriter, Seek, SeekFrom};
 use std::mem::size_of;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use vmm_sys_util::WriteZeroes;
+use vmm_sys_util::write_zeroes::WriteZeroes;
 
 /// A qcow file. Allows reading/writing clusters and appending clusters.
 #[derive(Debug)]

--- a/vfio/src/vfio_device.rs
+++ b/vfio/src/vfio_device.rs
@@ -19,8 +19,8 @@ use std::u32;
 use vfio_bindings::bindings::vfio::*;
 use vfio_ioctls::*;
 use vm_memory::{Address, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::ioctl::*;
-use vmm_sys_util::EventFd;
 
 #[derive(Debug)]
 pub enum VfioError {

--- a/vfio/src/vfio_pci.rs
+++ b/vfio/src/vfio_pci.rs
@@ -27,7 +27,7 @@ use std::{fmt, io};
 use vfio_bindings::bindings::vfio::*;
 use vm_allocator::SystemAllocator;
 use vm_memory::{Address, GuestAddress, GuestUsize};
-use vmm_sys_util::EventFd;
+use vmm_sys_util::eventfd::EventFd;
 
 #[derive(Debug)]
 pub enum VfioPciError {

--- a/vhost_rs/src/backend.rs
+++ b/vhost_rs/src/backend.rs
@@ -11,7 +11,7 @@
 
 use super::Result;
 use std::os::unix::io::RawFd;
-use vmm_sys_util::EventFd;
+use vmm_sys_util::eventfd::EventFd;
 
 /// Maximum number of memory regions supported.
 pub const VHOST_MAX_MEMORY_REGIONS: usize = 255;

--- a/vhost_rs/src/vhost_kern/mod.rs
+++ b/vhost_rs/src/vhost_kern/mod.rs
@@ -15,8 +15,8 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::ptr::null;
 
 use vm_memory::{Address, GuestAddress, GuestMemory, GuestUsize};
+use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::ioctl::{ioctl, ioctl_with_mut_ref, ioctl_with_ptr, ioctl_with_ref};
-use vmm_sys_util::EventFd;
 
 use super::{
     Error, Result, VhostBackend, VhostUserMemoryRegionInfo, VringConfigData,

--- a/vhost_rs/src/vhost_user/master.rs
+++ b/vhost_rs/src/vhost_user/master.rs
@@ -8,7 +8,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex};
 
-use vmm_sys_util::EventFd;
+use vmm_sys_util::eventfd::EventFd;
 
 use super::connection::Endpoint;
 use super::message::*;

--- a/vhost_rs/src/vhost_user/mod.rs
+++ b/vhost_rs/src/vhost_user/mod.rs
@@ -116,10 +116,10 @@ impl Error {
     }
 }
 
-impl std::convert::From<vmm_sys_util::Error> for Error {
+impl std::convert::From<vmm_sys_util::errno::Error> for Error {
     /// Convert raw socket errors into meaningful vhost-user errors.
     ///
-    /// The vmm_sys_util::Error is a simple wrapper over the raw errno, which doesn't means much
+    /// The vmm_sys_util::errno::Error is a simple wrapper over the raw errno, which doesn't means much
     /// to the vhost-user connection manager. So convert it into meaningful errors to simplify
     /// the connection manager logic.
     ///
@@ -128,7 +128,7 @@ impl std::convert::From<vmm_sys_util::Error> for Error {
     /// * - Error::SocketBroken: the underline socket is broken.
     /// * - Error::SocketError: other socket related errors.
     #[allow(unreachable_patterns)] // EWOULDBLOCK equals to EGAIN on linux
-    fn from(err: vmm_sys_util::Error) -> Self {
+    fn from(err: vmm_sys_util::errno::Error) -> Self {
         match err.errno() {
             // The socket is marked nonblocking and the requested operation would block.
             libc::EAGAIN => Error::SocketRetry(IOError::from_raw_os_error(libc::EAGAIN)),

--- a/vhost_rs/src/vhost_user/sock_ctrl_msg.rs
+++ b/vhost_rs/src/vhost_user/sock_ctrl_msg.rs
@@ -16,7 +16,7 @@ use std::ptr::{copy_nonoverlapping, null_mut, write_unaligned};
 use libc::{
     c_long, c_void, cmsghdr, iovec, msghdr, recvmsg, sendmsg, MSG_NOSIGNAL, SCM_RIGHTS, SOL_SOCKET,
 };
-use vmm_sys_util::{Error, Result};
+use vmm_sys_util::errno::{Error, Result};
 
 // Each of the following macros performs the same function as their C counterparts. They are each
 // macros because they are used to size statically allocated arrays.
@@ -335,7 +335,7 @@ mod tests {
 
     use libc::cmsghdr;
 
-    use vmm_sys_util::EventFd;
+    use vmm_sys_util::eventfd::EventFd;
 
     #[test]
     fn buffer_len() {

--- a/vm-virtio/src/block.rs
+++ b/vm-virtio/src/block.rs
@@ -28,7 +28,7 @@ use super::{
 use crate::VirtioInterrupt;
 use virtio_bindings::virtio_blk::*;
 use vm_memory::{Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap};
-use vmm_sys_util::EventFd;
+use vmm_sys_util::eventfd::EventFd;
 
 const CONFIG_SPACE_SIZE: usize = 8;
 const SECTOR_SHIFT: u8 = 9;

--- a/vm-virtio/src/console.rs
+++ b/vm-virtio/src/console.rs
@@ -20,7 +20,7 @@ use super::{
 };
 use crate::VirtioInterrupt;
 use vm_memory::{Bytes, GuestMemoryMmap};
-use vmm_sys_util::EventFd;
+use vmm_sys_util::eventfd::EventFd;
 
 const QUEUE_SIZE: u16 = 256;
 const NUM_QUEUES: usize = 2;

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -10,7 +10,7 @@ use super::*;
 use pci::{PciBarConfiguration, PciCapability};
 use std::sync::Arc;
 use vm_memory::GuestMemoryMmap;
-use vmm_sys_util::EventFd;
+use vmm_sys_util::eventfd::EventFd;
 
 pub enum VirtioInterruptType {
     Config,

--- a/vm-virtio/src/fs.rs
+++ b/vm-virtio/src/fs.rs
@@ -17,7 +17,7 @@ use vhost_rs::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFe
 use vhost_rs::vhost_user::{Master, VhostUserMaster};
 use vhost_rs::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
 use vm_memory::{Address, Error as MmapError, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
-use vmm_sys_util::EventFd;
+use vmm_sys_util::eventfd::EventFd;
 
 const CONFIG_SPACE_TAG_SIZE: usize = 36;
 const CONFIG_SPACE_NUM_QUEUES_SIZE: usize = 4;

--- a/vm-virtio/src/net.rs
+++ b/vm-virtio/src/net.rs
@@ -30,7 +30,7 @@ use crate::VirtioInterrupt;
 use net_util::{MacAddr, Tap, TapError, MAC_ADDR_LEN};
 use virtio_bindings::virtio_net::*;
 use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
-use vmm_sys_util::EventFd;
+use vmm_sys_util::eventfd::EventFd;
 
 /// The maximum buffer size when segmentation offload is enabled. This
 /// includes the 12-byte virtio net header.

--- a/vm-virtio/src/pmem.rs
+++ b/vm-virtio/src/pmem.rs
@@ -27,7 +27,7 @@ use crate::{VirtioInterrupt, VirtioInterruptType};
 use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestMemoryError, GuestMemoryMmap, GuestUsize,
 };
-use vmm_sys_util::EventFd;
+use vmm_sys_util::eventfd::EventFd;
 
 const QUEUE_SIZE: u16 = 256;
 const NUM_QUEUES: usize = 1;

--- a/vm-virtio/src/rng.rs
+++ b/vm-virtio/src/rng.rs
@@ -19,7 +19,7 @@ use super::{
 };
 use crate::{VirtioInterrupt, VirtioInterruptType};
 use vm_memory::{Bytes, GuestMemoryMmap};
-use vmm_sys_util::EventFd;
+use vmm_sys_util::eventfd::EventFd;
 
 const QUEUE_SIZE: u16 = 256;
 const NUM_QUEUES: usize = 1;

--- a/vm-virtio/src/transport/pci_common_config.rs
+++ b/vm-virtio/src/transport/pci_common_config.rs
@@ -257,7 +257,7 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use std::sync::Arc;
     use vm_memory::GuestMemoryMmap;
-    use vmm_sys_util::EventFd;
+    use vmm_sys_util::eventfd::EventFd;
 
     struct DummyDevice(u32);
     const QUEUE_SIZE: u16 = 256;

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -26,7 +26,7 @@ use pci::{
 };
 use vm_allocator::SystemAllocator;
 use vm_memory::{Address, ByteValued, GuestAddress, GuestMemoryMmap, GuestUsize, Le32};
-use vmm_sys_util::{EventFd, Result};
+use vmm_sys_util::{errno::Result, eventfd::EventFd};
 
 use super::VirtioPciCommonConfig;
 use crate::{

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -54,9 +54,9 @@ use vm_memory::{
     GuestMemoryRegion, GuestUsize,
 };
 use vm_virtio::transport::VirtioPciDevice;
+use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::register_signal_handler;
 use vmm_sys_util::terminal::Terminal;
-use vmm_sys_util::EventFd;
 
 const VCPU_RTSIG_OFFSET: i32 = 0;
 const X86_64_IRQ_BASE: u32 = 5;
@@ -142,16 +142,16 @@ pub enum Error {
     EpollError(io::Error),
 
     /// Write to the serial console failed.
-    Serial(vmm_sys_util::Error),
+    Serial(vmm_sys_util::errno::Error),
 
     /// Write to the virtio console failed.
-    Console(vmm_sys_util::Error),
+    Console(vmm_sys_util::errno::Error),
 
     /// Cannot setup terminal in raw mode.
-    SetTerminalRaw(vmm_sys_util::Error),
+    SetTerminalRaw(vmm_sys_util::errno::Error),
 
     /// Cannot setup terminal in canonical mode.
-    SetTerminalCanon(vmm_sys_util::Error),
+    SetTerminalCanon(vmm_sys_util::errno::Error),
 
     /// Cannot create the system allocator
     CreateSystemAllocator,
@@ -228,7 +228,7 @@ pub enum DeviceManagerError {
     RegisterIoevent(io::Error),
 
     /// Cannot create virtio device
-    VirtioDevice(vmm_sys_util::Error),
+    VirtioDevice(vmm_sys_util::errno::Error),
 
     /// Cannot add PCI device
     AddPciDevice(pci::PciRootError),


### PR DESCRIPTION
The structure of the vmm-sys-util crate has changed with lots of code
moving to submodules.

This change adjusts the use of the imported structs to reference the
submodules.

Fixes: #145

Signed-off-by: Rob Bradford <robert.bradford@intel.com>