### PR TITLE
tests: Ensure that the test pipeline fails

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -129,8 +129,11 @@ sudo adduser $USER kvm
 newgrp kvm << EOF
 cargo test --features "integration_tests"
 EOF
+RES=$?
 
 # Tear VFIO test network down
 sudo ip link del vfio-br0
 sudo ip link del vfio-tap0
 sudo ip link del vfio-tap1
+
+exit $RES


### PR DESCRIPTION
With the addition of commands after running the integration tests the
exit code of the tests were lost.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>