### PR TITLE
main: Add logging support controlled by command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,7 @@ dependencies = [
  "credibility 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ssh2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 [dependencies]
 clap = "2.33.0"
+lazy_static = "1.3.0"
+log = { version = "0.4.8", features = ["std"] }
 vmm = { path = "vmm" }
 
 [dev-dependencies]


### PR DESCRIPTION
This makes the log macros (error!, warn!, info!, etc) in the code work.
It currently defaults to showing only error! messages, but by passing an
increasing number of "-v"s on the command line the verbosity can be
increased.

By default log output goes onto stderr but it can also be sent to a
file.

Fixes: #121

Signed-off-by: Rob Bradford <robert.bradford@intel.com>