### PR TITLE
Don't trigger MSI-X interrupt if not enabled

### DIFF
--- a/pci/src/msix.rs
+++ b/pci/src/msix.rs
@@ -53,6 +53,7 @@ pub struct MsixConfig {
     pub pba_entries: Vec<u64>,
     interrupt_cb: Option<Arc<InterruptDelivery>>,
     masked: bool,
+    enabled: bool,
 }
 
 impl MsixConfig {
@@ -70,6 +71,7 @@ impl MsixConfig {
             pba_entries,
             interrupt_cb: None,
             masked: false,
+            enabled: false,
         }
     }
 
@@ -81,10 +83,15 @@ impl MsixConfig {
         self.masked
     }
 
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
     pub fn set_msg_ctl(&mut self, reg: u16) {
         let old_masked = self.masked;
 
         self.masked = ((reg >> FUNCTION_MASK_BIT) & 1u16) == 1u16;
+        self.enabled = ((reg >> MSIX_ENABLE_BIT) & 1u16) == 1u16;
 
         // If the Function Mask bit was set, and has just been cleared, it's
         // important to go through the entire PBA to check if there was any

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -423,6 +423,12 @@ impl PciDevice for VirtioPciDevice {
                     let config = &mut msix_config_clone.lock().unwrap();
                     let entry = &config.table_entries[vector as usize];
 
+                    // If MSI-X interrupts are not enabled for this device, then simply
+                    // ignore the interrupt.
+                    if !config.enabled() {
+                        return Ok(());
+                    }
+
                     // In case the vector control register associated with the entry
                     // has its first bit set, this means the vector is masked and the
                     // device should not inject the interrupt.


### PR DESCRIPTION
In case the MSI-X enabling bit (bit 15) has not been set from the guest, no interrupt should be triggered from the device.

Fixes #156 