### PR TITLE
Add support for "null" serial output

### DIFF
--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -67,7 +67,7 @@ pub struct Serial {
 }
 
 impl Serial {
-    fn new(interrupt: Box<Interrupt>, out: Option<Box<io::Write + Send>>) -> Serial {
+    pub fn new(interrupt: Box<Interrupt>, out: Option<Box<io::Write + Send>>) -> Serial {
         Serial {
             interrupt_enable: 0,
             interrupt_identification: DEFAULT_INTERRUPT_IDENTIFICATION,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -350,6 +350,7 @@ pub enum ConsoleOutputMode {
     Off,
     Tty,
     File,
+    Null,
 }
 
 impl ConsoleOutputMode {
@@ -382,6 +383,11 @@ impl<'a> ConsoleConfig<'a> {
             Ok(Self {
                 mode: ConsoleOutputMode::File,
                 file: Some(Path::new(&param[5..])),
+            })
+        } else if param.starts_with("null") {
+            Ok(Self {
+                mode: ConsoleOutputMode::Null,
+                file: None,
             })
         } else {
             Err(Error::ParseConsoleParam)

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -352,6 +352,15 @@ pub enum ConsoleOutputMode {
     File,
 }
 
+impl ConsoleOutputMode {
+    pub fn input_enabled(&self) -> bool {
+        match self {
+            ConsoleOutputMode::Tty => true,
+            _ => false,
+        }
+    }
+}
+
 pub struct ConsoleConfig<'a> {
     pub file: Option<&'a Path>,
     pub mode: ConsoleOutputMode,

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1489,7 +1489,9 @@ impl<'a> Vm<'a> {
                                 .read_raw(&mut out)
                                 .map_err(Error::Serial)?;
 
-                            if self.devices.serial.is_some() {
+                            if self.devices.serial.is_some()
+                                && self.config.serial.mode.input_enabled()
+                            {
                                 self.devices
                                     .serial
                                     .as_ref()
@@ -1500,7 +1502,9 @@ impl<'a> Vm<'a> {
                                     .map_err(Error::Serial)?;
                             }
 
-                            if self.devices.console.is_some() {
+                            if self.devices.console.is_some()
+                                && self.config.console.mode.input_enabled()
+                            {
                                 self.devices
                                     .console
                                     .as_ref()


### PR DESCRIPTION
Default the serial port to "null" output mode that disregards any output. This ensures that the booted kernel does not suffer from negative performance caused by trying to interact with a disabled serial port.

Fixes: #163 