### PR TITLE
vm-virtio: net: Fix out-of-range slice panic when under load

### DIFF
--- a/vm-virtio/src/net.rs
+++ b/vm-virtio/src/net.rs
@@ -268,7 +268,8 @@ impl NetEpollHandler {
                 );
                 match read_result {
                     Ok(_) => {
-                        read_count += limit;
+                        // Increment by number of bytes actually read
+                        read_count += limit - read_count;
                     }
                     Err(e) => {
                         error!("Failed to read slice: {:?}", e);


### PR DESCRIPTION
The numbr of bytes read was being incorrectly increased by the potential
length of the end of the sliced data rather than the number of bytes
that was in the range. This caused a panic when the the network was
under load by using iperf.

It's important to note that in the Firecracker code base the function
that read_slice() returns the number of bytes read which is used to
increment this counter. The VM memory version however only returns the
empty unit "()".

Fixes: #166

Signed-off-by: Rob Bradford <robert.bradford@intel.com>