### PR TITLE
vhost-user-blk device implementation

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -96,10 +96,17 @@ if [ ! -f "$VIRTIOFSD" ] || [ ! -f "$VUBRIDGE" ] || [ ! -f "$VUBD" ]; then
     popd
 fi
 
-BLKFILE="$WORKLOADS_DIR/blk"
-if [ ! -f "$BLKFILE" ]; then
+BLK_IMAGE="$WORKLOADS_DIR/blk.img"
+MNT_DIR="mount_image"
+if [ ! -f "$BLK_IMAGE" ]; then
    pushd $WORKLOADS_DIR
-   dd if=/dev/zero of=$BLKFILE bs=1M count=64
+   fallocate -l 16M $BLK_IMAGE
+   mkfs.ext4 -j $BLK_IMAGE
+   mkdir $MNT_DIR
+   sudo mount -t ext4 $BLK_IMAGE $MNT_DIR
+   sudo bash -c "echo bar > $MNT_DIR/foo"
+   sudo umount $BLK_IMAGE
+   rm -r $MNT_DIR
    popd
 fi
 

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -79,19 +79,28 @@ fi
 
 VIRTIOFSD="$WORKLOADS_DIR/virtiofsd"
 VUBRIDGE="$WORKLOADS_DIR/vubridge"
+VUBD="$WORKLOADS_DIR/vubd"
 QEMU_DIR="qemu_build"
-if [ ! -f "$VIRTIOFSD" ] || [ ! -f "$VUBRIDGE" ]; then
+if [ ! -f "$VIRTIOFSD" ] || [ ! -f "$VUBRIDGE" ] || [ ! -f "$VUBD" ]; then
     pushd $WORKLOADS_DIR
     git clone --depth 1 "https://github.com/sboeuf/qemu.git" -b "virtio-fs" $QEMU_DIR
     pushd $QEMU_DIR
     ./configure --prefix=$PWD --target-list=x86_64-softmmu
-    make virtiofsd tests/vhost-user-bridge -j `nproc`
+    make virtiofsd tests/vhost-user-bridge vhost-user-blk -j `nproc`
     cp virtiofsd $VIRTIOFSD
     cp tests/vhost-user-bridge $VUBRIDGE
+    cp vhost-user-blk $VUBD
     popd
     rm -rf $QEMU_DIR
     sudo setcap cap_dac_override,cap_sys_admin+epi "virtiofsd"
     popd
+fi
+
+BLKFILE="$WORKLOADS_DIR/blk"
+if [ ! -f "$BLKFILE" ]; then
+   pushd $WORKLOADS_DIR
+   dd if=/dev/zero of=$BLKFILE bs=1M count=64
+   popd
 fi
 
 SHARED_DIR="$WORKLOADS_DIR/shared_dir"

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,18 @@ fn main() {
                 .min_values(1),
         )
         .arg(
+            Arg::with_name("vhost-user-blk")
+                .long("vhost-user-blk")
+                .help(
+                    "Vhost user Block parameters \"sock=<socket_path>,\
+                     num_queues=<number_of_queues>,\
+                     queue_size=<size_of_each_queue>, \
+                     wce=<true|false, default true>\"",
+                )
+                .takes_value(true)
+                .min_values(1),
+        )
+        .arg(
             Arg::with_name("v")
                 .short("v")
                 .multiple(true)
@@ -209,6 +221,9 @@ fn main() {
     let devices: Option<Vec<&str>> = cmd_arguments.values_of("device").map(|x| x.collect());
     let vhost_user_net: Option<Vec<&str>> = cmd_arguments
         .values_of("vhost-user-net")
+        .map(|x| x.collect());
+    let vhost_user_blk: Option<Vec<&str>> = cmd_arguments
+        .values_of("vhost-user-blk")
         .map(|x| x.collect());
     let vsock: Option<Vec<&str>> = cmd_arguments.values_of("vsock").map(|x| x.collect());
 
@@ -250,6 +265,7 @@ fn main() {
         console,
         devices,
         vhost_user_net,
+        vhost_user_blk,
         vsock,
     }) {
         Ok(config) => config,

--- a/vhost_rs/src/vhost_user/connection.rs
+++ b/vhost_rs/src/vhost_user/connection.rs
@@ -197,45 +197,6 @@ impl<R: Req> Endpoint<R> {
         Ok(())
     }
 
-    /// Send a message with header, body and config info. Optional file descriptors may be attached to
-    /// the message.
-    ///
-    /// # Return:
-    /// * - number of bytes sent on success
-    /// * - SocketRetry: temporary error caused by signals or short of resources.
-    /// * - SocketBroken: the underline socket is broken.
-    /// * - SocketError: other socket related errors.
-    /// * - PartialMessage: received a partial message.
-    pub fn send_config_message(
-        &mut self,
-        hdr: &VhostUserMsgHeader<R>,
-        user_config: &VhostUserConfig,
-        buf: &mut [u8],
-        fds: Option<&[RawFd]>,
-    ) -> Result<()> {
-        // Safe because there can't be other mutable referance to hdr and body.
-        let iovs = unsafe {
-            [
-                slice::from_raw_parts(
-                    hdr as *const VhostUserMsgHeader<R> as *const u8,
-                    mem::size_of::<VhostUserMsgHeader<R>>(),
-                ),
-                slice::from_raw_parts(
-                    user_config as *const VhostUserConfig as *const u8,
-                    mem::size_of::<VhostUserConfig>(),
-                ),
-                slice::from_raw_parts(buf.as_ptr() as *const u8, buf.len()),
-            ]
-        };
-        let bytes = self.send_iovec(&iovs[..], fds)?;
-        let total =
-            mem::size_of::<VhostUserMsgHeader<R>>() + mem::size_of::<VhostUserConfig>() + buf.len();
-        if bytes != total {
-            return Err(Error::PartialMessage);
-        }
-        Ok(())
-    }
-
     /// Send a message with header, body and payload. Optional file descriptors
     /// may also be attached to the message.
     ///

--- a/vhost_rs/src/vhost_user/master.rs
+++ b/vhost_rs/src/vhost_user/master.rs
@@ -360,7 +360,7 @@ impl VhostUserMaster for Master {
         // "Master payload: virtio device config space"
         // But what content should the payload contains for a get_config() request?
         // So current implementation doesn't conform to the spec.
-        let hdr = node.send_request_with_config_body(MasterReq::GET_CONFIG, &body, None)?;
+        let hdr = node.send_request_with_body(MasterReq::GET_CONFIG, &body, None)?;
         let (reply, buf, rfds) = node.recv_reply_with_payload::<VhostUserConfig>(&hdr)?;
         if rfds.is_some() {
             Endpoint::<MasterReq>::close_rfds(rfds);
@@ -480,27 +480,6 @@ impl MasterInternal {
         Ok(hdr)
     }
 
-    fn send_request_with_config_body(
-        &mut self,
-        code: MasterReq,
-        user_config: &VhostUserConfig,
-        fds: Option<&[RawFd]>,
-    ) -> VhostUserResult<VhostUserMsgHeader<MasterReq>> {
-        if mem::size_of::<VhostUserConfig>() + user_config.size as usize > MAX_MSG_SIZE {
-            return Err(VhostUserError::InvalidParam);
-        }
-        self.check_state()?;
-
-        let hdr = Self::new_request_header(
-            code,
-            mem::size_of::<VhostUserConfig>() as u32 + user_config.size,
-        );
-        let mut buf = vec![0; user_config.size as usize];
-        self.main_sock
-            .send_config_message(&hdr, user_config, &mut buf, fds)?;
-        Ok(hdr)
-    }
-
     fn send_request_with_payload<T: Sized, P: Sized>(
         &mut self,
         code: MasterReq,
@@ -576,7 +555,7 @@ impl MasterInternal {
         if !reply.is_reply_for(hdr)
             || reply.get_size() as usize != mem::size_of::<T>() + bytes
             || rfds.is_some()
-            || !body.is_valid()
+            || body.is_valid()
         {
             Endpoint::<MasterReq>::close_rfds(rfds);
             return Err(VhostUserError::InvalidMessage);

--- a/vhost_rs/src/vhost_user/message.rs
+++ b/vhost_rs/src/vhost_user/message.rs
@@ -346,6 +346,8 @@ bitflags! {
         const SLAVE_SEND_FD = 0x0000_0400;
         /// Allow the slave to register a host notifier.
         const HOST_NOTIFIER = 0x0000_0800;
+        /// Support inflight shmfd.
+        const INFLIGHT_SHMFD = 0x0000_1000;
     }
 }
 

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -130,6 +130,8 @@ pub enum ActivateError {
     VhostUserSetup(vhost_user::Error),
     /// Failed to setup vhost-user daemon.
     VhostUserNetSetup(vhost_user::Error),
+    /// Failed to setup vhost-user daemon.
+    VhostUserBlkSetup(vhost_user::Error),
 }
 
 pub type ActivateResult = std::result::Result<(), ActivateError>;

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -132,6 +132,8 @@ pub enum ActivateError {
     VhostUserNetSetup(vhost_user::Error),
     /// Failed to setup vhost-user daemon.
     VhostUserBlkSetup(vhost_user::Error),
+    /// Failed to reset vhost-user daemon.
+    VhostUserReset(vhost_user::Error),
 }
 
 pub type ActivateResult = std::result::Result<(), ActivateError>;

--- a/vm-virtio/src/vhost_user/blk.rs
+++ b/vm-virtio/src/vhost_user/blk.rs
@@ -1,0 +1,226 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use libc;
+use libc::EFD_NONBLOCK;
+use std::cmp;
+use std::io::Write;
+use std::ptr::null;
+use std::sync::{Arc, RwLock};
+use std::thread;
+use std::vec::Vec;
+
+use crate::VirtioInterrupt;
+
+use vm_memory::GuestMemoryMmap;
+use vmm_sys_util::eventfd::EventFd;
+
+use super::super::{ActivateError, ActivateResult, Queue, VirtioDevice, VirtioDeviceType};
+use super::handler::*;
+use super::vu_common_ctrl::*;
+use super::{Error, Result};
+use std::mem;
+use vhost_rs::vhost_user::message::VhostUserConfigFlags;
+use vhost_rs::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
+use vhost_rs::vhost_user::{Master, VhostUserMaster, VhostUserMasterReqHandler};
+use vhost_rs::VhostBackend;
+use virtio_bindings::bindings::virtio_blk::*;
+
+macro_rules! offset_of {
+    ($ty:ty, $field:ident) => {
+        unsafe { &(*(null() as *const $ty)).$field as *const _ as usize }
+    };
+}
+
+struct SlaveReqHandler {}
+impl VhostUserMasterReqHandler for SlaveReqHandler {}
+
+pub struct Blk {
+    vhost_user_blk: Master,
+    kill_evt: EventFd,
+    avail_features: u64,
+    acked_features: u64,
+    config_space: Vec<u8>,
+    queue_sizes: Vec<u16>,
+}
+
+impl<'a> Blk {
+    /// Create a new vhost-user-blk device
+    pub fn new(wce: bool, vu_cfg: VhostUserConfig<'a>) -> Result<Blk> {
+        let mut vhost_user_blk = Master::connect(vu_cfg.sock, vu_cfg.num_queues as u64)
+            .map_err(Error::VhostUserCreateMaster)?;
+
+        let kill_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::CreateKillEventFd)?;
+
+        // Filling device and vring features VMM supports.
+        let mut avail_features = 1 << VIRTIO_BLK_F_SEG_MAX
+            | 1 << VIRTIO_BLK_F_RO
+            | 1 << VIRTIO_BLK_F_BLK_SIZE
+            | 1 << VIRTIO_BLK_F_FLUSH
+            | 1 << VIRTIO_BLK_F_TOPOLOGY
+            | 1 << VIRTIO_F_VERSION_1
+            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
+
+        // Set vhost-user owner.
+        vhost_user_blk
+            .set_owner()
+            .map_err(Error::VhostUserSetOwner)?;
+
+        // Get features from backend, do negotiation to get a feature collection which
+        // both VMM and backend support.
+        let backend_features = vhost_user_blk
+            .get_features()
+            .map_err(Error::VhostUserGetFeatures)?;
+        avail_features &= backend_features;
+        // Set features back is required by the vhost crate mechanism, since the
+        // later vhost call will check if features is filled in master before execution.
+        vhost_user_blk
+            .set_features(avail_features)
+            .map_err(Error::VhostUserSetFeatures)?;
+
+        // Identify if protocol features are supported by the slave.
+        let mut acked_features = 0;
+        if avail_features & VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits() != 0 {
+            acked_features |= VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits();
+
+            let mut protocol_features = vhost_user_blk
+                .get_protocol_features()
+                .map_err(Error::VhostUserGetProtocolFeatures)?;
+            protocol_features |= VhostUserProtocolFeatures::MQ;
+            protocol_features &= !VhostUserProtocolFeatures::INFLIGHT_SHMFD;
+            vhost_user_blk
+                .set_protocol_features(protocol_features)
+                .map_err(Error::VhostUserSetProtocolFeatures)?;
+        }
+
+        let config_len = mem::size_of::<virtio_blk_config>();
+        let mut config_space: Vec<u8> = vec![0u8; config_len as usize];
+
+        let queue_num_offset = offset_of!(virtio_blk_config, num_queues);
+        // only setnum_queues value.
+        config_space[queue_num_offset] = vu_cfg.num_queues as u8;
+
+        Ok(Blk {
+            vhost_user_blk,
+            kill_evt,
+            avail_features,
+            acked_features,
+            config_space,
+            queue_sizes: vec![vu_cfg.queue_size; vu_cfg.num_queues],
+        })
+    }
+}
+
+impl Drop for Blk {
+    fn drop(&mut self) {
+        if let Err(_e) = self.kill_evt.write(1) {
+            error!("failed to kill vhost-user-blk with error {}", _e);
+        }
+    }
+}
+
+impl VirtioDevice for Blk {
+    fn device_type(&self) -> u32 {
+        VirtioDeviceType::TYPE_BLOCK as u32
+    }
+
+    fn queue_max_sizes(&self) -> &[u16] {
+        &self.queue_sizes
+    }
+
+    fn features(&self, page: u32) -> u32 {
+        match page {
+            0 => self.avail_features as u32,
+            1 => (self.avail_features >> 32) as u32,
+            _ => {
+                warn!("Received request for unknown features page: {}", page);
+                0u32
+            }
+        }
+    }
+
+    fn ack_features(&mut self, page: u32, value: u32) {
+        let mut v = match page {
+            0 => u64::from(value),
+            1 => u64::from(value) << 32,
+            _ => {
+                warn!("Cannot acknowledge unknown features page: {}", page);
+                0u64
+            }
+        };
+
+        // Check if the guest is ACK'ing a feature that we didn't claim to have.
+        let unrequested_features = v & !self.avail_features;
+        if unrequested_features != 0 {
+            warn!("Received acknowledge request for unknown feature: {:x}", v);
+            // Don't count these features as acked.
+            v &= !unrequested_features;
+        }
+        self.acked_features |= v;
+    }
+
+    fn read_config(&self, offset: u64, mut data: &mut [u8]) {
+        let config_len = self.config_space.len() as u64;
+        if offset >= config_len {
+            error!("Failed to read config space");
+            return;
+        }
+        if let Some(end) = offset.checked_add(data.len() as u64) {
+            // This write can't fail, offset and end are checked against config_len.
+            data.write_all(&self.config_space[offset as usize..cmp::min(end, config_len) as usize])
+                .unwrap();
+        }
+    }
+
+    fn write_config(&mut self, offset: u64, data: &[u8]) {
+        let data_len = data.len() as u64;
+        let config_len = self.config_space.len() as u64;
+        if offset + data_len > config_len {
+            error!("Failed to write config space");
+            return;
+        }
+        let (_, right) = self.config_space.split_at_mut(offset as usize);
+        right.copy_from_slice(&data[..]);
+    }
+
+    fn activate(
+        &mut self,
+        mem: Arc<RwLock<GuestMemoryMmap>>,
+        interrupt_cb: Arc<VirtioInterrupt>,
+        queues: Vec<Queue>,
+        queue_evts: Vec<EventFd>,
+    ) -> ActivateResult {
+        let handler_kill_evt = self
+            .kill_evt
+            .try_clone()
+            .map_err(|_| ActivateError::CloneKillEventFd)?;
+
+        let vu_interrupt_list = setup_vhost_user(
+            &mut self.vhost_user_blk,
+            &mem.read().unwrap(),
+            queues,
+            queue_evts,
+            self.acked_features,
+        )
+        .map_err(ActivateError::VhostUserBlkSetup)?;
+
+        let mut handler = VhostUserEpollHandler::<SlaveReqHandler>::new(VhostUserEpollConfig {
+            interrupt_cb,
+            kill_evt: handler_kill_evt,
+            vu_interrupt_list,
+            slave_req_handler: None,
+        });
+
+        let handler_result = thread::Builder::new()
+            .name("vhost_user_blk".to_string())
+            .spawn(move || {
+                if let Err(e) = handler.run() {
+                    error!("net worker thread exited with error {:?}!", e);
+                }
+            });
+        if let Err(e) = handler_result {
+            error!("vhost-user blk thread create failed with error {:?}", e);
+        }
+        Ok(())
+    }
+}

--- a/vm-virtio/src/vhost_user/mod.rs
+++ b/vm-virtio/src/vhost_user/mod.rs
@@ -12,11 +12,13 @@ use std::io;
 use vhost_rs::Error as VhostError;
 use vm_memory::Error as MmapError;
 
+pub mod blk;
 pub mod fs;
 mod handler;
 pub mod net;
 pub mod vu_common_ctrl;
 
+pub use self::blk::Blk;
 pub use self::fs::*;
 pub use self::net::Net;
 pub use self::vu_common_ctrl::VhostUserConfig;
@@ -91,5 +93,7 @@ pub enum Error {
     VhostUserSetSlaveRequestFd(vhost_rs::Error),
     /// Invalid used address.
     UsedAddress,
+    /// Invalid features provided from vhost-user backend
+    InvalidFeatures,
 }
 type Result<T> = std::result::Result<T, Error>;

--- a/vm-virtio/src/vhost_user/mod.rs
+++ b/vm-virtio/src/vhost_user/mod.rs
@@ -61,6 +61,8 @@ pub enum Error {
     VhostUserProtocolNotSupport,
     /// Set owner failed.
     VhostUserSetOwner(VhostError),
+    /// Reset owner failed.
+    VhostUserResetOwner(VhostError),
     /// Set features failed.
     VhostUserSetFeatures(VhostError),
     /// Set protocol features failed.

--- a/vm-virtio/src/vhost_user/vu_common_ctrl.rs
+++ b/vm-virtio/src/vhost_user/vu_common_ctrl.rs
@@ -106,3 +106,18 @@ pub fn setup_vhost_user(
 
     setup_vhost_user_vring(vu, mem, queues, queue_evts)
 }
+
+pub fn reset_vhost_user(vu: &mut Master, num_queues: usize) -> Result<()> {
+    for queue_index in 0..num_queues {
+        // Disable the vrings.
+        vu.set_vring_enable(queue_index, false)
+            .map_err(Error::VhostUserSetVringEnable)?;
+
+        // Stop the vrings.
+        vu.get_vring_base(queue_index)
+            .map_err(Error::VhostUserSetFeatures)?;
+    }
+
+    // Reset the owner.
+    vu.reset_owner().map_err(Error::VhostUserResetOwner)
+}

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -63,12 +63,12 @@ pub enum Error<'a> {
     ParseTTYParam,
     /// Failed parsing vhost-user-net mac parameter.
     ParseVuNetMacParam(&'a str),
-    /// Failed parsing vhost-user-net sock parameter.
-    ParseVuNetSockParam,
-    /// Failed parsing vhost-user-net queue number parameter.
-    ParseVuNetNumQueuesParam(std::num::ParseIntError),
-    /// Failed parsing vhost-user-net queue size parameter.
-    ParseVuNetQueueSizeParam(std::num::ParseIntError),
+    /// Failed parsing vhost-user sock parameter.
+    ParseVuSockParam,
+    /// Failed parsing vhost-user queue number parameter.
+    ParseVuNumQueuesParam(std::num::ParseIntError),
+    /// Failed parsing vhost-user queue size parameter.
+    ParseVuQueueSizeParam(std::num::ParseIntError),
     /// Failed parsing vhost-user-net server parameter.
     ParseVuNetServerParam(std::num::ParseIntError),
     /// Failed parsing vsock context ID parameter.
@@ -495,17 +495,17 @@ impl<'a> VhostUserNetConfig<'a> {
             mac = MacAddr::parse_str(mac_str).map_err(Error::ParseVuNetMacParam)?;
         }
         if sock.is_empty() {
-            return Err(Error::ParseVuNetSockParam);
+            return Err(Error::ParseVuSockParam);
         }
         if !num_queues_str.is_empty() {
             num_queues = num_queues_str
                 .parse()
-                .map_err(Error::ParseVuNetNumQueuesParam)?;
+                .map_err(Error::ParseVuNumQueuesParam)?;
         }
         if !queue_size_str.is_empty() {
             queue_size = queue_size_str
                 .parse()
-                .map_err(Error::ParseVuNetQueueSizeParam)?;
+                .map_err(Error::ParseVuQueueSizeParam)?;
         }
 
         let vu_cfg = VhostUserConfig {


### PR DESCRIPTION
@sameo @rbradford @sboeuf @chao-p @bjzhjing 

for #130 

Please help review this PR, which is only work in **SINGLE** queue, and multi-queue is still on working. 

Below is command for vhost-user-blk 
./target/debug/cloud-hypervisor \
        --cpus 2 \
        --memory size=1024M,file=/dev/hugepages \
        --kernel /home/chen/project/linux-stable/arch/x86/boot/compressed/vmlinux.bin \
        --cmdline "console=ttyS0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda3" \
        --disk /home/chen/project/clear-18080-kvm.img  \
        --console off \
        --serial tty \
        --vhost-user-blk "sock=/var/tmp/vhost.1,num_queues=1,queue_size=128,wce=true"  \
        --rng

for issue #232 , i also did one patch to fix it , please @sboeuf review and try it, thanks.
https://github.com/intel/cloud-hypervisor/pull/173/commits/009394c8e85200430e37fa10e3f9c06efa51c355


