### PR TITLE
arch: x86_64: Update linux-loader crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 [[package]]
 name = "linux-loader"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/linux-loader#891ea4f0af62b2f80f5a3ddbbb6be588b19a78da"
+source = "git+https://github.com/rust-vmm/linux-loader#b2700818add982aa361842a0b8da776b3d1b5cb3"
 dependencies = [
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
 ]


### PR DESCRIPTION
The linux-loader crate has been updated with a regnerated bootparams.rs
which has changed the API slightly. Update to the latest linux-loader
and adapt the code to reflect the changes:

* e820_map is renamed to e820_table (and all similar variables updated)
* e820entry is renamed to boot_e820_entry
* The E820 type constants are not no longer included

Signed-off-by: Rob Bradford <robert.bradford@intel.com>