### PR TITLE
linters: Fix clippy issues

### DIFF
--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![allow(
     clippy::unreadable_literal,
-    clippy::const_static_lifetime,
+    clippy::redundant_static_lifetimes,
     clippy::cast_lossless,
     clippy::transmute_ptr_to_ptr,
     clippy::cast_ptr_alignment

--- a/arch_gen/src/x86/mod.rs
+++ b/arch_gen/src/x86/mod.rs
@@ -10,7 +10,7 @@
 #[allow(non_snake_case)]
 #[allow(
     clippy::unreadable_literal,
-    clippy::const_static_lifetime,
+    clippy::redundant_static_lifetimes,
     clippy::trivially_copy_pass_by_ref,
     clippy::useless_transmute,
     clippy::should_implement_trait,
@@ -19,8 +19,8 @@
 pub mod bootparam;
 #[allow(non_camel_case_types)]
 #[allow(non_upper_case_globals)]
-#[allow(clippy::unreadable_literal, clippy::const_static_lifetime)]
+#[allow(clippy::unreadable_literal, clippy::redundant_static_lifetimes)]
 pub mod mpspec;
 #[allow(non_upper_case_globals)]
-#[allow(clippy::unreadable_literal, clippy::const_static_lifetime)]
+#[allow(clippy::unreadable_literal, clippy::redundant_static_lifetimes)]
 pub mod msr_index;

--- a/devices/src/bus.rs
+++ b/devices/src/bus.rs
@@ -77,7 +77,7 @@ impl PartialOrd for BusRange {
 /// only restriction is that no two devices can overlap in this address space.
 #[derive(Clone, Default)]
 pub struct Bus {
-    devices: BTreeMap<BusRange, Arc<Mutex<BusDevice>>>,
+    devices: BTreeMap<BusRange, Arc<Mutex<dyn BusDevice>>>,
 }
 
 impl Bus {
@@ -88,7 +88,7 @@ impl Bus {
         }
     }
 
-    fn first_before(&self, addr: u64) -> Option<(BusRange, &Mutex<BusDevice>)> {
+    fn first_before(&self, addr: u64) -> Option<(BusRange, &Mutex<dyn BusDevice>)> {
         let (range, dev) = self
             .devices
             .range(..=BusRange { base: addr, len: 1 })
@@ -97,7 +97,7 @@ impl Bus {
         Some((*range, dev))
     }
 
-    pub fn resolve(&self, addr: u64) -> Option<(u64, u64, &Mutex<BusDevice>)> {
+    pub fn resolve(&self, addr: u64) -> Option<(u64, u64, &Mutex<dyn BusDevice>)> {
         if let Some((range, dev)) = self.first_before(addr) {
             let offset = addr - range.base;
             if offset < range.len {
@@ -108,7 +108,7 @@ impl Bus {
     }
 
     /// Puts the given device at the given address space.
-    pub fn insert(&mut self, device: Arc<Mutex<BusDevice>>, base: u64, len: u64) -> Result<()> {
+    pub fn insert(&mut self, device: Arc<Mutex<dyn BusDevice>>, base: u64, len: u64) -> Result<()> {
         if len == 0 {
             return Err(Error::Overlap);
         }

--- a/devices/src/ioapic.rs
+++ b/devices/src/ioapic.rs
@@ -188,7 +188,6 @@ impl BusDevice for Ioapic {
             IOWIN_OFF => self.ioapic_write(value),
             _ => {
                 error!("IOAPIC: failed writing at offset {}", offset);
-                return;
             }
         }
     }

--- a/devices/src/legacy/serial.rs
+++ b/devices/src/legacy/serial.rs
@@ -55,7 +55,7 @@ const DEFAULT_BAUD_DIVISOR: u16 = 12; // 9600 bps
 pub struct Serial {
     interrupt_enable: u8,
     interrupt_identification: u8,
-    interrupt: Box<Interrupt>,
+    interrupt: Box<dyn Interrupt>,
     line_control: u8,
     line_status: u8,
     modem_control: u8,
@@ -63,11 +63,11 @@ pub struct Serial {
     scratch: u8,
     baud_divisor: u16,
     in_buffer: VecDeque<u8>,
-    out: Option<Box<io::Write + Send>>,
+    out: Option<Box<dyn io::Write + Send>>,
 }
 
 impl Serial {
-    pub fn new(interrupt: Box<Interrupt>, out: Option<Box<io::Write + Send>>) -> Serial {
+    pub fn new(interrupt: Box<dyn Interrupt>, out: Option<Box<dyn io::Write + Send>>) -> Serial {
         Serial {
             interrupt_enable: 0,
             interrupt_identification: DEFAULT_INTERRUPT_IDENTIFICATION,
@@ -84,12 +84,12 @@ impl Serial {
     }
 
     /// Constructs a Serial port ready for output.
-    pub fn new_out(interrupt: Box<Interrupt>, out: Box<io::Write + Send>) -> Serial {
+    pub fn new_out(interrupt: Box<dyn Interrupt>, out: Box<dyn io::Write + Send>) -> Serial {
         Self::new(interrupt, Some(out))
     }
 
     /// Constructs a Serial port with no connected output.
-    pub fn new_sink(interrupt: Box<Interrupt>) -> Serial {
+    pub fn new_sink(interrupt: Box<dyn Interrupt>) -> Serial {
         Self::new(interrupt, None)
     }
 

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -192,8 +192,8 @@ impl BusDevice for PciConfigIo {
     fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         // `offset` is relative to 0xcf8
         let value = match offset {
-            0...3 => self.config_address,
-            4...7 => self.config_space_read(),
+            0..=3 => self.config_address,
+            4..=7 => self.config_space_read(),
             _ => 0xffff_ffff,
         };
 
@@ -214,8 +214,8 @@ impl BusDevice for PciConfigIo {
     fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
         // `offset` is relative to 0xcf8
         match offset {
-            o @ 0...3 => self.set_config_address(o, data),
-            o @ 4...7 => self.config_space_write(o - 4, data),
+            o @ 0..=3 => self.set_config_address(o, data),
+            o @ 4..=7 => self.config_space_write(o - 4, data),
             _ => (),
         };
     }

--- a/pci/src/device.rs
+++ b/pci/src/device.rs
@@ -18,7 +18,7 @@ pub struct InterruptParameters<'a> {
 }
 
 pub type InterruptDelivery =
-    Box<Fn(InterruptParameters) -> std::result::Result<(), std::io::Error> + Send + Sync>;
+    Box<dyn Fn(InterruptParameters) -> std::result::Result<(), std::io::Error> + Send + Sync>;
 
 #[derive(Debug)]
 pub enum Error {

--- a/qcow/src/qcow.rs
+++ b/qcow/src/qcow.rs
@@ -1087,10 +1087,10 @@ impl QcowFile {
 
         let max_valid_cluster_offset = self.refcounts.max_valid_cluster_offset();
         if let Some(new_cluster) = self.raw_file.add_cluster_end(max_valid_cluster_offset)? {
-            return Ok(new_cluster);
+            Ok(new_cluster)
         } else {
             error!("No free clusters in get_new_cluster()");
-            return Err(std::io::Error::from_raw_os_error(ENOSPC));
+            Err(std::io::Error::from_raw_os_error(ENOSPC))
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::sync::Mutex;
 use vmm::config;
 
 struct Logger {
-    output: Mutex<Box<std::io::Write + Send>>,
+    output: Mutex<Box<dyn std::io::Write + Send>>,
     start: std::time::Instant,
 }
 
@@ -195,7 +195,7 @@ fn main() {
         _ => LevelFilter::Trace,
     };
 
-    let log_file: Box<std::io::Write + Send> =
+    let log_file: Box<dyn std::io::Write + Send> =
         if let Some(file) = cmd_arguments.value_of("log-file") {
             Box::new(
                 std::fs::File::create(std::path::Path::new(file)).expect("Error creating log file"),
@@ -285,7 +285,7 @@ mod tests {
 
     struct Guest<'a> {
         tmp_dir: TempDir,
-        disk_config: &'a DiskConfig,
+        disk_config: &'a dyn DiskConfig,
         fw_path: String,
         network: GuestNetworkConfig,
     }
@@ -549,7 +549,7 @@ mod tests {
     }
 
     impl<'a> Guest<'a> {
-        fn new_from_ip_range(disk_config: &'a mut DiskConfig, class: &str, id: u8) -> Self {
+        fn new_from_ip_range(disk_config: &'a mut dyn DiskConfig, class: &str, id: u8) -> Self {
             let tmp_dir = TempDir::new("ch").unwrap();
 
             let mut workload_path = dirs::home_dir().unwrap();
@@ -576,7 +576,7 @@ mod tests {
             }
         }
 
-        fn new(disk_config: &'a mut DiskConfig) -> Self {
+        fn new(disk_config: &'a mut dyn DiskConfig) -> Self {
             let mut guard = NEXT_VM_ID.lock().unwrap();
             let id = *guard;
             *guard = id + 1;
@@ -767,8 +767,8 @@ mod tests {
             let mut bionic = BionicDiskConfig::new();
 
             vec![
-                &mut clear as &mut DiskConfig,
-                &mut bionic as &mut DiskConfig,
+                &mut clear as &mut dyn DiskConfig,
+                &mut bionic as &mut dyn DiskConfig,
             ]
             .iter_mut()
             .for_each(|disk_config| {

--- a/vfio/src/vfio_pci.rs
+++ b/vfio/src/vfio_pci.rs
@@ -388,11 +388,9 @@ impl VfioPciDevice {
                 ..Default::default()
             };
 
-            unsafe {
-                entry.u.msi.address_lo = route.msi_vector.msg_addr_lo;
-                entry.u.msi.address_hi = route.msi_vector.msg_addr_hi;
-                entry.u.msi.data = route.msi_vector.msg_data;
-            };
+            entry.u.msi.address_lo = route.msi_vector.msg_addr_lo;
+            entry.u.msi.address_hi = route.msi_vector.msg_addr_hi;
+            entry.u.msi.data = route.msi_vector.msg_data;
 
             entry_vec.push(entry);
         }

--- a/vm-virtio/src/console.rs
+++ b/vm-virtio/src/console.rs
@@ -57,7 +57,7 @@ struct ConsoleEpollHandler {
     mem: GuestMemoryMmap,
     interrupt_cb: Arc<VirtioInterrupt>,
     in_buffer: Arc<Mutex<VecDeque<u8>>>,
-    out: Box<io::Write + Send>,
+    out: Box<dyn io::Write + Send>,
     input_queue_evt: EventFd,
     output_queue_evt: EventFd,
     input_evt: EventFd,
@@ -321,13 +321,13 @@ pub struct Console {
     acked_features: u64,
     config: Arc<Mutex<VirtioConsoleConfig>>,
     input: Arc<ConsoleInput>,
-    out: Option<Box<io::Write + Send>>,
+    out: Option<Box<dyn io::Write + Send>>,
 }
 
 impl Console {
     /// Create a new virtio console device that gets random data from /dev/urandom.
     pub fn new(
-        out: Option<Box<io::Write + Send>>,
+        out: Option<Box<dyn io::Write + Send>>,
         cols: u16,
         rows: u16,
     ) -> io::Result<(Console, Arc<ConsoleInput>)> {

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -17,7 +17,7 @@ pub enum VirtioInterruptType {
 }
 
 pub type VirtioInterrupt = Box<
-    Fn(&VirtioInterruptType, Option<&Queue>) -> std::result::Result<(), std::io::Error>
+    dyn Fn(&VirtioInterruptType, Option<&Queue>) -> std::result::Result<(), std::io::Error>
         + Send
         + Sync,
 >;

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -223,7 +223,7 @@ pub struct VirtioPciDevice {
     msix_num: u16,
 
     // Virtio device reference and status
-    device: Box<VirtioDevice>,
+    device: Box<dyn VirtioDevice>,
     device_activated: bool,
 
     // PCI interrupts.
@@ -243,7 +243,11 @@ pub struct VirtioPciDevice {
 
 impl VirtioPciDevice {
     /// Constructs a new PCI transport for the given virtio device.
-    pub fn new(memory: GuestMemoryMmap, device: Box<VirtioDevice>, msix_num: u16) -> Result<Self> {
+    pub fn new(
+        memory: GuestMemoryMmap,
+        device: Box<dyn VirtioDevice>,
+        msix_num: u16,
+    ) -> Result<Self> {
         let mut queue_evts = Vec::new();
         for _ in device.queue_max_sizes().iter() {
             queue_evts.push(EventFd::new(EFD_NONBLOCK)?)
@@ -267,15 +271,15 @@ impl VirtioPciDevice {
         let (class, subclass) = match VirtioDeviceType::from(device.device_type()) {
             VirtioDeviceType::TYPE_NET => (
                 PciClassCode::NetworkController,
-                &PciNetworkControllerSubclass::EthernetController as &PciSubclass,
+                &PciNetworkControllerSubclass::EthernetController as &dyn PciSubclass,
             ),
             VirtioDeviceType::TYPE_BLOCK => (
                 PciClassCode::MassStorage,
-                &PciMassStorageSubclass::MassStorage as &PciSubclass,
+                &PciMassStorageSubclass::MassStorage as &dyn PciSubclass,
             ),
             _ => (
                 PciClassCode::Other,
-                &PciVirtioSubclass::NonTransitionalBase as &PciSubclass,
+                &PciVirtioSubclass::NonTransitionalBase as &dyn PciSubclass,
             ),
         };
 


### PR DESCRIPTION
Latest clippy version complains about our existing code for the
following reasons:

- trait objects without an explicit `dyn` are deprecated
- `...` range patterns are deprecated
- lint `clippy::const_static_lifetime` has been renamed to
  `clippy::redundant_static_lifetimes`
- unnecessary `unsafe` block
- unneeded return statement

All these issues have been fixed through this patch, and rustfmt has
been run to cleanup potential formatting errors due to those changes.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>