### PR TITLE
tests: Retrieve the bionic image from the Azure storage bucket

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -41,7 +41,7 @@ if [ ! -f "$CLEAR_OS_RAW_IMAGE" ]; then
 fi
 
 BIONIC_OS_IMAGE_NAME="bionic-server-cloudimg-amd64.img"
-BIONIC_OS_IMAGE_URL="https://cloud-images.ubuntu.com/bionic/current/$BIONIC_OS_IMAGE_NAME"
+BIONIC_OS_IMAGE_URL="https://cloudhypervisorstorage.blob.core.windows.net/images/$BIONIC_OS_IMAGE_NAME"
 BIONIC_OS_IMAGE="$WORKLOADS_DIR/$BIONIC_OS_IMAGE_NAME"
 if [ ! -f "$BIONIC_OS_IMAGE" ]; then
     pushd $WORKLOADS_DIR


### PR DESCRIPTION
Avoid network delays by grabbing the bionic image from the local storage
bucket.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>