### PR TITLE
tests: Make panics generate a backtrace

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -132,6 +132,7 @@ sudo setcap cap_net_admin+ep /usr/bin/qemu-system-x86_64
 
 sudo adduser $USER kvm
 newgrp kvm << EOF
+export RUST_BACKTRACE=1
 cargo test --features "integration_tests"
 EOF
 RES=$?

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -17,6 +17,7 @@ sudo adduser $USER kvm
 newgrp kvm << EOF || exit 1
 for f in \$(find . -name Cargo.toml -printf '%h\n' | sort -u); do
   pushd \$f > /dev/null;
+  export RUST_BACKTRACE=1
   cargo test || exit 1;
   popd > /dev/null;
 done


### PR DESCRIPTION
This will help pinpoint issues when debugging test failures.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>