### PR TITLE
ci: Fix virtio-fs tests

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -89,7 +89,7 @@ if [ ! -f "$VIRTIOFSD" ]; then
     cp virtiofsd $VIRTIOFSD
     popd
     rm -rf $QEMU_DIR
-    sudo setcap cap_sys_admin+epi "virtiofsd"
+    sudo setcap cap_dac_override,cap_sys_admin+epi "virtiofsd"
     popd
 fi
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -545,6 +545,8 @@ mod tests {
             .spawn()
             .unwrap();
 
+        thread::sleep(std::time::Duration::new(10, 0));
+
         (child, virtiofsd_socket_path)
     }
 
@@ -1246,6 +1248,9 @@ mod tests {
             );
 
             guest.ssh_command("sudo reboot")?;
+            thread::sleep(std::time::Duration::new(10, 0));
+            let _ = child.kill();
+            let _ = daemon_child.kill();
             let _ = child.wait();
             let _ = daemon_child.wait();
             Ok(())
@@ -1323,6 +1328,8 @@ mod tests {
             );
 
             guest.ssh_command("sudo reboot")?;
+            thread::sleep(std::time::Duration::new(10, 0));
+            let _ = child.kill();
             let _ = child.wait();
 
             Ok(())
@@ -1366,6 +1373,8 @@ mod tests {
             aver!(tb, guest.get_total_memory().unwrap_or_default() > 496_000);
 
             guest.ssh_command("sudo reboot")?;
+            thread::sleep(std::time::Duration::new(10, 0));
+            let _ = child.kill();
             let _ = child.wait();
 
             Ok(())


### PR DESCRIPTION
The virtiofsd daemon takes a bit of time creating and listening on the
socket. By adding 10s timeout, we make sure the vhost-user socket has
been properly created before the VMM tries to connect to it.

Also, the daemon needs cap_dac_override capabilities to access debugfs
filesystem.

Last thing, both virtio-fs and virtio-pmem tests were slightly different
from the others since they were not explicitly killing cloud-hypervisor
and virtiofsd processes once the test was done.

Fixes #182

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>