### PR TITLE
vmm: Correctly share guest memory regions across the whole codebase

### DIFF
--- a/vfio/src/vfio_device.rs
+++ b/vfio/src/vfio_device.rs
@@ -513,14 +513,18 @@ pub struct VfioDevice {
     group: VfioGroup,
     regions: Vec<VfioRegion>,
     irqs: HashMap<u32, VfioIrq>,
-    mem: GuestMemoryMmap,
+    mem: Arc<GuestMemoryMmap>,
 }
 
 impl VfioDevice {
     /// Create a new vfio device, then guest read/write on this device could be
     /// transfered into kernel vfio.
     /// sysfspath specify the vfio device path in sys file system.
-    pub fn new(sysfspath: &Path, device_fd: Arc<DeviceFd>, mem: GuestMemoryMmap) -> Result<Self> {
+    pub fn new(
+        sysfspath: &Path,
+        device_fd: Arc<DeviceFd>,
+        mem: Arc<GuestMemoryMmap>,
+    ) -> Result<Self> {
         let uuid_path: PathBuf = [sysfspath, Path::new("iommu_group")].iter().collect();
         let group_path = uuid_path.read_link().map_err(|_| VfioError::InvalidPath)?;
         let group_osstr = group_path.file_name().ok_or(VfioError::InvalidPath)?;

--- a/vm-virtio/src/block.rs
+++ b/vm-virtio/src/block.rs
@@ -321,7 +321,7 @@ impl Request {
 
 struct BlockEpollHandler<T: DiskFile> {
     queues: Vec<Queue>,
-    mem: GuestMemoryMmap,
+    mem: Arc<GuestMemoryMmap>,
     disk_image: T,
     disk_nsectors: u64,
     interrupt_cb: Arc<VirtioInterrupt>,
@@ -610,7 +610,7 @@ impl<T: 'static + DiskFile + Send> VirtioDevice for Block<T> {
 
     fn activate(
         &mut self,
-        mem: GuestMemoryMmap,
+        mem: Arc<GuestMemoryMmap>,
         interrupt_cb: Arc<VirtioInterrupt>,
         queues: Vec<Queue>,
         mut queue_evts: Vec<EventFd>,

--- a/vm-virtio/src/console.rs
+++ b/vm-virtio/src/console.rs
@@ -54,7 +54,7 @@ unsafe impl ByteValued for VirtioConsoleConfig {}
 
 struct ConsoleEpollHandler {
     queues: Vec<Queue>,
-    mem: GuestMemoryMmap,
+    mem: Arc<GuestMemoryMmap>,
     interrupt_cb: Arc<VirtioInterrupt>,
     in_buffer: Arc<Mutex<VecDeque<u8>>>,
     out: Box<dyn io::Write + Send>,
@@ -432,7 +432,7 @@ impl VirtioDevice for Console {
 
     fn activate(
         &mut self,
-        mem: GuestMemoryMmap,
+        mem: Arc<GuestMemoryMmap>,
         interrupt_cb: Arc<VirtioInterrupt>,
         queues: Vec<Queue>,
         mut queue_evts: Vec<EventFd>,

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -67,7 +67,7 @@ pub trait VirtioDevice: Send {
     /// Activates this device for real usage.
     fn activate(
         &mut self,
-        mem: GuestMemoryMmap,
+        mem: Arc<GuestMemoryMmap>,
         interrupt_evt: Arc<VirtioInterrupt>,
         queues: Vec<Queue>,
         queue_evts: Vec<EventFd>,

--- a/vm-virtio/src/device.rs
+++ b/vm-virtio/src/device.rs
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 use super::*;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use vm_memory::{GuestAddress, GuestMemoryMmap, GuestUsize};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -67,7 +67,7 @@ pub trait VirtioDevice: Send {
     /// Activates this device for real usage.
     fn activate(
         &mut self,
-        mem: Arc<GuestMemoryMmap>,
+        mem: Arc<RwLock<GuestMemoryMmap>>,
         interrupt_evt: Arc<VirtioInterrupt>,
         queues: Vec<Queue>,
         queue_evts: Vec<EventFd>,

--- a/vm-virtio/src/fs.rs
+++ b/vm-virtio/src/fs.rs
@@ -13,7 +13,7 @@ use std::io;
 use std::io::Write;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::result;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use vhost_rs::vhost_user::message::{
     VhostUserFSSlaveMsg, VhostUserProtocolFeatures, VhostUserVirtioFeatures,
@@ -368,7 +368,7 @@ impl Fs {
 
     fn setup_vu(
         &mut self,
-        mem: &Arc<GuestMemoryMmap>,
+        mem: &GuestMemoryMmap,
         queues: Vec<Queue>,
         queue_evts: Vec<EventFd>,
     ) -> Result<Vec<(EventFd, Queue)>> {
@@ -527,7 +527,7 @@ impl VirtioDevice for Fs {
 
     fn activate(
         &mut self,
-        mem: Arc<GuestMemoryMmap>,
+        mem: Arc<RwLock<GuestMemoryMmap>>,
         interrupt_cb: Arc<VirtioInterrupt>,
         queues: Vec<Queue>,
         queue_evts: Vec<EventFd>,
@@ -552,7 +552,7 @@ impl VirtioDevice for Fs {
         self.kill_evt = Some(self_kill_evt);
 
         let vu_call_evt_queue_list = self
-            .setup_vu(&mem, queues, queue_evts)
+            .setup_vu(&mem.read().unwrap(), queues, queue_evts)
             .map_err(ActivateError::VhostUserSetup)?;
 
         // Initialize slave communication.

--- a/vm-virtio/src/fs.rs
+++ b/vm-virtio/src/fs.rs
@@ -368,7 +368,7 @@ impl Fs {
 
     fn setup_vu(
         &mut self,
-        mem: &GuestMemoryMmap,
+        mem: &Arc<GuestMemoryMmap>,
         queues: Vec<Queue>,
         queue_evts: Vec<EventFd>,
     ) -> Result<Vec<(EventFd, Queue)>> {
@@ -527,7 +527,7 @@ impl VirtioDevice for Fs {
 
     fn activate(
         &mut self,
-        mem: GuestMemoryMmap,
+        mem: Arc<GuestMemoryMmap>,
         interrupt_cb: Arc<VirtioInterrupt>,
         queues: Vec<Queue>,
         queue_evts: Vec<EventFd>,

--- a/vm-virtio/src/net.rs
+++ b/vm-virtio/src/net.rs
@@ -115,7 +115,7 @@ fn vnet_hdr_len() -> usize {
 }
 
 struct NetEpollHandler {
-    mem: GuestMemoryMmap,
+    mem: Arc<GuestMemoryMmap>,
     tap: Tap,
     rx: RxVirtio,
     tx: TxVirtio,
@@ -572,7 +572,7 @@ impl VirtioDevice for Net {
 
     fn activate(
         &mut self,
-        mem: GuestMemoryMmap,
+        mem: Arc<GuestMemoryMmap>,
         interrupt_cb: Arc<VirtioInterrupt>,
         mut queues: Vec<Queue>,
         mut queue_evts: Vec<EventFd>,

--- a/vm-virtio/src/pmem.rs
+++ b/vm-virtio/src/pmem.rs
@@ -154,7 +154,7 @@ impl Request {
 
 struct PmemEpollHandler {
     queue: Queue,
-    mem: GuestMemoryMmap,
+    mem: Arc<GuestMemoryMmap>,
     disk: File,
     interrupt_cb: Arc<VirtioInterrupt>,
     queue_evt: EventFd,
@@ -382,7 +382,7 @@ impl VirtioDevice for Pmem {
 
     fn activate(
         &mut self,
-        mem: GuestMemoryMmap,
+        mem: Arc<GuestMemoryMmap>,
         interrupt_cb: Arc<VirtioInterrupt>,
         mut queues: Vec<Queue>,
         mut queue_evts: Vec<EventFd>,

--- a/vm-virtio/src/rng.rs
+++ b/vm-virtio/src/rng.rs
@@ -32,7 +32,7 @@ const KILL_EVENT: DeviceEventT = 1;
 
 struct RngEpollHandler {
     queues: Vec<Queue>,
-    mem: GuestMemoryMmap,
+    mem: Arc<GuestMemoryMmap>,
     random_file: File,
     interrupt_cb: Arc<VirtioInterrupt>,
     queue_evt: EventFd,
@@ -237,7 +237,7 @@ impl VirtioDevice for Rng {
 
     fn activate(
         &mut self,
-        mem: GuestMemoryMmap,
+        mem: Arc<GuestMemoryMmap>,
         interrupt_cb: Arc<VirtioInterrupt>,
         queues: Vec<Queue>,
         mut queue_evts: Vec<EventFd>,

--- a/vm-virtio/src/transport/pci_common_config.rs
+++ b/vm-virtio/src/transport/pci_common_config.rs
@@ -271,7 +271,7 @@ mod tests {
         }
         fn activate(
             &mut self,
-            _mem: GuestMemoryMmap,
+            _mem: Arc<GuestMemoryMmap>,
             _interrupt_evt: Arc<VirtioInterrupt>,
             _queues: Vec<Queue>,
             _queue_evts: Vec<EventFd>,

--- a/vm-virtio/src/transport/pci_common_config.rs
+++ b/vm-virtio/src/transport/pci_common_config.rs
@@ -254,7 +254,7 @@ mod tests {
     use super::*;
     use crate::{ActivateResult, VirtioInterrupt};
 
-    use std::sync::Arc;
+    use std::sync::{Arc, RwLock};
     use vm_memory::GuestMemoryMmap;
     use vmm_sys_util::eventfd::EventFd;
 
@@ -271,7 +271,7 @@ mod tests {
         }
         fn activate(
             &mut self,
-            _mem: Arc<GuestMemoryMmap>,
+            _mem: Arc<RwLock<GuestMemoryMmap>>,
             _interrupt_evt: Arc<VirtioInterrupt>,
             _queues: Vec<Queue>,
             _queue_evts: Vec<EventFd>,

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -235,7 +235,7 @@ pub struct VirtioPciDevice {
     queue_evts: Vec<EventFd>,
 
     // Guest memory
-    memory: Option<GuestMemoryMmap>,
+    memory: Option<Arc<GuestMemoryMmap>>,
 
     // Setting PCI BAR
     settings_bar: u8,
@@ -244,7 +244,7 @@ pub struct VirtioPciDevice {
 impl VirtioPciDevice {
     /// Constructs a new PCI transport for the given virtio device.
     pub fn new(
-        memory: GuestMemoryMmap,
+        memory: Arc<GuestMemoryMmap>,
         device: Box<dyn VirtioDevice>,
         msix_num: u16,
     ) -> Result<Self> {


### PR DESCRIPTION
This PR solves the problem of duplicating the VM guest memory by sharing it appropriately with every thread instead of copying it everywhere it needs to be owned.