### PR TITLE
vhost_rs: Wait for full request to be satisfied

### DIFF
--- a/vhost_rs/src/vhost_user/sock_ctrl_msg.rs
+++ b/vhost_rs/src/vhost_user/sock_ctrl_msg.rs
@@ -176,7 +176,7 @@ fn raw_recvmsg(fd: RawFd, iovecs: &mut [iovec], in_fds: &mut [RawFd]) -> Result<
 
     // Safe because the msghdr was properly constructed from valid (or null) pointers of the
     // indicated length and we check the return value.
-    let total_read = unsafe { recvmsg(fd, &mut msg, 0) };
+    let total_read = unsafe { recvmsg(fd, &mut msg, libc::MSG_WAITALL) };
 
     if total_read == -1 {
         return Err(Error::last());


### PR DESCRIPTION
The recvmsg syscall can split a request in multiple packets unless we
use the flag MSG_WAITALL to make sure the request will wait for the
whole data to be transferred before returning.

This flag is needed to prevent the vhost crate from returning the error
PartialMessage, which occured sporadically when using virtio-fs, and
which was detected as part of our continuous integration testing.

Fixes #182

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>