### PR TITLE
vhost_rs: some changes according to vhost user spec 

### DIFF
--- a/vhost_rs/src/vhost_user/master.rs
+++ b/vhost_rs/src/vhost_user/master.rs
@@ -352,7 +352,7 @@ impl VhostUserMaster for Master {
 
         let mut node = self.node.lock().unwrap();
         // depends on VhostUserProtocolFeatures::CONFIG
-        if node.acked_virtio_features & VhostUserProtocolFeatures::CONFIG.bits() == 0 {
+        if node.acked_protocol_features & VhostUserProtocolFeatures::CONFIG.bits() == 0 {
             return error_code(VhostUserError::InvalidOperation);
         }
 
@@ -384,11 +384,11 @@ impl VhostUserMaster for Master {
 
         let mut node = self.node.lock().unwrap();
         // depends on VhostUserProtocolFeatures::CONFIG
-        if node.acked_virtio_features & VhostUserProtocolFeatures::CONFIG.bits() == 0 {
+        if node.acked_protocol_features & VhostUserProtocolFeatures::CONFIG.bits() == 0 {
             return error_code(VhostUserError::InvalidOperation);
         }
 
-        let hdr = node.send_request_with_payload(MasterReq::GET_CONFIG, &body, buf, None)?;
+        let hdr = node.send_request_with_payload(MasterReq::SET_CONFIG, &body, buf, None)?;
         node.wait_for_ack(&hdr).map_err(|e| e.into())
     }
 

--- a/vhost_rs/src/vhost_user/master.rs
+++ b/vhost_rs/src/vhost_user/master.rs
@@ -603,7 +603,7 @@ impl MasterInternal {
     #[inline]
     fn new_request_header(request: MasterReq, size: u32) -> VhostUserMsgHeader<MasterReq> {
         // TODO: handle NEED_REPLY flag
-        VhostUserMsgHeader::new(request, 0, size)
+        VhostUserMsgHeader::new(request, 0x1, size)
     }
 }
 

--- a/vhost_rs/src/vhost_user/master.rs
+++ b/vhost_rs/src/vhost_user/master.rs
@@ -360,7 +360,7 @@ impl VhostUserMaster for Master {
         // "Master payload: virtio device config space"
         // But what content should the payload contains for a get_config() request?
         // So current implementation doesn't conform to the spec.
-        let hdr = node.send_request_with_body(MasterReq::GET_CONFIG, &body, None)?;
+        let hdr = node.send_request_with_config_body(MasterReq::GET_CONFIG, &body, None)?;
         let (reply, buf, rfds) = node.recv_reply_with_payload::<VhostUserConfig>(&hdr)?;
         if rfds.is_some() {
             Endpoint::<MasterReq>::close_rfds(rfds);
@@ -480,6 +480,27 @@ impl MasterInternal {
         Ok(hdr)
     }
 
+    fn send_request_with_config_body(
+        &mut self,
+        code: MasterReq,
+        user_config: &VhostUserConfig,
+        fds: Option<&[RawFd]>,
+    ) -> VhostUserResult<VhostUserMsgHeader<MasterReq>> {
+        if mem::size_of::<VhostUserConfig>() + user_config.size as usize > MAX_MSG_SIZE {
+            return Err(VhostUserError::InvalidParam);
+        }
+        self.check_state()?;
+
+        let hdr = Self::new_request_header(
+            code,
+            mem::size_of::<VhostUserConfig>() as u32 + user_config.size,
+        );
+        let mut buf = vec![0; user_config.size as usize];
+        self.main_sock
+            .send_config_message(&hdr, user_config, &mut buf, fds)?;
+        Ok(hdr)
+    }
+
     fn send_request_with_payload<T: Sized, P: Sized>(
         &mut self,
         code: MasterReq,
@@ -555,7 +576,7 @@ impl MasterInternal {
         if !reply.is_reply_for(hdr)
             || reply.get_size() as usize != mem::size_of::<T>() + bytes
             || rfds.is_some()
-            || body.is_valid()
+            || !body.is_valid()
         {
             Endpoint::<MasterReq>::close_rfds(rfds);
             return Err(VhostUserError::InvalidMessage);

--- a/vhost_rs/src/vhost_user/message.rs
+++ b/vhost_rs/src/vhost_user/message.rs
@@ -575,10 +575,9 @@ impl VhostUserMsgValidator for VhostUserConfig {
     fn is_valid(&self) -> bool {
         if (self.flags & !VhostUserConfigFlags::all().bits()) != 0 {
             return false;
-        } else if self.offset < VHOST_USER_CONFIG_OFFSET
-            || self.offset >= VHOST_USER_CONFIG_SIZE
+        } else if self.offset >= VHOST_USER_CONFIG_SIZE
             || self.size == 0
-            || self.size > (VHOST_USER_CONFIG_SIZE - VHOST_USER_CONFIG_OFFSET)
+            || self.size > VHOST_USER_CONFIG_SIZE
             || self.size + self.offset > VHOST_USER_CONFIG_SIZE
         {
             return false;

--- a/vhost_rs/src/vhost_user/message.rs
+++ b/vhost_rs/src/vhost_user/message.rs
@@ -540,12 +540,10 @@ impl VhostUserMsgValidator for VhostUserVringAddr {
 bitflags! {
     /// Flags for the device configuration message.
     pub struct VhostUserConfigFlags: u32 {
-        /// TODO: seems the vhost-user spec has refined the definition, EMPTY is removed.
-        const EMPTY = 0x0;
-        /// Vhost master messages used for writable fields
-        const WRITABLE = 0x1;
-        /// Mark that message is part of an ongoing live-migration operation.
-        const LIVE_MIGRATION = 0x2;
+        /// Vhost master messages used for writeable fields.
+        const WRITABLE = 0x0;
+        /// Vhost master messages used for live migration.
+        const LIVE_MIGRATION = 0x1;
     }
 }
 
@@ -787,7 +785,7 @@ mod tests {
         let mut msg = VhostUserConfig::new(
             VHOST_USER_CONFIG_OFFSET,
             VHOST_USER_CONFIG_SIZE - VHOST_USER_CONFIG_OFFSET,
-            VhostUserConfigFlags::EMPTY,
+            VhostUserConfigFlags::WRITABLE,
         );
 
         assert!(msg.is_valid());
@@ -804,7 +802,7 @@ mod tests {
         msg.size = 2;
         assert!(!msg.is_valid());
         msg.size = 1;
-        msg.flags |= VhostUserConfigFlags::WRITABLE.bits();
+        msg.flags |= VhostUserConfigFlags::LIVE_MIGRATION.bits();
         assert!(msg.is_valid());
         msg.flags |= 0x4;
         assert!(!msg.is_valid());


### PR DESCRIPTION
As @sboeuf said in #173, i split out vhost user changes to this PR, the older PR will be as pure vhost-user-blok changes.

There are some bugs in current vhost_rs code, and read_config()/write_config() are not compatible with vhost user config info spec. I changed those according to vhost user spec, please help review those patches, thanks. 

@sameo @sboeuf @rbradford @chao-p  