### PR TITLE
Bump vmm-sys-util crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,7 +1046,7 @@ dependencies = [
 [[package]]
 name = "vmm-sys-util"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vmm-sys-util#829d605a079e32762013c7c9527b1deca8face77"
+source = "git+https://github.com/rust-vmm/vmm-sys-util#fd4dcd172e5e607bb480ff8c9004c90f6671043f"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/vfio/src/lib.rs
+++ b/vfio/src/lib.rs
@@ -9,6 +9,7 @@ extern crate byteorder;
 extern crate devices;
 extern crate kvm_bindings;
 extern crate kvm_ioctls;
+#[macro_use]
 extern crate log;
 extern crate pci;
 extern crate vfio_bindings;


### PR DESCRIPTION
cloud-hypervisor: Bumb vmm-sys-util crate version
    
PR #225 failed because we were still using the vmm-sys-util logging
macros and the crate's syslog module got removed. 
This PR relies on the previous commit switching to using the log crate macros instead.
