### PR TITLE
vfio: fix compile error

### DIFF
--- a/vfio/src/vfio_pci.rs
+++ b/vfio/src/vfio_pci.rs
@@ -388,9 +388,11 @@ impl VfioPciDevice {
                 ..Default::default()
             };
 
-            entry.u.msi.address_lo = route.msi_vector.msg_addr_lo;
-            entry.u.msi.address_hi = route.msi_vector.msg_addr_hi;
-            entry.u.msi.data = route.msi_vector.msg_data;
+            unsafe {
+                entry.u.msi.address_lo = route.msi_vector.msg_addr_lo;
+                entry.u.msi.address_hi = route.msi_vector.msg_addr_hi;
+                entry.u.msi.data = route.msi_vector.msg_data;
+            }
 
             entry_vec.push(entry);
         }


### PR DESCRIPTION
When compiling On Ubuntu 18.04 which rustc version is 1.35.0,
we will get following compile error.

error[E0133]: access to union field is unsafe and requires unsafe
function or block
   --> vfio/src/vfio_pci.rs:391:13
    |
391 |           entry.u.msi.address_lo = route.msi_vector.msg_addr_lo;
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
access to union field
    |
    = note: the field may not be properly initialized: using
uninitialized data will cause undefined behavior

This patch fixes this issue by using unsafe when accessing union field.

Signed-off-by: Li Qiang <liq3ea@163.com>