### PR TITLE
Enable rebooting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2074,7 +2074,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_reboot() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -2143,7 +2142,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_bzimage_reboot() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -55,7 +55,6 @@ impl Vmm {
 }
 
 pub fn boot_kernel(config: VmConfig) -> Result<()> {
-    #[allow(clippy::never_loop)]
     loop {
         let vmm = Vmm::new()?;
         let mut vm = Vm::new(&vmm.kvm, &config).map_err(Error::VmNew)?;
@@ -64,8 +63,6 @@ pub fn boot_kernel(config: VmConfig) -> Result<()> {
         if vm.start(entry).map_err(Error::VmStart)? == ExitBehaviour::Shutdown {
             break;
         }
-        error!("Shutting down rather than rebooting due to known resource leaks: https://github.com/intel/cloud-hypervisor/issues/223");
-        break;
     }
 
     Ok(())


### PR DESCRIPTION
Now that the thread management in under control thanks to #234 and the fix for #229 the only thing that remains to be cleaned up in the manually mmap()ed regions. I hope that we will have a cleaner solution in the future with rust-vmm/vm-memory#43 this will works for now.