### PR TITLE
scripts: Fix integration tests script:

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -81,7 +81,7 @@ fi
 VIRTIOFSD="$WORKLOADS_DIR/virtiofsd"
 VUBRIDGE="$WORKLOADS_DIR/vubridge"
 QEMU_DIR="qemu_build"
-if [ ! -f "$VIRTIOFSD" || ! -f "$VUBRIDGE" ]; then
+if [ ! -f "$VIRTIOFSD" ] || [ ! -f "$VUBRIDGE" ]; then
     pushd $WORKLOADS_DIR
     git clone --depth 1 "https://github.com/sboeuf/qemu.git" -b "virtio-fs" $QEMU_DIR
     pushd $QEMU_DIR


### PR DESCRIPTION
Running the integration test script showed the following error:

+ '[' '!' -f /home/rob/workloads/virtiofsd
scripts/run_integration_tests.sh: line 84: [: missing `]'
+ -f /home/rob/workloads/vubridge ']'
scripts/run_integration_tests.sh: line 84: -f: command not found

This was preventing the test from reusing build QEMU artifacts.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>