### PR TITLE
build: Really make the acpi feature disableable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ tempdir= "0.3.7"
 lazy_static= "1.4.0"
 
 [features]
-default = []
+default = ["acpi"]
+acpi = ["vmm/acpi"]
 
 # Integration tests require a special environment to run in
 integration_tests = []

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [features]
-default = ["acpi"]
+default = []
 acpi = ["acpi_tables"]
 
 [dependencies]

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -13,6 +13,7 @@ extern crate byteorder;
 extern crate kvm_bindings;
 extern crate libc;
 
+#[cfg(feature = "acpi")]
 extern crate acpi_tables;
 extern crate arch_gen;
 extern crate kvm_ioctls;

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -5,7 +5,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
+#[cfg(feature = "acpi")]
 mod acpi;
+
 mod gdt;
 pub mod interrupts;
 pub mod layout;
@@ -127,7 +129,7 @@ pub fn configure_system(
     cmdline_size: usize,
     num_cpus: u8,
     setup_hdr: Option<setup_header>,
-    serial_enabled: bool,
+    _serial_enabled: bool,
 ) -> super::Result<()> {
     const KERNEL_BOOT_FLAG_MAGIC: u16 = 0xaa55;
     const KERNEL_HDR_MAGIC: u32 = 0x53726448;
@@ -185,7 +187,7 @@ pub fn configure_system(
 
     #[cfg(feature = "acpi")]
     {
-        let rsdp_addr = acpi::create_acpi_tables(guest_mem, num_cpus, serial_enabled);
+        let rsdp_addr = acpi::create_acpi_tables(guest_mem, num_cpus, _serial_enabled);
         params.0.acpi_rsdp_addr = rsdp_addr.0;
     }
 

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -17,5 +17,5 @@ vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
 tempfile = "3.1.0"
 
 [features]
-default = ["acpi"]
+default = []
 acpi = []

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 
 [features]
-default = ["acpi"]
-acpi = ["acpi_tables"]
+default = []
+acpi = ["acpi_tables","devices/acpi", "arch/acpi"]
 
 [dependencies]
 acpi_tables = { path = "../acpi_tables", optional = true }


### PR DESCRIPTION
The command "cargo build --no-default-features" does not recursively
disable the default features across the workspace. Instead add an acpi
feature at the top-level, making it default, and then make that feature
conditional on all the crate acpi features.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>