### PR TITLE
vm-virtio: Add vsock support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,16 @@ fn main() {
                 .min_values(1),
         )
         .arg(
+            Arg::with_name("vsock")
+                .long("vsock")
+                .help(
+                    "Virtio VSOCK parameters \"cid=<context_id>,\
+                     sock=<socket_path>\"",
+                )
+                .takes_value(true)
+                .min_values(1),
+        )
+        .arg(
             Arg::with_name("v")
                 .short("v")
                 .multiple(true)
@@ -200,6 +210,7 @@ fn main() {
     let vhost_user_net: Option<Vec<&str>> = cmd_arguments
         .values_of("vhost-user-net")
         .map(|x| x.collect());
+    let vsock: Option<Vec<&str>> = cmd_arguments.values_of("vsock").map(|x| x.collect());
 
     let log_level = match cmd_arguments.occurrences_of("v") {
         0 => LevelFilter::Error,
@@ -239,6 +250,7 @@ fn main() {
         console,
         devices,
         vhost_user_net,
+        vsock,
     }) {
         Ok(config) => config,
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -974,7 +974,7 @@ mod tests {
                     .trim()
                     .parse::<u32>()
                     .unwrap_or_default(),
-                10
+                12
             );
 
             guest.ssh_command("sudo shutdown -h now")?;
@@ -1031,7 +1031,7 @@ mod tests {
                     .trim()
                     .parse::<u32>()
                     .unwrap_or_default(),
-                10
+                12
             );
 
             guest.ssh_command("sudo shutdown -h now")?;
@@ -1088,7 +1088,7 @@ mod tests {
                     .trim()
                     .parse::<u32>()
                     .unwrap_or_default(),
-                10
+                12
             );
 
             guest.ssh_command("sudo shutdown -h now")?;
@@ -2062,7 +2062,7 @@ mod tests {
                     .trim()
                     .parse::<u32>()
                     .unwrap_or_default(),
-                10
+                12
             );
 
             guest.ssh_command("sudo shutdown -h now")?;

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -27,7 +27,7 @@ pub mod net;
 mod pmem;
 mod queue;
 mod rng;
-mod vsock;
+pub mod vsock;
 
 pub mod transport;
 pub mod vhost_user;
@@ -49,6 +49,7 @@ const DEVICE_FEATURES_OK: u32 = 0x08;
 const DEVICE_FAILED: u32 = 0x80;
 
 const VIRTIO_F_VERSION_1: u32 = 32;
+const VIRTIO_F_IN_ORDER: u32 = 35;
 
 // Types taken from linux/virtio_ids.h
 #[derive(Copy, Clone)]

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -27,6 +27,7 @@ pub mod net;
 mod pmem;
 mod queue;
 mod rng;
+mod vsock;
 
 pub mod transport;
 pub mod vhost_user;
@@ -38,6 +39,7 @@ pub use self::net::*;
 pub use self::pmem::*;
 pub use self::queue::*;
 pub use self::rng::*;
+pub use self::vsock::*;
 
 const DEVICE_INIT: u32 = 0x00;
 const DEVICE_ACKNOWLEDGE: u32 = 0x01;

--- a/vm-virtio/src/queue.rs
+++ b/vm-virtio/src/queue.rs
@@ -41,10 +41,12 @@ unsafe impl ByteValued for Descriptor {}
 
 /// A virtio descriptor chain.
 pub struct DescriptorChain<'a> {
-    mem: &'a GuestMemoryMmap,
     desc_table: GuestAddress,
     queue_size: u16,
     ttl: u16, // used to prevent infinite chain cycles
+
+    /// Reference to guest memory
+    pub mem: &'a GuestMemoryMmap,
 
     /// Index into the descriptor table
     pub index: u16,

--- a/vm-virtio/src/vsock.rs
+++ b/vm-virtio/src/vsock.rs
@@ -1,0 +1,311 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+/// This is the `VirtioDevice` implementation for our vsock device. It handles the virtio-level
+/// device logic: feature negociation, device configuration, and device activation.
+/// The run-time device logic (i.e. event-driven data handling) is implemented by
+/// `super::epoll_handler::EpollHandler`.
+///
+/// We aim to conform to the VirtIO v1.1 spec:
+/// https://docs.oasis-open.org/virtio/virtio/v1.1/virtio-v1.1.html
+///
+/// The vsock device has two input parameters: a CID to identify the device, and a `VsockBackend`
+/// to use for offloading vsock traffic.
+///
+/// Upon its activation, the vsock device creates its `EpollHandler`, passes it the event-interested
+/// file descriptors, and registers these descriptors with the VMM `EpollContext`. Going forward,
+/// the `EpollHandler` will get notified whenever an event occurs on the just-registered FDs:
+/// - an RX queue FD;
+/// - a TX queue FD;
+/// - an event queue FD; and
+/// - a backend FD.
+///
+use epoll;
+use libc::EFD_NONBLOCK;
+use std;
+use std::io;
+use std::os::unix::io::AsRawFd;
+use std::result;
+use std::sync::{Arc, RwLock};
+use std::thread;
+
+use super::Error as DeviceError;
+use super::{
+    ActivateError, ActivateResult, DeviceEventT, Queue, VirtioDevice, VirtioDeviceType,
+    VIRTIO_F_VERSION_1,
+};
+use crate::VirtioInterrupt;
+use byteorder::{ByteOrder, LittleEndian};
+use vm_memory::GuestMemoryMmap;
+use vmm_sys_util::eventfd::EventFd;
+
+const QUEUE_SIZE: u16 = 256;
+const NUM_QUEUES: usize = 3;
+const QUEUE_SIZES: &[u16] = &[QUEUE_SIZE; NUM_QUEUES];
+
+// New descriptors are pending on the rx queue.
+const RX_QUEUE_EVENT: DeviceEventT = 0;
+// New descriptors are pending on the tx queue.
+const TX_QUEUE_EVENT: DeviceEventT = 1;
+// New descriptors are pending on the event queue.
+const EVT_QUEUE_EVENT: DeviceEventT = 2;
+// The device has been dropped.
+const KILL_EVENT: DeviceEventT = 3;
+
+struct VsockEpollHandler {
+    _cid: u64,
+    _mem: Arc<RwLock<GuestMemoryMmap>>,
+    _queues: Vec<Queue>,
+    queue_evts: Vec<EventFd>,
+    kill_evt: EventFd,
+    _interrupt_cb: Arc<VirtioInterrupt>,
+}
+
+impl VsockEpollHandler {
+    fn run(&mut self) -> result::Result<(), DeviceError> {
+        // Create the epoll file descriptor
+        let epoll_fd = epoll::create(true).map_err(DeviceError::EpollCreateFd)?;
+
+        // Add events
+        epoll::ctl(
+            epoll_fd,
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            self.queue_evts[0].as_raw_fd(),
+            epoll::Event::new(epoll::Events::EPOLLIN, u64::from(RX_QUEUE_EVENT)),
+        )
+        .map_err(DeviceError::EpollCtl)?;
+        epoll::ctl(
+            epoll_fd,
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            self.queue_evts[1].as_raw_fd(),
+            epoll::Event::new(epoll::Events::EPOLLIN, u64::from(TX_QUEUE_EVENT)),
+        )
+        .map_err(DeviceError::EpollCtl)?;
+        epoll::ctl(
+            epoll_fd,
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            self.queue_evts[2].as_raw_fd(),
+            epoll::Event::new(epoll::Events::EPOLLIN, u64::from(EVT_QUEUE_EVENT)),
+        )
+        .map_err(DeviceError::EpollCtl)?;
+        epoll::ctl(
+            epoll_fd,
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            self.kill_evt.as_raw_fd(),
+            epoll::Event::new(epoll::Events::EPOLLIN, u64::from(KILL_EVENT)),
+        )
+        .map_err(DeviceError::EpollCtl)?;
+
+        let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); 4];
+
+        'epoll: loop {
+            let num_events = match epoll::wait(epoll_fd, -1, &mut events[..]) {
+                Ok(res) => res,
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::Interrupted {
+                        // It's well defined from the epoll_wait() syscall
+                        // documentation that the epoll loop can be interrupted
+                        // before any of the requested events occurred or the
+                        // timeout expired. In both those cases, epoll_wait()
+                        // returns an error of type EINTR, but this should not
+                        // be considered as a regular error. Instead it is more
+                        // appropriate to retry, by calling into epoll_wait().
+                        continue;
+                    }
+                    return Err(DeviceError::EpollWait(e));
+                }
+            };
+
+            for event in events.iter().take(num_events) {
+                let ev_type = event.data as u16;
+
+                match ev_type {
+                    RX_QUEUE_EVENT => {
+                        if let Err(e) = self.queue_evts[0].read() {
+                            error!("Failed to get queue event: {:?}", e);
+                            break 'epoll;
+                        }
+
+                        debug!("RX queue event received");
+                    }
+                    TX_QUEUE_EVENT => {
+                        if let Err(e) = self.queue_evts[1].read() {
+                            error!("Failed to get queue event: {:?}", e);
+                            break 'epoll;
+                        }
+
+                        debug!("TX queue event received");
+                    }
+                    EVT_QUEUE_EVENT => {
+                        if let Err(e) = self.queue_evts[2].read() {
+                            error!("Failed to get queue event: {:?}", e);
+                            break 'epoll;
+                        }
+
+                        debug!("EVT queue event received");
+                    }
+                    KILL_EVENT => {
+                        debug!("KILL_EVENT received, stopping epoll loop");
+                        break 'epoll;
+                    }
+                    _ => {
+                        error!("Unknown event for virtio-vsock");
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Virtio device exposing virtual socket to the guest.
+pub struct Vsock {
+    cid: u64,
+    kill_evt: Option<EventFd>,
+    avail_features: u64,
+    acked_features: u64,
+}
+
+impl Vsock {
+    pub fn new(cid: u64) -> io::Result<Vsock> {
+        let avail_features = 1u64 << VIRTIO_F_VERSION_1;
+
+        Ok(Vsock {
+            cid,
+            kill_evt: None,
+            avail_features,
+            acked_features: 0u64,
+        })
+    }
+}
+
+impl Drop for Vsock {
+    fn drop(&mut self) {
+        if let Some(kill_evt) = self.kill_evt.take() {
+            // Ignore the result because there is nothing we can do about it.
+            let _ = kill_evt.write(1);
+        }
+    }
+}
+
+impl VirtioDevice for Vsock {
+    fn device_type(&self) -> u32 {
+        VirtioDeviceType::TYPE_VSOCK as u32
+    }
+
+    fn queue_max_sizes(&self) -> &[u16] {
+        QUEUE_SIZES
+    }
+
+    fn features(&self, page: u32) -> u32 {
+        match page {
+            // Get the lower 32-bits of the features bitfield.
+            0 => self.avail_features as u32,
+            // Get the upper 32-bits of the features bitfield.
+            1 => (self.avail_features >> 32) as u32,
+            _ => {
+                warn!("Received request for unknown features page.");
+                0u32
+            }
+        }
+    }
+
+    fn ack_features(&mut self, page: u32, value: u32) {
+        let mut v = match page {
+            0 => u64::from(value),
+            1 => u64::from(value) << 32,
+            _ => {
+                warn!("Cannot acknowledge unknown features page.");
+                0u64
+            }
+        };
+
+        // Check if the guest is ACK'ing a feature that we didn't claim to have.
+        let unrequested_features = v & !self.avail_features;
+        if unrequested_features != 0 {
+            warn!("Received acknowledge request for unknown feature.");
+
+            // Don't count these features as acked.
+            v &= !unrequested_features;
+        }
+        self.acked_features |= v;
+    }
+
+    fn read_config(&self, offset: u64, data: &mut [u8]) {
+        match offset {
+            0 if data.len() == 8 => LittleEndian::write_u64(data, self.cid),
+            0 if data.len() == 4 => LittleEndian::write_u32(data, (self.cid & 0xffff_ffff) as u32),
+            4 if data.len() == 4 => {
+                LittleEndian::write_u32(data, ((self.cid >> 32) & 0xffff_ffff) as u32)
+            }
+            _ => warn!(
+                "vsock: virtio-vsock received invalid read request of {} bytes at offset {}",
+                data.len(),
+                offset
+            ),
+        }
+    }
+
+    fn write_config(&mut self, offset: u64, data: &[u8]) {
+        warn!(
+            "vsock: guest driver attempted to write device config (offset={:x}, len={:x})",
+            offset,
+            data.len()
+        );
+    }
+
+    fn activate(
+        &mut self,
+        mem: Arc<RwLock<GuestMemoryMmap>>,
+        interrupt_cb: Arc<VirtioInterrupt>,
+        queues: Vec<Queue>,
+        queue_evts: Vec<EventFd>,
+    ) -> ActivateResult {
+        if queues.len() != NUM_QUEUES || queue_evts.len() != NUM_QUEUES {
+            error!(
+                "Cannot perform activate. Expected {} queue(s), got {}",
+                NUM_QUEUES,
+                queues.len()
+            );
+            return Err(ActivateError::BadActivate);
+        }
+
+        let (self_kill_evt, kill_evt) =
+            match EventFd::new(EFD_NONBLOCK).and_then(|e| Ok((e.try_clone()?, e))) {
+                Ok(v) => v,
+                Err(e) => {
+                    error!("failed creating kill EventFd pair: {}", e);
+                    return Err(ActivateError::BadActivate);
+                }
+            };
+        self.kill_evt = Some(self_kill_evt);
+
+        let mut handler = VsockEpollHandler {
+            _cid: self.cid,
+            _mem: mem,
+            _queues: queues,
+            queue_evts,
+            kill_evt,
+            _interrupt_cb: interrupt_cb,
+        };
+
+        let worker_result = thread::Builder::new()
+            .name("virtio_vsock".to_string())
+            .spawn(move || handler.run());
+
+        if let Err(e) = worker_result {
+            error!("failed to spawn virtio_vsock worker: {}", e);
+            return Err(ActivateError::BadActivate);;
+        }
+
+        Ok(())
+    }
+}

--- a/vm-virtio/src/vsock/csm/connection.rs
+++ b/vm-virtio/src/vsock/csm/connection.rs
@@ -1,0 +1,633 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+/// The main job of `VsockConnection` is to forward data traffic, back and forth, between a
+/// guest-side AF_VSOCK socket and a host-side generic `Read + Write + AsRawFd` stream, while
+/// also managing its internal state.
+/// To that end, `VsockConnection` implements:
+/// - `VsockChannel` for:
+///   - moving data from the host stream to a guest-provided RX buffer, via `recv_pkt()`; and
+///   - moving data from a guest-provided TX buffer to the host stream, via `send_pkt()`; and
+///   - updating its internal state, by absorbing control packets (anything other than
+///     VSOCK_OP_RW).
+/// - `VsockEpollListener` for getting notified about the availability of data or free buffer
+///   space at the host stream.
+///
+/// Note: there is a certain asymmetry to the RX and TX data flows:
+///       - RX transfers do not need any data buffering, since data is read straight from the
+///         host stream and into the guest-provided RX buffer;
+///       - TX transfers may require some data to be buffered by `VsockConnection`, if the host
+///         peer can't keep up with reading the data that we're writing. This is because, once
+///         the guest driver provides some data in a virtio TX buffer, the vsock device must
+///         consume it.  If that data can't be forwarded straight to the host stream, we'll
+///         have to store it in a buffer (and flush it at a later time). Vsock flow control
+///         ensures that our TX buffer doesn't overflow.
+///
+// The code in this file is best read with a fresh memory of the vsock protocol inner-workings.
+// To help with that, here is a
+//
+// Short primer on the vsock protocol
+// ----------------------------------
+//
+// 1. Establishing a connection
+//    A vsock connection is considered established after a two-way handshake:
+//    - the initiating peer sends a connection request packet (`hdr.op` == VSOCK_OP_REQUEST);
+//      then
+//    - the listening peer sends back a connection response packet (`hdr.op` ==
+//      VSOCK_OP_RESPONSE).
+//
+// 2. Terminating a connection
+//    When a peer wants to shut down an established connection, it sends a VSOCK_OP_SHUTDOWN
+//    packet. Two header flags are used with VSOCK_OP_SHUTDOWN, indicating the sender's
+//    intention:
+//    - VSOCK_FLAGS_SHUTDOWN_RCV: the sender will receive no more data for this connection; and
+//    - VSOCK_FLAGS_SHUTDOWN_SEND: the sender will send no more data for this connection.
+//    After a shutdown packet, the receiving peer will have some protocol-undefined time to
+//    flush its buffers, and then forcefully terminate the connection by sending back an RST
+//    packet. If the shutdown-initiating peer doesn't receive this RST packet during a timeout
+//    period, it will send one itself, thus terminating the connection.
+//    Note: a peer can send more than one VSOCK_OP_SHUTDOWN packets. However, read/write
+//          indications cannot be undone. E.g. once a "no-more-sending" promise was made, it
+//          cannot be taken back.  That is, `hdr.flags` will be ORed between subsequent
+//          VSOCK_OP_SHUTDOWN packets.
+//
+// 3. Flow control
+//    Before sending a data packet (VSOCK_OP_RW), the sender must make sure that the receiver
+//    has enough free buffer space to store that data. If this condition is not respected, the
+//    receiving peer's behaviour is undefined. In this implementation, we forcefully terminate
+//    the connection by sending back a VSOCK_OP_RST packet.
+//    Note: all buffer space information is computed and stored on a per-connection basis.
+//    Peers keep each other informed about the free buffer space they have by filling in two
+//    packet header members with each packet they send:
+//    - `hdr.buf_alloc`: the total buffer space the peer has allocated for receiving data; and
+//    - `hdr.fwd_cnt`: the total number of bytes the peer has successfully flushed out of its
+//       buffer.
+//    One can figure out how much space its peer has available in its buffer by inspecting the
+//    difference between how much it has sent to the peer and how much the peer has flushed out
+//    (i.e.  "forwarded", in the vsock spec terminology):
+//    `peer_free = peer_buf_alloc - (total_bytes_sent_to_peer - peer_fwd_cnt)`.
+//    Note: the above requires that peers constantly keep each other informed on their buffer
+//          space situation. However, since there are no receipt acknowledgement packets
+//          defined for the vsock protocol, packet flow can often be unidirectional (just one
+//          peer sending data to another), so the sender's information about the receiver's
+//          buffer space can get quickly outdated. The vsock protocol defines two solutions to
+//          this problem:
+//          1. The sender can explicitly ask for a buffer space (i.e. "credit") update from its
+//             peer, via a VSOCK_OP_CREDIT_REQUEST packet, to which it will get a
+//             VSOCK_OP_CREDIT_UPDATE response (or any response will do, really, since credit
+//             information must be included in any packet);
+//          2. The receiver can be proactive, and send VSOCK_OP_CREDIT_UPDATE packet, whenever
+//             it thinks its peer's information is out of date.
+//          Our implementation uses the proactive approach.
+//
+use std::io::{ErrorKind, Read, Write};
+use std::num::Wrapping;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::time::{Duration, Instant};
+
+use super::super::defs::uapi;
+use super::super::packet::VsockPacket;
+use super::super::{Result as VsockResult, VsockChannel, VsockEpollListener, VsockError};
+use super::defs;
+use super::txbuf::TxBuf;
+use super::{ConnState, Error, PendingRx, PendingRxSet, Result};
+
+/// A self-managing connection object, that handles communication between a guest-side AF_VSOCK
+/// socket and a host-side `Read + Write + AsRawFd` stream.
+///
+pub struct VsockConnection<S: Read + Write + AsRawFd> {
+    /// The current connection state.
+    state: ConnState,
+    /// The local CID. Most of the time this will be the constant `2` (the vsock host CID).
+    local_cid: u64,
+    /// The peer (guest) CID.
+    peer_cid: u64,
+    /// The local (host) port.
+    local_port: u32,
+    /// The peer (guest) port.
+    peer_port: u32,
+    /// The (connected) host-side stream.
+    stream: S,
+    /// The TX buffer for this connection.
+    tx_buf: TxBuf,
+    /// Total number of bytes that have been successfully written to `self.stream`, either
+    /// directly, or flushed from `self.tx_buf`.
+    fwd_cnt: Wrapping<u32>,
+    /// The amount of buffer space that the peer (guest) has allocated for this connection.
+    peer_buf_alloc: u32,
+    /// The total number of bytes that the peer has forwarded away.
+    peer_fwd_cnt: Wrapping<u32>,
+    /// The total number of bytes sent to the peer (guest vsock driver)
+    rx_cnt: Wrapping<u32>,
+    /// Our `self.fwd_cnt`, as last sent to the peer. This is used to provide proactive credit
+    /// updates, and let the peer know it's OK to send more data.
+    last_fwd_cnt_to_peer: Wrapping<u32>,
+    /// The set of pending RX packet indications that `recv_pkt()` will use to fill in a
+    /// packet for the peer (guest).
+    pending_rx: PendingRxSet,
+    /// Instant when this connection should be scheduled for immediate termination, due to some
+    /// timeout condition having been fulfilled.
+    expiry: Option<Instant>,
+}
+
+impl<S> VsockChannel for VsockConnection<S>
+where
+    S: Read + Write + AsRawFd,
+{
+    /// Fill in a vsock packet, to be delivered to our peer (the guest driver).
+    ///
+    /// As per the `VsockChannel` trait, this should only be called when there is data to be
+    /// fetched from the channel (i.e. `has_pending_rx()` is true). Otherwise, it will error
+    /// out with `VsockError::NoData`.
+    /// Pending RX indications are set by other mutable actions performed on the channel. For
+    /// instance, `send_pkt()` could set an Rst indication, if called with a VSOCK_OP_SHUTDOWN
+    /// packet, or `notify()` could set a Rw indication (a data packet can be fetched from the
+    /// channel), if data was ready to be read from the host stream.
+    ///
+    /// Returns:
+    /// - `Ok(())`: the packet has been successfully filled in and is ready for delivery;
+    /// - `Err(VsockError::NoData)`: there was no data available with which to fill in the
+    ///    packet;
+    /// - `Err(VsockError::PktBufMissing)`: the packet would've been filled in with data, but
+    ///    it is missing the data buffer.
+    ///
+    fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> VsockResult<()> {
+        // Perform some generic initialization that is the same for any packet operation (e.g.
+        // source, destination, credit, etc).
+        self.init_pkt(pkt);
+
+        // If forceful termination is pending, there's no point in checking for anything else.
+        // It's dead, Jim.
+        if self.pending_rx.remove(PendingRx::Rst) {
+            pkt.set_op(uapi::VSOCK_OP_RST);
+            return Ok(());
+        }
+
+        // Next up: if we're due a connection confirmation, that's all we need to know to fill
+        // in this packet.
+        if self.pending_rx.remove(PendingRx::Response) {
+            self.state = ConnState::Established;
+            pkt.set_op(uapi::VSOCK_OP_RESPONSE);
+            return Ok(());
+        }
+
+        // Same thing goes for locally-initiated connections that need to yield a connection
+        // request.
+        if self.pending_rx.remove(PendingRx::Request) {
+            self.expiry =
+                Some(Instant::now() + Duration::from_millis(defs::CONN_REQUEST_TIMEOUT_MS));
+            pkt.set_op(uapi::VSOCK_OP_REQUEST);
+            return Ok(());
+        }
+
+        // A credit update is basically a no-op, so we should only waste a perfectly fine RX
+        // buffer on it if we really have nothing else to say.
+        if self.pending_rx.remove(PendingRx::CreditUpdate) && !self.has_pending_rx() {
+            pkt.set_op(uapi::VSOCK_OP_CREDIT_UPDATE);
+            self.last_fwd_cnt_to_peer = self.fwd_cnt;
+            return Ok(());
+        }
+
+        // Alright, if we got to here, we need to cough up a data packet. We've already checked
+        // for all other pending RX indications.
+        if !self.pending_rx.remove(PendingRx::Rw) {
+            return Err(VsockError::NoData);
+        }
+
+        match self.state {
+            // A data packet is only valid for established connections, and connections for
+            // which our peer has initiated a graceful shutdown, but can still receive data.
+            ConnState::Established | ConnState::PeerClosed(false, _) => (),
+            _ => {
+                // Any other connection state is invalid at this point, and we need to kill it
+                // with fire.
+                pkt.set_op(uapi::VSOCK_OP_RST);
+                return Ok(());
+            }
+        }
+
+        // Oh wait, before we start bringing in the big data, can our peer handle receiving so
+        // much bytey goodness?
+        if self.need_credit_update_from_peer() {
+            self.last_fwd_cnt_to_peer = self.fwd_cnt;
+            pkt.set_op(uapi::VSOCK_OP_CREDIT_REQUEST);
+            return Ok(());
+        }
+
+        let buf = pkt.buf_mut().ok_or(VsockError::PktBufMissing)?;
+
+        // The maximum amount of data we can read in is limited by both the RX buffer size and
+        // the peer available buffer space.
+        let max_len = std::cmp::min(buf.len(), self.peer_avail_credit());
+
+        // Read data from the stream straight to the RX buffer, for maximum throughput.
+        match self.stream.read(&mut buf[..max_len]) {
+            Ok(read_cnt) => {
+                if read_cnt == 0 {
+                    // A 0-length read means the host stream was closed down. In that case,
+                    // we'll ask our peer to shut down the connection. We can neither send nor
+                    // receive any more data.
+                    self.state = ConnState::LocalClosed;
+                    self.expiry = Some(
+                        Instant::now() + Duration::from_millis(defs::CONN_SHUTDOWN_TIMEOUT_MS),
+                    );
+                    pkt.set_op(uapi::VSOCK_OP_SHUTDOWN)
+                        .set_flag(uapi::VSOCK_FLAGS_SHUTDOWN_RCV)
+                        .set_flag(uapi::VSOCK_FLAGS_SHUTDOWN_SEND);
+                } else {
+                    // On a successful data read, we fill in the packet with the RW op, and
+                    // length of the read data.
+                    pkt.set_op(uapi::VSOCK_OP_RW).set_len(read_cnt as u32);
+                }
+            }
+            Err(err) => {
+                // We are not expecting any errors when reading from the underlying stream. If
+                // any show up, we'll immediately kill this connection.
+                error!(
+                    "vsock: error reading from backing stream: lp={}, pp={}, err={:?}",
+                    self.local_port, self.peer_port, err
+                );
+                pkt.set_op(uapi::VSOCK_OP_RST);
+            }
+        };
+
+        self.rx_cnt += Wrapping(pkt.len());
+        self.last_fwd_cnt_to_peer = self.fwd_cnt;
+
+        Ok(())
+    }
+
+    /// Deliver a guest-generated packet to this connection.
+    ///
+    /// This forwards the data in RW packets to the host stream, and absorbs control packets,
+    /// using them to manage the internal connection state.
+    ///
+    /// Returns:
+    /// always `Ok(())`: the packet has been consumed;
+    ///
+    fn send_pkt(&mut self, pkt: &VsockPacket) -> VsockResult<()> {
+        // Update the peer credit information.
+        self.peer_buf_alloc = pkt.buf_alloc();
+        self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
+
+        match self.state {
+            // Most frequent case: this is an established connection that needs to forward some
+            // data to the host stream. Also works for a connection that has begun shutting
+            // down, but the peer still has some data to send.
+            ConnState::Established | ConnState::PeerClosed(_, false)
+                if pkt.op() == uapi::VSOCK_OP_RW =>
+            {
+                if pkt.buf().is_none() {
+                    info!(
+                        "vsock: dropping empty data packet from guest (lp={}, pp={}",
+                        self.local_port, self.peer_port
+                    );
+                    return Ok(());
+                }
+
+                // Unwrapping here is safe, since we just checked `pkt.buf()` above.
+                let buf_slice = &pkt.buf().unwrap()[..(pkt.len() as usize)];
+                if let Err(err) = self.send_bytes(buf_slice) {
+                    // If we can't write to the host stream, that's an unrecoverable error, so
+                    // we'll terminate this connection.
+                    warn!(
+                        "vsock: error writing to local stream (lp={}, pp={}): {:?}",
+                        self.local_port, self.peer_port, err
+                    );
+                    self.kill();
+                    return Ok(());
+                }
+
+                // We might've just consumed some data. If that's the case, we might need to
+                // update the peer on our buffer space situation, so that it can keep sending
+                // data packets our way.
+                if self.peer_needs_credit_update() {
+                    self.pending_rx.insert(PendingRx::CreditUpdate);
+                }
+            }
+
+            // Next up: receiving a response / confirmation for a host-initiated connection.
+            // We'll move to an Established state, and pass on the good news through the host
+            // stream.
+            ConnState::LocalInit if pkt.op() == uapi::VSOCK_OP_RESPONSE => {
+                self.expiry = None;
+                self.state = ConnState::Established;
+            }
+
+            // The peer wants to shut down an established connection.  If they have nothing
+            // more to send nor receive, and we don't have to wait to drain our TX buffer, we
+            // can schedule an RST packet (to terminate the connection on the next recv call).
+            // Otherwise, we'll arm the kill timer.
+            ConnState::Established if pkt.op() == uapi::VSOCK_OP_SHUTDOWN => {
+                let recv_off = pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_RCV != 0;
+                let send_off = pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_SEND != 0;
+                self.state = ConnState::PeerClosed(recv_off, send_off);
+                if recv_off && send_off {
+                    if self.tx_buf.is_empty() {
+                        self.pending_rx.insert(PendingRx::Rst);
+                    } else {
+                        self.expiry = Some(
+                            Instant::now() + Duration::from_millis(defs::CONN_SHUTDOWN_TIMEOUT_MS),
+                        );
+                    }
+                }
+            }
+
+            // The peer wants to update a shutdown request, with more receive/send indications.
+            // The same logic as above applies.
+            ConnState::PeerClosed(ref mut recv_off, ref mut send_off)
+                if pkt.op() == uapi::VSOCK_OP_SHUTDOWN =>
+            {
+                *recv_off = *recv_off || (pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_RCV != 0);
+                *send_off = *send_off || (pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_SEND != 0);
+                if *recv_off && *send_off && self.tx_buf.is_empty() {
+                    self.pending_rx.insert(PendingRx::Rst);
+                }
+            }
+
+            // A credit update from our peer is valid only in a state which allows data
+            // transfer towards the peer.
+            ConnState::Established | ConnState::PeerInit | ConnState::PeerClosed(false, _)
+                if pkt.op() == uapi::VSOCK_OP_CREDIT_UPDATE =>
+            {
+                // Nothing to do here; we've already updated peer credit.
+            }
+
+            // A credit request from our peer is valid only in a state which allows data
+            // transfer from the peer. We'll respond with a credit update packet.
+            ConnState::Established | ConnState::PeerInit | ConnState::PeerClosed(_, false)
+                if pkt.op() == uapi::VSOCK_OP_CREDIT_REQUEST =>
+            {
+                self.pending_rx.insert(PendingRx::CreditUpdate);
+            }
+
+            _ => {
+                debug!(
+                    "vsock: dropping invalid TX pkt for connection: state={:?}, pkt.hdr={:?}",
+                    self.state,
+                    pkt.hdr()
+                );
+            }
+        };
+
+        Ok(())
+    }
+
+    /// Check if the connection has any pending packet addressed to the peer.
+    ///
+    fn has_pending_rx(&self) -> bool {
+        !self.pending_rx.is_empty()
+    }
+}
+
+impl<S> VsockEpollListener for VsockConnection<S>
+where
+    S: Read + Write + AsRawFd,
+{
+    /// Get the file descriptor that this connection wants polled.
+    ///
+    /// The connection is interested in being notified about EPOLLIN / EPOLLOUT events on the
+    /// host stream.
+    ///
+    fn get_polled_fd(&self) -> RawFd {
+        self.stream.as_raw_fd()
+    }
+
+    /// Get the event set that this connection is interested in.
+    ///
+    /// A connection will want to be notified when:
+    /// - data is available to be read from the host stream, so that it can store an RW pending
+    ///   RX indication; and
+    /// - data can be written to the host stream, and the TX buffer needs to be flushed.
+    ///
+    fn get_polled_evset(&self) -> epoll::Events {
+        let mut evset = epoll::Events::empty();
+        if !self.tx_buf.is_empty() {
+            // There's data waiting in the TX buffer, so we are interested in being notified
+            // when writing to the host stream wouldn't block.
+            evset.insert(epoll::Events::EPOLLOUT);
+        }
+        // We're generally interested in being notified when data can be read from the host
+        // stream, unless we're in a state which doesn't allow moving data from host to guest.
+        match self.state {
+            ConnState::Killed | ConnState::LocalClosed | ConnState::PeerClosed(true, _) => (),
+            _ if self.need_credit_update_from_peer() => (),
+            _ => evset.insert(epoll::Events::EPOLLIN),
+        }
+        evset
+    }
+
+    /// Notify the connection about an event (or set of events) that it was interested in.
+    ///
+    fn notify(&mut self, evset: epoll::Events) {
+        if evset.contains(epoll::Events::EPOLLIN) {
+            // Data can be read from the host stream. Setting a Rw pending indication, so that
+            // the muxer will know to call `recv_pkt()` later.
+            self.pending_rx.insert(PendingRx::Rw);
+        }
+
+        if evset.contains(epoll::Events::EPOLLOUT) {
+            // Data can be written to the host stream. Time to flush out the TX buffer.
+            //
+            if self.tx_buf.is_empty() {
+                info!("vsock: connection received unexpected EPOLLOUT event");
+                return;
+            }
+            let flushed = self
+                .tx_buf
+                .flush_to(&mut self.stream)
+                .unwrap_or_else(|err| {
+                    warn!(
+                        "vsock: error flushing TX buf for (lp={}, pp={}): {:?}",
+                        self.local_port, self.peer_port, err
+                    );
+                    self.kill();
+                    0
+                });
+            self.fwd_cnt += Wrapping(flushed as u32);
+
+            // If this connection was shutting down, but is waiting to drain the TX buffer
+            // before forceful termination, the wait might be over.
+            if self.state == ConnState::PeerClosed(true, true) && self.tx_buf.is_empty() {
+                self.pending_rx.insert(PendingRx::Rst);
+            } else if self.peer_needs_credit_update() {
+                // If we've freed up some more buffer space, we may need to let the peer know it
+                // can safely send more data our way.
+                self.pending_rx.insert(PendingRx::CreditUpdate);
+            }
+        }
+    }
+}
+
+impl<S> VsockConnection<S>
+where
+    S: Read + Write + AsRawFd,
+{
+    /// Create a new guest-initiated connection object.
+    ///
+    pub fn new_peer_init(
+        stream: S,
+        local_cid: u64,
+        peer_cid: u64,
+        local_port: u32,
+        peer_port: u32,
+        peer_buf_alloc: u32,
+    ) -> Self {
+        Self {
+            local_cid,
+            peer_cid,
+            local_port,
+            peer_port,
+            stream,
+            state: ConnState::PeerInit,
+            tx_buf: TxBuf::new(),
+            fwd_cnt: Wrapping(0),
+            peer_buf_alloc,
+            peer_fwd_cnt: Wrapping(0),
+            rx_cnt: Wrapping(0),
+            last_fwd_cnt_to_peer: Wrapping(0),
+            pending_rx: PendingRxSet::from(PendingRx::Response),
+            expiry: None,
+        }
+    }
+
+    /// Create a new host-initiated connection object.
+    ///
+    pub fn new_local_init(
+        stream: S,
+        local_cid: u64,
+        peer_cid: u64,
+        local_port: u32,
+        peer_port: u32,
+    ) -> Self {
+        Self {
+            local_cid,
+            peer_cid,
+            local_port,
+            peer_port,
+            stream,
+            state: ConnState::LocalInit,
+            tx_buf: TxBuf::new(),
+            fwd_cnt: Wrapping(0),
+            peer_buf_alloc: 0,
+            peer_fwd_cnt: Wrapping(0),
+            rx_cnt: Wrapping(0),
+            last_fwd_cnt_to_peer: Wrapping(0),
+            pending_rx: PendingRxSet::from(PendingRx::Request),
+            expiry: None,
+        }
+    }
+
+    /// Check if there is an expiry (kill) timer set for this connection, sometime in the
+    /// future.
+    ///
+    pub fn will_expire(&self) -> bool {
+        match self.expiry {
+            None => false,
+            Some(t) => t > Instant::now(),
+        }
+    }
+
+    /// Check if this connection needs to be scheduled for forceful termination, due to its
+    /// kill timer having expired.
+    ///
+    pub fn has_expired(&self) -> bool {
+        match self.expiry {
+            None => false,
+            Some(t) => t <= Instant::now(),
+        }
+    }
+
+    /// Get the kill timer value, if one is set.
+    ///
+    pub fn expiry(&self) -> Option<Instant> {
+        self.expiry
+    }
+
+    /// Schedule the connection to be forcefully terminated ASAP (i.e. the next time the
+    /// connection is asked to yield a packet, via `recv_pkt()`).
+    ///
+    pub fn kill(&mut self) {
+        self.state = ConnState::Killed;
+        self.pending_rx.insert(PendingRx::Rst);
+    }
+
+    /// Send some raw data (a byte-slice) to the host stream.
+    ///
+    /// Raw data can either be sent straight to the host stream, or to our TX buffer, if the
+    /// former fails.
+    ///
+    fn send_bytes(&mut self, buf: &[u8]) -> Result<()> {
+        // If there is data in the TX buffer, that means we're already registered for EPOLLOUT
+        // events on the underlying stream. Therefore, there's no point in attempting a write
+        // at this point. `self.notify()` will get called when EPOLLOUT arrives, and it will
+        // attempt to drain the TX buffer then.
+        if !self.tx_buf.is_empty() {
+            return self.tx_buf.push(buf);
+        }
+
+        // The TX buffer is empty, so we can try to write straight to the host stream.
+        let written = match self.stream.write(buf) {
+            Ok(cnt) => cnt,
+            Err(e) => {
+                // Absorb any would-block errors, since we can always try again later.
+                if e.kind() == ErrorKind::WouldBlock {
+                    0
+                } else {
+                    // We don't know how to handle any other write error, so we'll send it up
+                    // the call chain.
+                    return Err(Error::StreamWrite(e));
+                }
+            }
+        };
+        // Move the "forwarded bytes" counter ahead by how much we were able to send out.
+        self.fwd_cnt += Wrapping(written as u32);
+
+        // If we couldn't write the whole slice, we'll need to push the remaining data to our
+        // buffer.
+        if written < buf.len() {
+            self.tx_buf.push(&buf[written..])?;
+        }
+
+        Ok(())
+    }
+
+    /// Check if the credit information the peer has last received from us is outdated.
+    ///
+    fn peer_needs_credit_update(&self) -> bool {
+        (self.fwd_cnt - self.last_fwd_cnt_to_peer).0 as usize >= defs::CONN_CREDIT_UPDATE_THRESHOLD
+    }
+
+    /// Check if we need to ask the peer for a credit update before sending any more data its
+    /// way.
+    ///
+    fn need_credit_update_from_peer(&self) -> bool {
+        self.peer_avail_credit() == 0
+    }
+
+    /// Get the maximum number of bytes that we can send to our peer, without overflowing its
+    /// buffer.
+    ///
+    fn peer_avail_credit(&self) -> usize {
+        (Wrapping(self.peer_buf_alloc as u32) - (self.rx_cnt - self.peer_fwd_cnt)).0 as usize
+    }
+
+    /// Prepare a packet header for transmission to our peer.
+    ///
+    fn init_pkt<'a>(&self, pkt: &'a mut VsockPacket) -> &'a mut VsockPacket {
+        // Make sure the header is zeroed-out first.
+        // This looks sub-optimal, but it is actually optimized-out in the compiled code to be
+        // faster than a memset().
+        for b in pkt.hdr_mut() {
+            *b = 0;
+        }
+
+        pkt.set_src_cid(self.local_cid)
+            .set_dst_cid(self.peer_cid)
+            .set_src_port(self.local_port)
+            .set_dst_port(self.peer_port)
+            .set_type(uapi::VSOCK_TYPE_STREAM)
+            .set_buf_alloc(defs::CONN_TX_BUF_SIZE as u32)
+            .set_fwd_cnt(self.fwd_cnt.0)
+    }
+}

--- a/vm-virtio/src/vsock/csm/connection.rs
+++ b/vm-virtio/src/vsock/csm/connection.rs
@@ -631,3 +631,556 @@ where
             .set_fwd_cnt(self.fwd_cnt.0)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use libc::EFD_NONBLOCK;
+
+    use std::io::{Error as IoError, ErrorKind, Read, Result as IoResult, Write};
+    use std::os::unix::io::RawFd;
+    use std::time::{Duration, Instant};
+    use vmm_sys_util::eventfd::EventFd;
+
+    use super::super::super::defs::uapi;
+    use super::super::super::tests::TestContext;
+    use super::super::defs as csm_defs;
+    use super::*;
+
+    const LOCAL_CID: u64 = 2;
+    const PEER_CID: u64 = 3;
+    const LOCAL_PORT: u32 = 1002;
+    const PEER_PORT: u32 = 1003;
+    const PEER_BUF_ALLOC: u32 = 64 * 1024;
+
+    enum StreamState {
+        Closed,
+        Error(ErrorKind),
+        Ready,
+        WouldBlock,
+    }
+
+    struct TestStream {
+        fd: EventFd,
+        read_buf: Vec<u8>,
+        read_state: StreamState,
+        write_buf: Vec<u8>,
+        write_state: StreamState,
+    }
+    impl TestStream {
+        fn new() -> Self {
+            Self {
+                fd: EventFd::new(EFD_NONBLOCK).unwrap(),
+                read_state: StreamState::Ready,
+                write_state: StreamState::Ready,
+                read_buf: Vec::new(),
+                write_buf: Vec::new(),
+            }
+        }
+        fn new_with_read_buf(buf: &[u8]) -> Self {
+            let mut stream = Self::new();
+            stream.read_buf = buf.to_vec();
+            stream
+        }
+    }
+
+    impl AsRawFd for TestStream {
+        fn as_raw_fd(&self) -> RawFd {
+            self.fd.as_raw_fd()
+        }
+    }
+
+    impl Read for TestStream {
+        fn read(&mut self, data: &mut [u8]) -> IoResult<usize> {
+            match self.read_state {
+                StreamState::Closed => Ok(0),
+                StreamState::Error(kind) => Err(IoError::new(kind, "whatevs")),
+                StreamState::Ready => {
+                    if self.read_buf.is_empty() {
+                        return Err(IoError::new(ErrorKind::WouldBlock, "EAGAIN"));
+                    }
+                    let len = std::cmp::min(data.len(), self.read_buf.len());
+                    assert_ne!(len, 0);
+                    data[..len].copy_from_slice(&self.read_buf[..len]);
+                    self.read_buf = self.read_buf.split_off(len);
+                    Ok(len)
+                }
+                StreamState::WouldBlock => Err(IoError::new(ErrorKind::WouldBlock, "EAGAIN")),
+            }
+        }
+    }
+
+    impl Write for TestStream {
+        fn write(&mut self, data: &[u8]) -> IoResult<usize> {
+            match self.write_state {
+                StreamState::Closed => Err(IoError::new(ErrorKind::BrokenPipe, "EPIPE")),
+                StreamState::Error(kind) => Err(IoError::new(kind, "whatevs")),
+                StreamState::Ready => {
+                    self.write_buf.extend_from_slice(data);
+                    Ok(data.len())
+                }
+                StreamState::WouldBlock => Err(IoError::new(ErrorKind::WouldBlock, "EAGAIN")),
+            }
+        }
+        fn flush(&mut self) -> IoResult<()> {
+            Ok(())
+        }
+    }
+
+    fn init_pkt(pkt: &mut VsockPacket, op: u16, len: u32) -> &mut VsockPacket {
+        for b in pkt.hdr_mut() {
+            *b = 0;
+        }
+        pkt.set_src_cid(PEER_CID)
+            .set_dst_cid(LOCAL_CID)
+            .set_src_port(PEER_PORT)
+            .set_dst_port(LOCAL_PORT)
+            .set_type(uapi::VSOCK_TYPE_STREAM)
+            .set_buf_alloc(PEER_BUF_ALLOC)
+            .set_op(op)
+            .set_len(len)
+    }
+
+    // This is the connection state machine test context: a helper struct to provide CSM testing
+    // primitives. A single `VsockPacket` object will be enough for our testing needs. We'll be
+    // using it for simulating both packet sends and packet receives. We need to keep the vsock
+    // testing context alive, since `VsockPacket` is just a pointer-wrapper over some data that
+    // resides in guest memory. The vsock test context owns the `GuestMemory` object, so we'll make
+    // it a member here, in order to make sure that guest memory outlives our testing packet.  A
+    // single `VsockConnection` object will also suffice for our testing needs. We'll be using a
+    // specially crafted `Read + Write + AsRawFd` object as a backing stream, so that we can
+    // control the various error conditions that might arise.
+    struct CsmTestContext {
+        _vsock_test_ctx: TestContext,
+        pkt: VsockPacket,
+        conn: VsockConnection<TestStream>,
+    }
+
+    impl CsmTestContext {
+        fn new_established() -> Self {
+            Self::new(ConnState::Established)
+        }
+
+        fn new(conn_state: ConnState) -> Self {
+            let vsock_test_ctx = TestContext::new();
+            let mut handler_ctx = vsock_test_ctx.create_epoll_handler_context();
+            let stream = TestStream::new();
+            let mut pkt = VsockPacket::from_rx_virtq_head(
+                &handler_ctx.handler.queues[0]
+                    .iter(&vsock_test_ctx.mem)
+                    .next()
+                    .unwrap(),
+            )
+            .unwrap();
+            let conn = match conn_state {
+                ConnState::PeerInit => VsockConnection::<TestStream>::new_peer_init(
+                    stream,
+                    LOCAL_CID,
+                    PEER_CID,
+                    LOCAL_PORT,
+                    PEER_PORT,
+                    PEER_BUF_ALLOC,
+                ),
+                ConnState::LocalInit => VsockConnection::<TestStream>::new_local_init(
+                    stream, LOCAL_CID, PEER_CID, LOCAL_PORT, PEER_PORT,
+                ),
+                ConnState::Established => {
+                    let mut conn = VsockConnection::<TestStream>::new_peer_init(
+                        stream,
+                        LOCAL_CID,
+                        PEER_CID,
+                        LOCAL_PORT,
+                        PEER_PORT,
+                        PEER_BUF_ALLOC,
+                    );
+                    assert!(conn.has_pending_rx());
+                    conn.recv_pkt(&mut pkt).unwrap();
+                    assert_eq!(pkt.op(), uapi::VSOCK_OP_RESPONSE);
+                    conn
+                }
+                other => panic!("invalid ctx state: {:?}", other),
+            };
+            assert_eq!(conn.state, conn_state);
+            Self {
+                _vsock_test_ctx: vsock_test_ctx,
+                pkt,
+                conn,
+            }
+        }
+
+        fn set_stream(&mut self, stream: TestStream) {
+            self.conn.stream = stream;
+        }
+
+        fn set_peer_credit(&mut self, credit: u32) {
+            assert!(credit < self.conn.peer_buf_alloc);
+            self.conn.peer_fwd_cnt = Wrapping(0);
+            self.conn.rx_cnt = Wrapping(self.conn.peer_buf_alloc - credit);
+            assert_eq!(self.conn.peer_avail_credit(), credit as usize);
+        }
+
+        fn send(&mut self) {
+            self.conn.send_pkt(&self.pkt).unwrap();
+        }
+
+        fn recv(&mut self) {
+            self.conn.recv_pkt(&mut self.pkt).unwrap();
+        }
+
+        fn notify_epollin(&mut self) {
+            self.conn.notify(epoll::Events::EPOLLIN);
+            assert!(self.conn.has_pending_rx());
+        }
+
+        fn notify_epollout(&mut self) {
+            self.conn.notify(epoll::Events::EPOLLOUT);
+        }
+
+        fn init_pkt(&mut self, op: u16, len: u32) -> &mut VsockPacket {
+            init_pkt(&mut self.pkt, op, len)
+        }
+
+        fn init_data_pkt(&mut self, data: &[u8]) -> &VsockPacket {
+            assert!(data.len() <= self.pkt.buf().unwrap().len());
+            self.init_pkt(uapi::VSOCK_OP_RW, data.len() as u32);
+            self.pkt.buf_mut().unwrap()[..data.len()].copy_from_slice(data);
+            &self.pkt
+        }
+    }
+
+    #[test]
+    fn test_peer_request() {
+        let mut ctx = CsmTestContext::new(ConnState::PeerInit);
+        assert!(ctx.conn.has_pending_rx());
+        ctx.recv();
+        // For peer-initiated requests, our connection should always yield a vsock reponse packet,
+        // in order to establish the connection.
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RESPONSE);
+        assert_eq!(ctx.pkt.src_cid(), LOCAL_CID);
+        assert_eq!(ctx.pkt.dst_cid(), PEER_CID);
+        assert_eq!(ctx.pkt.src_port(), LOCAL_PORT);
+        assert_eq!(ctx.pkt.dst_port(), PEER_PORT);
+        assert_eq!(ctx.pkt.type_(), uapi::VSOCK_TYPE_STREAM);
+        assert_eq!(ctx.pkt.len(), 0);
+        // After yielding the response packet, the connection should have transitioned to the
+        // established state.
+        assert_eq!(ctx.conn.state, ConnState::Established);
+    }
+
+    #[test]
+    fn test_local_request() {
+        let mut ctx = CsmTestContext::new(ConnState::LocalInit);
+        // Host-initiated connections should first yield a connection request packet.
+        assert!(ctx.conn.has_pending_rx());
+        // Before yielding the connection request packet, the timeout kill timer shouldn't be
+        // armed.
+        assert!(!ctx.conn.will_expire());
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_REQUEST);
+        // Since the request might time-out, the kill timer should now be armed.
+        assert!(ctx.conn.will_expire());
+        assert!(!ctx.conn.has_expired());
+        ctx.init_pkt(uapi::VSOCK_OP_RESPONSE, 0);
+        ctx.send();
+        // Upon receiving a connection response, the connection should have transitioned to the
+        // established state, and the kill timer should've been disarmed.
+        assert_eq!(ctx.conn.state, ConnState::Established);
+        assert!(!ctx.conn.will_expire());
+    }
+
+    #[test]
+    fn test_local_request_timeout() {
+        let mut ctx = CsmTestContext::new(ConnState::LocalInit);
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_REQUEST);
+        assert!(ctx.conn.will_expire());
+        assert!(!ctx.conn.has_expired());
+        std::thread::sleep(std::time::Duration::from_millis(
+            defs::CONN_REQUEST_TIMEOUT_MS,
+        ));
+        assert!(ctx.conn.has_expired());
+    }
+
+    #[test]
+    fn test_rx_data() {
+        let mut ctx = CsmTestContext::new_established();
+        let data = &[1, 2, 3, 4];
+        ctx.set_stream(TestStream::new_with_read_buf(data));
+        assert_eq!(ctx.conn.get_polled_fd(), ctx.conn.stream.as_raw_fd());
+        ctx.notify_epollin();
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RW);
+        assert_eq!(ctx.pkt.len() as usize, data.len());
+        assert_eq!(ctx.pkt.buf().unwrap()[..ctx.pkt.len() as usize], *data);
+
+        // There's no more data in the stream, so `recv_pkt` should yield `VsockError::NoData`.
+        match ctx.conn.recv_pkt(&mut ctx.pkt) {
+            Err(VsockError::NoData) => (),
+            other => panic!("{:?}", other),
+        }
+
+        // A recv attempt in an invalid state should yield an instant reset packet.
+        ctx.conn.state = ConnState::LocalClosed;
+        ctx.notify_epollin();
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RST);
+    }
+
+    #[test]
+    fn test_local_close() {
+        let mut ctx = CsmTestContext::new_established();
+        let mut stream = TestStream::new();
+        stream.read_state = StreamState::Closed;
+        ctx.set_stream(stream);
+        ctx.notify_epollin();
+        ctx.recv();
+        // When the host-side stream is closed, we can neither send not receive any more data.
+        // Therefore, the vsock shutdown packet that we'll deliver to the guest must contain both
+        // the no-more-send and the no-more-recv indications.
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_SHUTDOWN);
+        assert_ne!(ctx.pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_SEND, 0);
+        assert_ne!(ctx.pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_RCV, 0);
+
+        // The kill timer should now be armed.
+        assert!(ctx.conn.will_expire());
+        assert!(
+            ctx.conn.expiry().unwrap()
+                < Instant::now() + Duration::from_millis(defs::CONN_SHUTDOWN_TIMEOUT_MS)
+        );
+    }
+
+    #[test]
+    fn test_peer_close() {
+        // Test that send/recv shutdown indications are handled correctly.
+        // I.e. once set, an indication cannot be reset.
+        {
+            let mut ctx = CsmTestContext::new_established();
+
+            ctx.init_pkt(uapi::VSOCK_OP_SHUTDOWN, 0)
+                .set_flags(uapi::VSOCK_FLAGS_SHUTDOWN_RCV);
+            ctx.send();
+            assert_eq!(ctx.conn.state, ConnState::PeerClosed(true, false));
+
+            // Attempting to reset the no-more-recv indication should not work
+            // (we are only setting the no-more-send indication here).
+            ctx.pkt.set_flags(uapi::VSOCK_FLAGS_SHUTDOWN_SEND);
+            ctx.send();
+            assert_eq!(ctx.conn.state, ConnState::PeerClosed(true, true));
+        }
+
+        // Test case:
+        // - reading data from a no-more-send connection should work; and
+        // - writing data should have no effect.
+        {
+            let data = &[1, 2, 3, 4];
+            let mut ctx = CsmTestContext::new_established();
+            ctx.set_stream(TestStream::new_with_read_buf(data));
+            ctx.init_pkt(uapi::VSOCK_OP_SHUTDOWN, 0)
+                .set_flags(uapi::VSOCK_FLAGS_SHUTDOWN_SEND);
+            ctx.send();
+            ctx.notify_epollin();
+            ctx.recv();
+            assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RW);
+            assert_eq!(&ctx.pkt.buf().unwrap()[..ctx.pkt.len() as usize], data);
+
+            ctx.init_data_pkt(data);
+            ctx.send();
+            assert_eq!(ctx.conn.stream.write_buf.len(), 0);
+            assert!(ctx.conn.tx_buf.is_empty());
+        }
+
+        // Test case:
+        // - writing data to a no-more-recv connection should work; and
+        // - attempting to read data from it should yield an RST packet.
+        {
+            let mut ctx = CsmTestContext::new_established();
+            ctx.init_pkt(uapi::VSOCK_OP_SHUTDOWN, 0)
+                .set_flags(uapi::VSOCK_FLAGS_SHUTDOWN_RCV);
+            ctx.send();
+            let data = &[1, 2, 3, 4];
+            ctx.init_data_pkt(data);
+            ctx.send();
+            assert_eq!(ctx.conn.stream.write_buf, data.to_vec());
+
+            ctx.notify_epollin();
+            ctx.recv();
+            assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RST);
+        }
+
+        // Test case: setting both no-more-send and no-more-recv indications should have the
+        // connection confirm termination (i.e. yield an RST).
+        {
+            let mut ctx = CsmTestContext::new_established();
+            ctx.init_pkt(uapi::VSOCK_OP_SHUTDOWN, 0)
+                .set_flags(uapi::VSOCK_FLAGS_SHUTDOWN_RCV | uapi::VSOCK_FLAGS_SHUTDOWN_SEND);
+            ctx.send();
+            assert!(ctx.conn.has_pending_rx());
+            ctx.recv();
+            assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RST);
+        }
+    }
+
+    #[test]
+    fn test_local_read_error() {
+        let mut ctx = CsmTestContext::new_established();
+        let mut stream = TestStream::new();
+        stream.read_state = StreamState::Error(ErrorKind::PermissionDenied);
+        ctx.set_stream(stream);
+        ctx.notify_epollin();
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RST);
+    }
+
+    #[test]
+    fn test_credit_request_to_peer() {
+        let mut ctx = CsmTestContext::new_established();
+        ctx.set_peer_credit(0);
+        ctx.notify_epollin();
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_CREDIT_REQUEST);
+    }
+
+    #[test]
+    fn test_credit_request_from_peer() {
+        let mut ctx = CsmTestContext::new_established();
+        ctx.init_pkt(uapi::VSOCK_OP_CREDIT_REQUEST, 0);
+        ctx.send();
+        assert!(ctx.conn.has_pending_rx());
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_CREDIT_UPDATE);
+        assert_eq!(ctx.pkt.buf_alloc(), csm_defs::CONN_TX_BUF_SIZE as u32);
+        assert_eq!(ctx.pkt.fwd_cnt(), ctx.conn.fwd_cnt.0);
+    }
+
+    #[test]
+    fn test_credit_update_to_peer() {
+        let mut ctx = CsmTestContext::new_established();
+
+        // Force a stale state, where the peer hasn't been updated on our credit situation.
+        ctx.conn.last_fwd_cnt_to_peer = Wrapping(0);
+        ctx.conn.fwd_cnt = Wrapping(csm_defs::CONN_CREDIT_UPDATE_THRESHOLD as u32);
+
+        // Fake a data send from the peer, to bring us over the credit update threshold.
+        let data = &[1, 2, 3, 4];
+        ctx.init_data_pkt(data);
+        ctx.send();
+
+        // The CSM should now have a credit update available for the peer.
+        assert!(ctx.conn.has_pending_rx());
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_CREDIT_UPDATE);
+        assert_eq!(
+            ctx.pkt.fwd_cnt() as usize,
+            csm_defs::CONN_CREDIT_UPDATE_THRESHOLD + data.len()
+        );
+        assert_eq!(ctx.conn.fwd_cnt, ctx.conn.last_fwd_cnt_to_peer);
+    }
+
+    #[test]
+    fn test_tx_buffering() {
+        // Test case:
+        // - when writing to the backing stream would block, TX data should end up in the TX buf
+        // - when the CSM is notified that it can write to the backing stream, it should flush
+        //   the TX buf.
+        {
+            let mut ctx = CsmTestContext::new_established();
+
+            let mut stream = TestStream::new();
+            stream.write_state = StreamState::WouldBlock;
+            ctx.set_stream(stream);
+
+            // Send some data through the connection. The backing stream is set to reject writes,
+            // so the data should end up in the TX buffer.
+            let data = &[1, 2, 3, 4];
+            ctx.init_data_pkt(data);
+            ctx.send();
+
+            // When there's data in the TX buffer, the connection should ask to be notified when it
+            // can write to its backing stream.
+            assert!(ctx
+                .conn
+                .get_polled_evset()
+                .contains(epoll::Events::EPOLLOUT));
+            assert_eq!(ctx.conn.tx_buf.len(), data.len());
+
+            // Unlock the write stream and notify the connection it can now write its bufferred
+            // data.
+            ctx.set_stream(TestStream::new());
+            ctx.conn.notify(epoll::Events::EPOLLOUT);
+            assert!(ctx.conn.tx_buf.is_empty());
+            assert_eq!(ctx.conn.stream.write_buf, data);
+        }
+    }
+
+    #[test]
+    fn test_stream_write_error() {
+        // Test case: sending a data packet to a broken / closed backing stream should kill it.
+        {
+            let mut ctx = CsmTestContext::new_established();
+            let mut stream = TestStream::new();
+            stream.write_state = StreamState::Closed;
+            ctx.set_stream(stream);
+
+            let data = &[1, 2, 3, 4];
+            ctx.init_data_pkt(data);
+            ctx.send();
+
+            assert_eq!(ctx.conn.state, ConnState::Killed);
+            assert!(ctx.conn.has_pending_rx());
+            ctx.recv();
+            assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RST);
+        }
+
+        // Test case: notifying a connection that it can flush its TX buffer to a broken stream
+        // should kill the connection.
+        {
+            let mut ctx = CsmTestContext::new_established();
+
+            let mut stream = TestStream::new();
+            stream.write_state = StreamState::WouldBlock;
+            ctx.set_stream(stream);
+
+            // Send some data through the connection. The backing stream is set to reject writes,
+            // so the data should end up in the TX buffer.
+            let data = &[1, 2, 3, 4];
+            ctx.init_data_pkt(data);
+            ctx.send();
+
+            // Set the backing stream to error out on write.
+            let mut stream = TestStream::new();
+            stream.write_state = StreamState::Closed;
+            ctx.set_stream(stream);
+
+            assert!(ctx
+                .conn
+                .get_polled_evset()
+                .contains(epoll::Events::EPOLLOUT));
+            ctx.notify_epollout();
+            assert_eq!(ctx.conn.state, ConnState::Killed);
+        }
+    }
+
+    #[test]
+    fn test_peer_credit_misbehavior() {
+        let mut ctx = CsmTestContext::new_established();
+
+        let mut stream = TestStream::new();
+        stream.write_state = StreamState::WouldBlock;
+        ctx.set_stream(stream);
+
+        // Fill up the TX buffer.
+        let data = vec![0u8; ctx.pkt.buf().unwrap().len()];
+        ctx.init_data_pkt(data.as_slice());
+        for _i in 0..(csm_defs::CONN_TX_BUF_SIZE / data.len()) {
+            ctx.send();
+        }
+
+        // Then try to send more data.
+        ctx.send();
+
+        // The connection should've committed suicide.
+        assert_eq!(ctx.conn.state, ConnState::Killed);
+        assert!(ctx.conn.has_pending_rx());
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RST);
+    }
+}

--- a/vm-virtio/src/vsock/csm/mod.rs
+++ b/vm-virtio/src/vsock/csm/mod.rs
@@ -1,0 +1,129 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+/// This module implements our vsock connection state machine. The heavy lifting is done by
+/// `connection::VsockConnection`, while this file only defines some constants and helper structs.
+///
+mod connection;
+mod txbuf;
+
+pub use connection::VsockConnection;
+
+pub mod defs {
+    /// Vsock connection TX buffer capacity.
+    pub const CONN_TX_BUF_SIZE: usize = 64 * 1024;
+
+    /// After the guest thinks it has filled our TX buffer up to this limit (in bytes), we'll send
+    /// them a credit update packet, to let them know we can handle more.
+    pub const CONN_CREDIT_UPDATE_THRESHOLD: usize = CONN_TX_BUF_SIZE - 4 * 4 * 1024;
+
+    /// Connection request timeout, in millis.
+    pub const CONN_REQUEST_TIMEOUT_MS: u64 = 2000;
+
+    /// Connection graceful shutdown timeout, in millis.
+    pub const CONN_SHUTDOWN_TIMEOUT_MS: u64 = 2000;
+}
+
+#[derive(Debug)]
+pub enum Error {
+    /// Attempted to push data to a full TX buffer.
+    TxBufFull,
+    /// An I/O error occurred, when attempting to flush the connection TX buffer.
+    TxBufFlush(std::io::Error),
+    /// An I/O error occurred, when attempting to write data to the host-side stream.
+    StreamWrite(std::io::Error),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// A vsock connection state.
+///
+#[derive(Debug, PartialEq)]
+pub enum ConnState {
+    /// The connection has been initiated by the host end, but is yet to be confirmed by the guest.
+    LocalInit,
+    /// The connection has been initiated by the guest, but we are yet to confirm it, by sending
+    /// a response packet (VSOCK_OP_RESPONSE).
+    PeerInit,
+    /// The connection handshake has been performed successfully, and data can now be exchanged.
+    Established,
+    /// The host (AF_UNIX) socket was closed.
+    LocalClosed,
+    /// A VSOCK_OP_SHUTDOWN packet was received from the guest. The tuple represents the guest R/W
+    /// indication: (will_not_recv_anymore_data, will_not_send_anymore_data).
+    PeerClosed(bool, bool),
+    /// The connection is scheduled to be forcefully terminated as soon as possible.
+    Killed,
+}
+
+/// An RX indication, used by `VsockConnection` to schedule future `recv_pkt()` responses.
+/// For instance, after being notified that there is available data to be read from the host stream
+/// (via `notify()`), the connection will store a `PendingRx::Rw` to be later inspected by
+/// `recv_pkt()`.
+///
+#[derive(Clone, Copy, PartialEq)]
+enum PendingRx {
+    /// We need to yield a connection request packet (VSOCK_OP_REQUEST).
+    Request = 0,
+    /// We need to yield a connection response packet (VSOCK_OP_RESPONSE).
+    Response = 1,
+    /// We need to yield a forceful connection termination packet (VSOCK_OP_RST).
+    Rst = 2,
+    /// We need to yield a data packet (VSOCK_OP_RW), by reading from the AF_UNIX socket.
+    Rw = 3,
+    /// We need to yield a credit update packet (VSOCK_OP_CREDIT_UPDATE).
+    CreditUpdate = 4,
+}
+impl PendingRx {
+    /// Transform the enum value into a bitmask, that can be used for set operations.
+    ///
+    fn into_mask(self) -> u16 {
+        1u16 << (self as u16)
+    }
+}
+
+/// A set of RX indications (`PendingRx` items).
+///
+struct PendingRxSet {
+    data: u16,
+}
+
+impl PendingRxSet {
+    /// Insert an item into the set.
+    ///
+    fn insert(&mut self, it: PendingRx) {
+        self.data |= it.into_mask();
+    }
+
+    /// Remove an item from the set and return:
+    /// - true, if the item was in the set; or
+    /// - false, if the item wasn't in the set.
+    ///
+    fn remove(&mut self, it: PendingRx) -> bool {
+        let ret = self.contains(it);
+        self.data &= !it.into_mask();
+        ret
+    }
+
+    /// Check if an item is present in this set.
+    ///
+    fn contains(&self, it: PendingRx) -> bool {
+        self.data & it.into_mask() != 0
+    }
+
+    /// Check if the set is empty.
+    ///
+    fn is_empty(&self) -> bool {
+        self.data == 0
+    }
+}
+
+/// Create a set containing only one item.
+///
+impl From<PendingRx> for PendingRxSet {
+    fn from(it: PendingRx) -> Self {
+        Self {
+            data: it.into_mask(),
+        }
+    }
+}

--- a/vm-virtio/src/vsock/csm/txbuf.rs
+++ b/vm-virtio/src/vsock/csm/txbuf.rs
@@ -1,0 +1,279 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::io::Write;
+use std::mem;
+use std::num::Wrapping;
+
+use super::defs;
+use super::{Error, Result};
+
+/// A simple ring-buffer implementation, used by vsock connections to buffer TX (guest -> host)
+/// data.  Memory for this buffer is allocated lazily, since buffering will only be needed when
+/// the host can't read fast enough.
+///
+pub struct TxBuf {
+    /// The actual u8 buffer - only allocated after the first push.
+    data: Option<Box<[u8; Self::SIZE]>>,
+    /// Ring-buffer head offset - where new data is pushed to.
+    head: Wrapping<u32>,
+    /// Ring-buffer tail offset - where data is flushed from.
+    tail: Wrapping<u32>,
+}
+
+impl TxBuf {
+    /// Total buffer size, in bytes.
+    ///
+    const SIZE: usize = defs::CONN_TX_BUF_SIZE;
+
+    /// Ring-buffer constructor.
+    ///
+    pub fn new() -> Self {
+        Self {
+            data: None,
+            head: Wrapping(0),
+            tail: Wrapping(0),
+        }
+    }
+
+    /// Get the used length of this buffer - number of bytes that have been pushed in, but not
+    /// yet flushed out.
+    ///
+    pub fn len(&self) -> usize {
+        (self.head - self.tail).0 as usize
+    }
+
+    /// Push a byte slice onto the ring-buffer.
+    ///
+    /// Either the entire source slice will be pushed to the ring-buffer, or none of it, if
+    /// there isn't enough room, in which case `Err(Error::TxBufFull)` is returned.
+    ///
+    pub fn push(&mut self, src: &[u8]) -> Result<()> {
+        // Error out if there's no room to push the entire slice.
+        if self.len() + src.len() > Self::SIZE {
+            return Err(Error::TxBufFull);
+        }
+
+        // We're using a closure here to return the boxed slice, instead of a value (i.e.
+        // `get_or_insert_with()` instead of `get_or_insert()`), because we only want the box
+        // created when `self.data` is None. If we were to use `get_or_insert(box)`, the box
+        // argument would always get evaluated (which implies a heap allocation), even though
+        // it would later be discarded (when `self.data.is_some()`). Apparently, clippy fails
+        // to see this, and insists on issuing some warning.
+        #[allow(clippy::redundant_closure)]
+        let data = self.data.get_or_insert_with(||
+                // Using uninitialized memory here is quite safe, since we never read from any
+                // area of the buffer before writing to it. First we push, then we flush only
+                // what had been prviously pushed.
+                Box::new(unsafe {mem::uninitialized::<[u8; Self::SIZE]>()}));
+
+        // Buffer head, as an offset into the data slice.
+        let head_ofs = self.head.0 as usize % Self::SIZE;
+
+        // Pushing a slice to this buffer can take either one or two slice copies: - one copy,
+        // if the slice fits between `head_ofs` and `Self::SIZE`; or - two copies, if the
+        // ring-buffer head wraps around.
+
+        // First copy length: we can only go from the head offset up to the total buffer size.
+        let len = std::cmp::min(Self::SIZE - head_ofs, src.len());
+        data[head_ofs..(head_ofs + len)].copy_from_slice(&src[..len]);
+
+        // If the slice didn't fit, the buffer head will wrap around, and pushing continues
+        // from the start of the buffer (`&self.data[0]`).
+        if len < src.len() {
+            data[..(src.len() - len)].copy_from_slice(&src[len..]);
+        }
+
+        // Either way, we've just pushed exactly `src.len()` bytes, so that's the amount by
+        // which the (wrapping) buffer head needs to move forward.
+        self.head += Wrapping(src.len() as u32);
+
+        Ok(())
+    }
+
+    /// Flush the contents of the ring-buffer to a writable stream.
+    ///
+    /// Return the number of bytes that have been transferred out of the ring-buffer and into
+    /// the writable stream.
+    ///
+    pub fn flush_to<W>(&mut self, sink: &mut W) -> Result<usize>
+    where
+        W: Write,
+    {
+        // Nothing to do, if this buffer holds no data.
+        if self.is_empty() {
+            return Ok(0);
+        }
+
+        // Buffer tail, as an offset into the buffer data slice.
+        let tail_ofs = self.tail.0 as usize % Self::SIZE;
+
+        // Flushing the buffer can take either one or two writes:
+        // - one write, if the tail doesn't need to wrap around to reach the head; or
+        // - two writes, if the tail would wrap around: tail to slice end, then slice end to
+        //   head.
+
+        // First write length: the lesser of tail to slice end, or tail to head.
+        let len_to_write = std::cmp::min(Self::SIZE - tail_ofs, self.len());
+
+        // It's safe to unwrap here, since we've already checked if the buffer was empty.
+        let data = self.data.as_ref().unwrap();
+
+        // Issue the first write and absorb any `WouldBlock` error (we can just try again
+        // later).
+        let written = sink
+            .write(&data[tail_ofs..(tail_ofs + len_to_write)])
+            .map_err(Error::TxBufFlush)?;
+
+        // Move the buffer tail ahead by the amount (of bytes) we were able to flush out.
+        self.tail += Wrapping(written as u32);
+
+        // If we weren't able to flush out as much as we tried, there's no point in attempting
+        // our second write.
+        if written < len_to_write {
+            return Ok(written);
+        }
+
+        // Attempt our second write. This will return immediately if a second write isn't
+        // needed, since checking for an empty buffer is the first thing we do in this
+        // function.
+        Ok(written + self.flush_to(sink)?)
+    }
+
+    /// Check if the buffer holds any data that hasn't yet been flushed out.
+    ///
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Error as IoError;
+    use std::io::Result as IoResult;
+    use std::io::{ErrorKind, Write};
+
+    struct TestSink {
+        data: Vec<u8>,
+        err: Option<IoError>,
+        capacity: usize,
+    }
+
+    impl TestSink {
+        const DEFAULT_CAPACITY: usize = 2 * TxBuf::SIZE;
+        fn new() -> Self {
+            Self {
+                data: Vec::with_capacity(Self::DEFAULT_CAPACITY),
+                err: None,
+                capacity: Self::DEFAULT_CAPACITY,
+            }
+        }
+    }
+
+    impl Write for TestSink {
+        fn write(&mut self, src: &[u8]) -> IoResult<usize> {
+            if self.err.is_some() {
+                return Err(self.err.take().unwrap());
+            }
+            let len_to_push = std::cmp::min(self.capacity - self.data.len(), src.len());
+            self.data.extend_from_slice(&src[..len_to_push]);
+            Ok(len_to_push)
+        }
+        fn flush(&mut self) -> IoResult<()> {
+            Ok(())
+        }
+    }
+
+    impl TestSink {
+        fn clear(&mut self) {
+            self.data = Vec::with_capacity(self.capacity);
+            self.err = None;
+        }
+        fn set_err(&mut self, err: IoError) {
+            self.err = Some(err);
+        }
+        fn set_capacity(&mut self, capacity: usize) {
+            self.capacity = capacity;
+            if self.data.len() > self.capacity {
+                self.data.resize(self.capacity, 0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_push_nowrap() {
+        let mut txbuf = TxBuf::new();
+        let mut sink = TestSink::new();
+        assert!(txbuf.is_empty());
+
+        assert!(txbuf.data.is_none());
+        txbuf.push(&[1, 2, 3, 4]).unwrap();
+        txbuf.push(&[5, 6, 7, 8]).unwrap();
+        txbuf.flush_to(&mut sink).unwrap();
+        assert_eq!(sink.data, [1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn test_push_wrap() {
+        let mut txbuf = TxBuf::new();
+        let mut sink = TestSink::new();
+        let mut tmp: Vec<u8> = Vec::new();
+
+        tmp.resize(TxBuf::SIZE - 2, 0);
+        txbuf.push(tmp.as_slice()).unwrap();
+        txbuf.flush_to(&mut sink).unwrap();
+        sink.clear();
+
+        txbuf.push(&[1, 2, 3, 4]).unwrap();
+        assert_eq!(txbuf.flush_to(&mut sink).unwrap(), 4);
+        assert_eq!(sink.data, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_push_error() {
+        let mut txbuf = TxBuf::new();
+        let mut tmp = Vec::with_capacity(TxBuf::SIZE);
+
+        tmp.resize(TxBuf::SIZE - 1, 0);
+        txbuf.push(tmp.as_slice()).unwrap();
+        match txbuf.push(&[1, 2]) {
+            Err(Error::TxBufFull) => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_incomplete_flush() {
+        let mut txbuf = TxBuf::new();
+        let mut sink = TestSink::new();
+
+        sink.set_capacity(2);
+        txbuf.push(&[1, 2, 3, 4]).unwrap();
+        assert_eq!(txbuf.flush_to(&mut sink).unwrap(), 2);
+        assert_eq!(txbuf.len(), 2);
+        assert_eq!(sink.data, [1, 2]);
+
+        sink.set_capacity(4);
+        assert_eq!(txbuf.flush_to(&mut sink).unwrap(), 2);
+        assert!(txbuf.is_empty());
+        assert_eq!(sink.data, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_flush_error() {
+        const EACCESS: i32 = 13;
+
+        let mut txbuf = TxBuf::new();
+        let mut sink = TestSink::new();
+
+        txbuf.push(&[1, 2, 3, 4]).unwrap();
+        let io_err = IoError::from_raw_os_error(EACCESS);
+        sink.set_err(io_err);
+        match txbuf.flush_to(&mut sink) {
+            Err(Error::TxBufFlush(ref err)) if err.kind() == ErrorKind::PermissionDenied => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
+    }
+}

--- a/vm-virtio/src/vsock/device.rs
+++ b/vm-virtio/src/vsock/device.rs
@@ -36,12 +36,12 @@ use std::result;
 use std::sync::{Arc, RwLock};
 use std::thread;
 
-use super::Error as DeviceError;
-use super::{
+use crate::Error as DeviceError;
+use crate::VirtioInterrupt;
+use crate::{
     ActivateError, ActivateResult, DeviceEventT, Queue, VirtioDevice, VirtioDeviceType,
     VIRTIO_F_VERSION_1,
 };
-use crate::VirtioInterrupt;
 use byteorder::{ByteOrder, LittleEndian};
 use vm_memory::GuestMemoryMmap;
 use vmm_sys_util::eventfd::EventFd;

--- a/vm-virtio/src/vsock/mod.rs
+++ b/vm-virtio/src/vsock/mod.rs
@@ -89,6 +89,30 @@ pub enum VsockError {
 }
 type Result<T> = std::result::Result<T, VsockError>;
 
+#[derive(Debug)]
+pub enum VsockEpollHandlerError {
+    /// The vsock data/buffer virtio descriptor length is smaller than expected.
+    BufDescTooSmall,
+    /// The vsock data/buffer virtio descriptor is expected, but missing.
+    BufDescMissing,
+    /// Chained GuestMemory error.
+    GuestMemory,
+    /// Bounds check failed on guest memory pointer.
+    GuestMemoryBounds,
+    /// The vsock header descriptor length is too small.
+    HdrDescTooSmall(u32),
+    /// The vsock header `len` field holds an invalid value.
+    InvalidPktLen(u32),
+    /// A data fetch was attempted when no data was available.
+    NoData,
+    /// A data buffer was expected for the provided packet, but it is missing.
+    PktBufMissing,
+    /// Encountered an unexpected write-only virtio descriptor.
+    UnreadableDescriptor,
+    /// Encountered an unexpected read-only virtio descriptor.
+    UnwritableDescriptor,
+}
+
 /// A passive, event-driven object, that needs to be notified whenever an epoll-able event occurs.
 /// An event-polling control loop will use `get_polled_fd()` and `get_polled_evset()` to query
 /// the listener for the file descriptor and the set of events it's interested in. When such an
@@ -131,3 +155,183 @@ pub trait VsockChannel {
 /// Currently, the only implementation we have is `crate::virtio::unix::muxer::VsockMuxer`, which
 /// translates guest-side vsock connections to host-side Unix domain socket connections.
 pub trait VsockBackend: VsockChannel + VsockEpollListener + Send {}
+
+#[cfg(test)]
+mod tests {
+    use libc::EFD_NONBLOCK;
+
+    use super::device::{VsockEpollHandler, RX_QUEUE_EVENT, TX_QUEUE_EVENT};
+    use super::packet::VSOCK_PKT_HDR_SIZE;
+    use super::*;
+
+    use std::os::unix::io::AsRawFd;
+    use std::sync::{Arc, RwLock};
+    use vmm_sys_util::eventfd::EventFd;
+
+    use crate::device::{VirtioInterrupt, VirtioInterruptType};
+    use crate::queue::tests::VirtQueue as GuestQ;
+    use crate::queue::Queue;
+    use crate::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
+    use vm_memory::{GuestAddress, GuestMemoryMmap};
+
+    pub struct TestBackend {
+        pub evfd: EventFd,
+        pub rx_err: Option<VsockError>,
+        pub tx_err: Option<VsockError>,
+        pub pending_rx: bool,
+        pub rx_ok_cnt: usize,
+        pub tx_ok_cnt: usize,
+        pub evset: Option<epoll::Events>,
+    }
+    impl TestBackend {
+        pub fn new() -> Self {
+            Self {
+                evfd: EventFd::new(EFD_NONBLOCK).unwrap(),
+                rx_err: None,
+                tx_err: None,
+                pending_rx: false,
+                rx_ok_cnt: 0,
+                tx_ok_cnt: 0,
+                evset: None,
+            }
+        }
+        pub fn set_rx_err(&mut self, err: Option<VsockError>) {
+            self.rx_err = err;
+        }
+        pub fn set_tx_err(&mut self, err: Option<VsockError>) {
+            self.tx_err = err;
+        }
+        pub fn set_pending_rx(&mut self, prx: bool) {
+            self.pending_rx = prx;
+        }
+    }
+    impl VsockChannel for TestBackend {
+        fn recv_pkt(&mut self, _pkt: &mut VsockPacket) -> Result<()> {
+            match self.rx_err.take() {
+                None => {
+                    self.rx_ok_cnt += 1;
+                    Ok(())
+                }
+                Some(e) => Err(e),
+            }
+        }
+        fn send_pkt(&mut self, _pkt: &VsockPacket) -> Result<()> {
+            match self.tx_err.take() {
+                None => {
+                    self.tx_ok_cnt += 1;
+                    Ok(())
+                }
+                Some(e) => Err(e),
+            }
+        }
+        fn has_pending_rx(&self) -> bool {
+            self.pending_rx
+        }
+    }
+    impl VsockEpollListener for TestBackend {
+        fn get_polled_fd(&self) -> RawFd {
+            self.evfd.as_raw_fd()
+        }
+        fn get_polled_evset(&self) -> epoll::Events {
+            epoll::Events::EPOLLIN
+        }
+        fn notify(&mut self, evset: epoll::Events) {
+            self.evset = Some(evset);
+        }
+    }
+    impl VsockBackend for TestBackend {}
+
+    pub struct TestContext {
+        pub cid: u64,
+        pub mem: GuestMemoryMmap,
+        pub mem_size: usize,
+        pub device: Vsock<TestBackend>,
+    }
+
+    impl TestContext {
+        pub fn new() -> Self {
+            const CID: u64 = 52;
+            const MEM_SIZE: usize = 1024 * 1024 * 128;
+            Self {
+                cid: CID,
+                mem: GuestMemoryMmap::new(&[(GuestAddress(0), MEM_SIZE)]).unwrap(),
+                mem_size: MEM_SIZE,
+                device: Vsock::new(CID, TestBackend::new()).unwrap(),
+            }
+        }
+
+        pub fn create_epoll_handler_context(&self) -> EpollHandlerContext {
+            const QSIZE: u16 = 2;
+
+            let guest_rxvq = GuestQ::new(GuestAddress(0x0010_0000), &self.mem, QSIZE as u16);
+            let guest_txvq = GuestQ::new(GuestAddress(0x0020_0000), &self.mem, QSIZE as u16);
+            let guest_evvq = GuestQ::new(GuestAddress(0x0030_0000), &self.mem, QSIZE as u16);
+            let rxvq = guest_rxvq.create_queue();
+            let txvq = guest_txvq.create_queue();
+            let evvq = guest_evvq.create_queue();
+
+            // Set up one available descriptor in the RX queue.
+            guest_rxvq.dtable[0].set(
+                0x0040_0000,
+                VSOCK_PKT_HDR_SIZE as u32,
+                VIRTQ_DESC_F_WRITE | VIRTQ_DESC_F_NEXT,
+                1,
+            );
+            guest_rxvq.dtable[1].set(0x0040_1000, 4096, VIRTQ_DESC_F_WRITE, 0);
+            guest_rxvq.avail.ring[0].set(0);
+            guest_rxvq.avail.idx.set(1);
+
+            // Set up one available descriptor in the TX queue.
+            guest_txvq.dtable[0].set(0x0050_0000, VSOCK_PKT_HDR_SIZE as u32, VIRTQ_DESC_F_NEXT, 1);
+            guest_txvq.dtable[1].set(0x0050_1000, 4096, 0, 0);
+            guest_txvq.avail.ring[0].set(0);
+            guest_txvq.avail.idx.set(1);
+
+            let queues = vec![rxvq, txvq, evvq];
+            let queue_evts = vec![
+                EventFd::new(EFD_NONBLOCK).unwrap(),
+                EventFd::new(EFD_NONBLOCK).unwrap(),
+                EventFd::new(EFD_NONBLOCK).unwrap(),
+            ];
+            let interrupt_cb = Arc::new(Box::new(
+                move |_: &VirtioInterruptType, _: Option<&Queue>| Ok(()),
+            ) as VirtioInterrupt);
+
+            EpollHandlerContext {
+                guest_rxvq,
+                guest_txvq,
+                guest_evvq,
+                handler: VsockEpollHandler {
+                    mem: Arc::new(RwLock::new(self.mem.clone())),
+                    queues,
+                    queue_evts,
+                    kill_evt: EventFd::new(EFD_NONBLOCK).unwrap(),
+                    interrupt_cb,
+                    backend: TestBackend::new(),
+                },
+            }
+        }
+    }
+
+    pub struct EpollHandlerContext<'a> {
+        pub handler: VsockEpollHandler<TestBackend>,
+        pub guest_rxvq: GuestQ<'a>,
+        pub guest_txvq: GuestQ<'a>,
+        pub guest_evvq: GuestQ<'a>,
+    }
+
+    impl<'a> EpollHandlerContext<'a> {
+        pub fn signal_txq_event(&mut self) {
+            self.handler.queue_evts[1].write(1).unwrap();
+            self.handler
+                .handle_event(TX_QUEUE_EVENT, epoll::Events::EPOLLIN)
+                .unwrap();
+        }
+        pub fn signal_rxq_event(&mut self) {
+            self.handler.queue_evts[0].write(1).unwrap();
+            self.handler
+                .handle_event(RX_QUEUE_EVENT, epoll::Events::EPOLLIN)
+                .unwrap();
+        }
+    }
+}

--- a/vm-virtio/src/vsock/mod.rs
+++ b/vm-virtio/src/vsock/mod.rs
@@ -14,6 +14,8 @@ mod packet;
 mod unix;
 
 pub use self::device::Vsock;
+pub use self::unix::VsockUnixBackend;
+pub use self::unix::VsockUnixError;
 
 use std::os::unix::io::RawFd;
 

--- a/vm-virtio/src/vsock/mod.rs
+++ b/vm-virtio/src/vsock/mod.rs
@@ -8,6 +8,123 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the THIRD-PARTY file.
 
+mod csm;
 mod device;
+mod packet;
 
 pub use self::device::Vsock;
+
+use std::os::unix::io::RawFd;
+
+use packet::VsockPacket;
+
+mod defs {
+
+    /// Max vsock packet data/buffer size.
+    pub const MAX_PKT_BUF_SIZE: usize = 64 * 1024;
+
+    pub mod uapi {
+
+        /// Vsock packet operation IDs.
+        /// Defined in `/include/uapi/linux/virtio_vsock.h`.
+        ///
+        /// Connection request.
+        pub const VSOCK_OP_REQUEST: u16 = 1;
+        /// Connection response.
+        pub const VSOCK_OP_RESPONSE: u16 = 2;
+        /// Connection reset.
+        pub const VSOCK_OP_RST: u16 = 3;
+        /// Connection clean shutdown.
+        pub const VSOCK_OP_SHUTDOWN: u16 = 4;
+        /// Connection data (read/write).
+        pub const VSOCK_OP_RW: u16 = 5;
+        /// Flow control credit update.
+        pub const VSOCK_OP_CREDIT_UPDATE: u16 = 6;
+        /// Flow control credit update request.
+        pub const VSOCK_OP_CREDIT_REQUEST: u16 = 7;
+
+        /// Vsock packet flags.
+        /// Defined in `/include/uapi/linux/virtio_vsock.h`.
+        ///
+        /// Valid with a VSOCK_OP_SHUTDOWN packet: the packet sender will receive no more data.
+        pub const VSOCK_FLAGS_SHUTDOWN_RCV: u32 = 1;
+        /// Valid with a VSOCK_OP_SHUTDOWN packet: the packet sender will send no more data.
+        pub const VSOCK_FLAGS_SHUTDOWN_SEND: u32 = 2;
+
+        /// Vsock packet type.
+        /// Defined in `/include/uapi/linux/virtio_vsock.h`.
+        ///
+        /// Stream / connection-oriented packet (the only currently valid type).
+        pub const VSOCK_TYPE_STREAM: u16 = 1;
+
+        pub const VSOCK_HOST_CID: u64 = 2;
+    }
+}
+
+#[derive(Debug)]
+pub enum VsockError {
+    /// The vsock data/buffer virtio descriptor length is smaller than expected.
+    BufDescTooSmall,
+    /// The vsock data/buffer virtio descriptor is expected, but missing.
+    BufDescMissing,
+    /// Chained GuestMemory error.
+    GuestMemory,
+    /// Bounds check failed on guest memory pointer.
+    GuestMemoryBounds,
+    /// The vsock header descriptor length is too small.
+    HdrDescTooSmall(u32),
+    /// The vsock header `len` field holds an invalid value.
+    InvalidPktLen(u32),
+    /// A data fetch was attempted when no data was available.
+    NoData,
+    /// A data buffer was expected for the provided packet, but it is missing.
+    PktBufMissing,
+    /// Encountered an unexpected write-only virtio descriptor.
+    UnreadableDescriptor,
+    /// Encountered an unexpected read-only virtio descriptor.
+    UnwritableDescriptor,
+}
+type Result<T> = std::result::Result<T, VsockError>;
+
+/// A passive, event-driven object, that needs to be notified whenever an epoll-able event occurs.
+/// An event-polling control loop will use `get_polled_fd()` and `get_polled_evset()` to query
+/// the listener for the file descriptor and the set of events it's interested in. When such an
+/// event occurs, the control loop will route the event to the listener via `notify()`.
+///
+pub trait VsockEpollListener {
+    /// Get the file descriptor the listener needs polled.
+    fn get_polled_fd(&self) -> RawFd;
+
+    /// Get the set of events for which the listener wants to be notified.
+    fn get_polled_evset(&self) -> epoll::Events;
+
+    /// Notify the listener that one ore more events have occurred.
+    fn notify(&mut self, evset: epoll::Events);
+}
+
+/// Any channel that handles vsock packet traffic: sending and receiving packets. Since we're
+/// implementing the device model here, our responsibility is to always process the sending of
+/// packets (i.e. the TX queue). So, any locally generated data, addressed to the driver (e.g.
+/// a connection response or RST), will have to be queued, until we get to processing the RX queue.
+///
+/// Note: `recv_pkt()` and `send_pkt()` are named analogous to `Read::read()` and `Write::write()`,
+///       respectively. I.e.
+///       - `recv_pkt(&mut pkt)` will read data from the channel, and place it into `pkt`; and
+///       - `send_pkt(&pkt)` will fetch data from `pkt`, and place it into the channel.
+pub trait VsockChannel {
+    /// Read/receive an incoming packet from the channel.
+    fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> Result<()>;
+
+    /// Write/send a packet through the channel.
+    fn send_pkt(&mut self, pkt: &VsockPacket) -> Result<()>;
+
+    /// Checks whether there is pending incoming data inside the channel, meaning that a subsequent
+    /// call to `recv_pkt()` won't fail.
+    fn has_pending_rx(&self) -> bool;
+}
+
+/// The vsock backend, which is basically an epoll-event-driven vsock channel, that needs to be
+/// sendable through a mpsc channel (the latter due to how `vmm::EpollContext` works).
+/// Currently, the only implementation we have is `crate::virtio::unix::muxer::VsockMuxer`, which
+/// translates guest-side vsock connections to host-side Unix domain socket connections.
+pub trait VsockBackend: VsockChannel + VsockEpollListener + Send {}

--- a/vm-virtio/src/vsock/mod.rs
+++ b/vm-virtio/src/vsock/mod.rs
@@ -11,6 +11,7 @@
 mod csm;
 mod device;
 mod packet;
+mod unix;
 
 pub use self::device::Vsock;
 

--- a/vm-virtio/src/vsock/mod.rs
+++ b/vm-virtio/src/vsock/mod.rs
@@ -1,0 +1,13 @@
+// Copyright 2019 Intel Corporation. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+mod device;
+
+pub use self::device::Vsock;

--- a/vm-virtio/src/vsock/packet.rs
+++ b/vm-virtio/src/vsock/packet.rs
@@ -1,0 +1,341 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// `VsockPacket` provides a thin wrapper over the buffers exchanged via virtio queues.
+/// There are two components to a vsock packet, each using its own descriptor in a
+/// virtio queue:
+/// - the packet header; and
+/// - the packet data/buffer.
+/// There is a 1:1 relation between descriptor chains and packets: the first (chain head) holds
+/// the header, and an optional second descriptor holds the data. The second descriptor is only
+/// present for data packets (VSOCK_OP_RW).
+///
+/// `VsockPacket` wraps these two buffers and provides direct access to the data stored
+/// in guest memory. This is done to avoid unnecessarily copying data from guest memory
+/// to temporary buffers, before passing it on to the vsock backend.
+///
+use byteorder::{ByteOrder, LittleEndian};
+
+use super::super::DescriptorChain;
+use super::defs;
+use super::{Result, VsockError};
+
+// The vsock packet header is defined by the C struct:
+//
+// ```C
+// struct virtio_vsock_hdr {
+//     le64 src_cid;
+//     le64 dst_cid;
+//     le32 src_port;
+//     le32 dst_port;
+//     le32 len;
+//     le16 type;
+//     le16 op;
+//     le32 flags;
+//     le32 buf_alloc;
+//     le32 fwd_cnt;
+// };
+// ```
+//
+// This structed will occupy the buffer pointed to by the head descriptor. We'll be accessing it
+// as a byte slice. To that end, we define below the offsets for each field struct, as well as the
+// packed struct size, as a bunch of `usize` consts.
+// Note that these offsets are only used privately by the `VsockPacket` struct, the public interface
+// consisting of getter and setter methods, for each struct field, that will also handle the correct
+// endianess.
+
+/// The vsock packet header struct size (when packed).
+pub const VSOCK_PKT_HDR_SIZE: usize = 44;
+
+// Source CID.
+const HDROFF_SRC_CID: usize = 0;
+
+// Destination CID.
+const HDROFF_DST_CID: usize = 8;
+
+// Source port.
+const HDROFF_SRC_PORT: usize = 16;
+
+// Destination port.
+const HDROFF_DST_PORT: usize = 20;
+
+// Data length (in bytes) - may be 0, if there is no data buffer.
+const HDROFF_LEN: usize = 24;
+
+// Socket type. Currently, only connection-oriented streams are defined by the vsock protocol.
+const HDROFF_TYPE: usize = 28;
+
+// Operation ID - one of the VSOCK_OP_* values; e.g.
+// - VSOCK_OP_RW: a data packet;
+// - VSOCK_OP_REQUEST: connection request;
+// - VSOCK_OP_RST: forcefull connection termination;
+// etc (see `super::defs::uapi` for the full list).
+const HDROFF_OP: usize = 30;
+
+// Additional options (flags) associated with the current operation (`op`).
+// Currently, only used with shutdown requests (VSOCK_OP_SHUTDOWN).
+const HDROFF_FLAGS: usize = 32;
+
+// Size (in bytes) of the packet sender receive buffer (for the connection to which this packet
+// belongs).
+const HDROFF_BUF_ALLOC: usize = 36;
+
+// Number of bytes the sender has received and consumed (for the connection to which this packet
+// belongs). For instance, for our Unix backend, this counter would be the total number of bytes
+// we have successfully written to a backing Unix socket.
+const HDROFF_FWD_CNT: usize = 40;
+
+/// The vsock packet, implemented as a wrapper over a virtq descriptor chain:
+/// - the chain head, holding the packet header; and
+/// - (an optional) data/buffer descriptor, only present for data packets (VSOCK_OP_RW).
+///
+pub struct VsockPacket {
+    hdr: *mut u8,
+    buf: Option<*mut u8>,
+    buf_size: usize,
+}
+
+impl VsockPacket {
+    /// Create the packet wrapper from a TX virtq chain head.
+    ///
+    /// The chain head is expected to hold valid packet header data. A following packet buffer
+    /// descriptor can optionally end the chain. Bounds and pointer checks are performed when
+    /// creating the wrapper.
+    ///
+    pub fn from_tx_virtq_head(head: &DescriptorChain) -> Result<Self> {
+        // All buffers in the TX queue must be readable.
+        //
+        if head.is_write_only() {
+            return Err(VsockError::UnreadableDescriptor);
+        }
+
+        // The packet header should fit inside the head descriptor.
+        if head.len < VSOCK_PKT_HDR_SIZE as u32 {
+            return Err(VsockError::HdrDescTooSmall(head.len));
+        }
+
+        let mut pkt = Self {
+            hdr: head
+                .mem
+                .get_host_address(head.addr)
+                .ok_or_else(|| VsockError::GuestMemory)? as *mut u8,
+            buf: None,
+            buf_size: 0,
+        };
+
+        // No point looking for a data/buffer descriptor, if the packet is zero-lengthed.
+        if pkt.len() == 0 {
+            return Ok(pkt);
+        }
+
+        // Reject weirdly-sized packets.
+        //
+        if pkt.len() > defs::MAX_PKT_BUF_SIZE as u32 {
+            return Err(VsockError::InvalidPktLen(pkt.len()));
+        }
+
+        // If the packet header showed a non-zero length, there should be a data descriptor here.
+        let buf_desc = head.next_descriptor().ok_or(VsockError::BufDescMissing)?;
+
+        // TX data should be read-only.
+        if buf_desc.is_write_only() {
+            return Err(VsockError::UnreadableDescriptor);
+        }
+
+        // The data buffer should be large enough to fit the size of the data, as described by
+        // the header descriptor.
+        if buf_desc.len < pkt.len() {
+            return Err(VsockError::BufDescTooSmall);
+        }
+
+        pkt.buf_size = buf_desc.len as usize;
+        pkt.buf = Some(
+            buf_desc
+                .mem
+                .get_host_address(buf_desc.addr)
+                .ok_or_else(|| VsockError::GuestMemory)? as *mut u8,
+        );
+
+        Ok(pkt)
+    }
+
+    /// Create the packet wrapper from an RX virtq chain head.
+    ///
+    /// There must be two descriptors in the chain, both writable: a header descriptor and a data
+    /// descriptor. Bounds and pointer checks are performed when creating the wrapper.
+    ///
+    pub fn from_rx_virtq_head(head: &DescriptorChain) -> Result<Self> {
+        // All RX buffers must be writable.
+        //
+        if !head.is_write_only() {
+            return Err(VsockError::UnwritableDescriptor);
+        }
+
+        // The packet header should fit inside the head descriptor.
+        if head.len < VSOCK_PKT_HDR_SIZE as u32 {
+            return Err(VsockError::HdrDescTooSmall(head.len));
+        }
+
+        // All RX descriptor chains should have a header and a data descriptor.
+        if !head.has_next() {
+            return Err(VsockError::BufDescMissing);
+        }
+        let buf_desc = head.next_descriptor().ok_or(VsockError::BufDescMissing)?;
+
+        Ok(Self {
+            hdr: head
+                .mem
+                .get_host_address(head.addr)
+                .ok_or_else(|| VsockError::GuestMemory)? as *mut u8,
+            buf: Some(
+                buf_desc
+                    .mem
+                    .get_host_address(buf_desc.addr)
+                    .ok_or_else(|| VsockError::GuestMemory)? as *mut u8,
+            ),
+            buf_size: buf_desc.len as usize,
+        })
+    }
+
+    /// Provides in-place, byte-slice, access to the vsock packet header.
+    ///
+    pub fn hdr(&self) -> &[u8] {
+        // This is safe since bound checks have already been performed when creating the packet
+        // from the virtq descriptor.
+        unsafe { std::slice::from_raw_parts(self.hdr as *const u8, VSOCK_PKT_HDR_SIZE) }
+    }
+
+    /// Provides in-place, byte-slice, mutable access to the vsock packet header.
+    ///
+    pub fn hdr_mut(&mut self) -> &mut [u8] {
+        // This is safe since bound checks have already been performed when creating the packet
+        // from the virtq descriptor.
+        unsafe { std::slice::from_raw_parts_mut(self.hdr, VSOCK_PKT_HDR_SIZE) }
+    }
+
+    /// Provides in-place, byte-slice access to the vsock packet data buffer.
+    ///
+    /// Note: control packets (e.g. connection request or reset) have no data buffer associated.
+    ///       For those packets, this method will return `None`.
+    /// Also note: calling `len()` on the returned slice will yield the buffer size, which may be
+    ///            (and often is) larger than the length of the packet data. The packet data length
+    ///            is stored in the packet header, and accessible via `VsockPacket::len()`.
+    pub fn buf(&self) -> Option<&[u8]> {
+        self.buf.map(|ptr| {
+            // This is safe since bound checks have already been performed when creating the packet
+            // from the virtq descriptor.
+            unsafe { std::slice::from_raw_parts(ptr as *const u8, self.buf_size) }
+        })
+    }
+
+    /// Provides in-place, byte-slice, mutable access to the vsock packet data buffer.
+    ///
+    /// Note: control packets (e.g. connection request or reset) have no data buffer associated.
+    ///       For those packets, this method will return `None`.
+    /// Also note: calling `len()` on the returned slice will yield the buffer size, which may be
+    ///            (and often is) larger than the length of the packet data. The packet data length
+    ///            is stored in the packet header, and accessible via `VsockPacket::len()`.
+    pub fn buf_mut(&mut self) -> Option<&mut [u8]> {
+        self.buf.map(|ptr| {
+            // This is safe since bound checks have already been performed when creating the packet
+            // from the virtq descriptor.
+            unsafe { std::slice::from_raw_parts_mut(ptr, self.buf_size) }
+        })
+    }
+
+    pub fn src_cid(&self) -> u64 {
+        LittleEndian::read_u64(&self.hdr()[HDROFF_SRC_CID..])
+    }
+
+    pub fn set_src_cid(&mut self, cid: u64) -> &mut Self {
+        LittleEndian::write_u64(&mut self.hdr_mut()[HDROFF_SRC_CID..], cid);
+        self
+    }
+
+    pub fn dst_cid(&self) -> u64 {
+        LittleEndian::read_u64(&self.hdr()[HDROFF_DST_CID..])
+    }
+
+    pub fn set_dst_cid(&mut self, cid: u64) -> &mut Self {
+        LittleEndian::write_u64(&mut self.hdr_mut()[HDROFF_DST_CID..], cid);
+        self
+    }
+
+    pub fn src_port(&self) -> u32 {
+        LittleEndian::read_u32(&self.hdr()[HDROFF_SRC_PORT..])
+    }
+
+    pub fn set_src_port(&mut self, port: u32) -> &mut Self {
+        LittleEndian::write_u32(&mut self.hdr_mut()[HDROFF_SRC_PORT..], port);
+        self
+    }
+
+    pub fn dst_port(&self) -> u32 {
+        LittleEndian::read_u32(&self.hdr()[HDROFF_DST_PORT..])
+    }
+
+    pub fn set_dst_port(&mut self, port: u32) -> &mut Self {
+        LittleEndian::write_u32(&mut self.hdr_mut()[HDROFF_DST_PORT..], port);
+        self
+    }
+
+    pub fn len(&self) -> u32 {
+        LittleEndian::read_u32(&self.hdr()[HDROFF_LEN..])
+    }
+
+    pub fn set_len(&mut self, len: u32) -> &mut Self {
+        LittleEndian::write_u32(&mut self.hdr_mut()[HDROFF_LEN..], len);
+        self
+    }
+
+    pub fn type_(&self) -> u16 {
+        LittleEndian::read_u16(&self.hdr()[HDROFF_TYPE..])
+    }
+
+    pub fn set_type(&mut self, type_: u16) -> &mut Self {
+        LittleEndian::write_u16(&mut self.hdr_mut()[HDROFF_TYPE..], type_);
+        self
+    }
+
+    pub fn op(&self) -> u16 {
+        LittleEndian::read_u16(&self.hdr()[HDROFF_OP..])
+    }
+
+    pub fn set_op(&mut self, op: u16) -> &mut Self {
+        LittleEndian::write_u16(&mut self.hdr_mut()[HDROFF_OP..], op);
+        self
+    }
+
+    pub fn flags(&self) -> u32 {
+        LittleEndian::read_u32(&self.hdr()[HDROFF_FLAGS..])
+    }
+
+    pub fn set_flags(&mut self, flags: u32) -> &mut Self {
+        LittleEndian::write_u32(&mut self.hdr_mut()[HDROFF_FLAGS..], flags);
+        self
+    }
+
+    pub fn set_flag(&mut self, flag: u32) -> &mut Self {
+        self.set_flags(self.flags() | flag);
+        self
+    }
+
+    pub fn buf_alloc(&self) -> u32 {
+        LittleEndian::read_u32(&self.hdr()[HDROFF_BUF_ALLOC..])
+    }
+
+    pub fn set_buf_alloc(&mut self, buf_alloc: u32) -> &mut Self {
+        LittleEndian::write_u32(&mut self.hdr_mut()[HDROFF_BUF_ALLOC..], buf_alloc);
+        self
+    }
+
+    pub fn fwd_cnt(&self) -> u32 {
+        LittleEndian::read_u32(&self.hdr()[HDROFF_FWD_CNT..])
+    }
+
+    pub fn set_fwd_cnt(&mut self, fwd_cnt: u32) -> &mut Self {
+        LittleEndian::write_u32(&mut self.hdr_mut()[HDROFF_FWD_CNT..], fwd_cnt);
+        self
+    }
+}

--- a/vm-virtio/src/vsock/packet.rs
+++ b/vm-virtio/src/vsock/packet.rs
@@ -339,3 +339,319 @@ impl VsockPacket {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use vm_memory::{GuestAddress, GuestMemoryMmap};
+
+    use super::super::tests::TestContext;
+    use super::*;
+    use crate::queue::tests::VirtqDesc as GuestQDesc;
+    use crate::vsock::defs::MAX_PKT_BUF_SIZE;
+    use crate::VIRTQ_DESC_F_WRITE;
+
+    macro_rules! create_context {
+        ($test_ctx:ident, $handler_ctx:ident) => {
+            let $test_ctx = TestContext::new();
+            let mut $handler_ctx = $test_ctx.create_epoll_handler_context();
+            // For TX packets, hdr.len should be set to a valid value.
+            set_pkt_len(1024, &$handler_ctx.guest_txvq.dtable[0], &$test_ctx.mem);
+        };
+    }
+
+    macro_rules! expect_asm_error {
+        (tx, $test_ctx:expr, $handler_ctx:expr, $err:pat) => {
+            expect_asm_error!($test_ctx, $handler_ctx, $err, from_tx_virtq_head, 1);
+        };
+        (rx, $test_ctx:expr, $handler_ctx:expr, $err:pat) => {
+            expect_asm_error!($test_ctx, $handler_ctx, $err, from_rx_virtq_head, 0);
+        };
+        ($test_ctx:expr, $handler_ctx:expr, $err:pat, $ctor:ident, $vq:expr) => {
+            match VsockPacket::$ctor(
+                &$handler_ctx.handler.queues[$vq]
+                    .iter(&$test_ctx.mem)
+                    .next()
+                    .unwrap(),
+            ) {
+                Err($err) => (),
+                Ok(_) => panic!("Packet assembly should've failed!"),
+                Err(other) => panic!("Packet assembly failed with: {:?}", other),
+            }
+        };
+    }
+
+    fn set_pkt_len(len: u32, guest_desc: &GuestQDesc, mem: &GuestMemoryMmap) {
+        let hdr_gpa = guest_desc.addr.get();
+        let hdr_ptr = mem.get_host_address(GuestAddress(hdr_gpa)).unwrap() as *mut u8;
+        let len_ptr = unsafe { hdr_ptr.add(HDROFF_LEN) };
+
+        LittleEndian::write_u32(unsafe { std::slice::from_raw_parts_mut(len_ptr, 4) }, len);
+    }
+
+    #[test]
+    #[allow(clippy::cognitive_complexity)]
+    fn test_tx_packet_assembly() {
+        // Test case: successful TX packet assembly.
+        {
+            create_context!(test_ctx, handler_ctx);
+
+            let pkt = VsockPacket::from_tx_virtq_head(
+                &handler_ctx.handler.queues[1]
+                    .iter(&test_ctx.mem)
+                    .next()
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(pkt.hdr().len(), VSOCK_PKT_HDR_SIZE);
+            assert_eq!(
+                pkt.buf().unwrap().len(),
+                handler_ctx.guest_txvq.dtable[1].len.get() as usize
+            );
+        }
+
+        // Test case: error on write-only hdr descriptor.
+        {
+            create_context!(test_ctx, handler_ctx);
+            handler_ctx.guest_txvq.dtable[0]
+                .flags
+                .set(VIRTQ_DESC_F_WRITE);
+            expect_asm_error!(tx, test_ctx, handler_ctx, VsockError::UnreadableDescriptor);
+        }
+
+        // Test case: header descriptor has insufficient space to hold the packet header.
+        {
+            create_context!(test_ctx, handler_ctx);
+            handler_ctx.guest_txvq.dtable[0]
+                .len
+                .set(VSOCK_PKT_HDR_SIZE as u32 - 1);
+            expect_asm_error!(tx, test_ctx, handler_ctx, VsockError::HdrDescTooSmall(_));
+        }
+
+        // Test case: zero-length TX packet.
+        {
+            create_context!(test_ctx, handler_ctx);
+            set_pkt_len(0, &handler_ctx.guest_txvq.dtable[0], &test_ctx.mem);
+            let mut pkt = VsockPacket::from_tx_virtq_head(
+                &handler_ctx.handler.queues[1]
+                    .iter(&test_ctx.mem)
+                    .next()
+                    .unwrap(),
+            )
+            .unwrap();
+            assert!(pkt.buf().is_none());
+            assert!(pkt.buf_mut().is_none());
+        }
+
+        // Test case: TX packet has more data than we can handle.
+        {
+            create_context!(test_ctx, handler_ctx);
+            set_pkt_len(
+                MAX_PKT_BUF_SIZE as u32 + 1,
+                &handler_ctx.guest_txvq.dtable[0],
+                &test_ctx.mem,
+            );
+            expect_asm_error!(tx, test_ctx, handler_ctx, VsockError::InvalidPktLen(_));
+        }
+
+        // Test case:
+        // - packet header advertises some data length; and
+        // - the data descriptor is missing.
+        {
+            create_context!(test_ctx, handler_ctx);
+            set_pkt_len(1024, &handler_ctx.guest_txvq.dtable[0], &test_ctx.mem);
+            handler_ctx.guest_txvq.dtable[0].flags.set(0);
+            expect_asm_error!(tx, test_ctx, handler_ctx, VsockError::BufDescMissing);
+        }
+
+        // Test case: error on write-only buf descriptor.
+        {
+            create_context!(test_ctx, handler_ctx);
+            handler_ctx.guest_txvq.dtable[1]
+                .flags
+                .set(VIRTQ_DESC_F_WRITE);
+            expect_asm_error!(tx, test_ctx, handler_ctx, VsockError::UnreadableDescriptor);
+        }
+
+        // Test case: the buffer descriptor cannot fit all the data advertised by the the
+        // packet header `len` field.
+        {
+            create_context!(test_ctx, handler_ctx);
+            set_pkt_len(8 * 1024, &handler_ctx.guest_txvq.dtable[0], &test_ctx.mem);
+            handler_ctx.guest_txvq.dtable[1].len.set(4 * 1024);
+            expect_asm_error!(tx, test_ctx, handler_ctx, VsockError::BufDescTooSmall);
+        }
+    }
+
+    #[test]
+    fn test_rx_packet_assembly() {
+        // Test case: successful RX packet assembly.
+        {
+            create_context!(test_ctx, handler_ctx);
+            let pkt = VsockPacket::from_rx_virtq_head(
+                &handler_ctx.handler.queues[0]
+                    .iter(&test_ctx.mem)
+                    .next()
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(pkt.hdr().len(), VSOCK_PKT_HDR_SIZE);
+            assert_eq!(
+                pkt.buf().unwrap().len(),
+                handler_ctx.guest_rxvq.dtable[1].len.get() as usize
+            );
+        }
+
+        // Test case: read-only RX packet header.
+        {
+            create_context!(test_ctx, handler_ctx);
+            handler_ctx.guest_rxvq.dtable[0].flags.set(0);
+            expect_asm_error!(rx, test_ctx, handler_ctx, VsockError::UnwritableDescriptor);
+        }
+
+        // Test case: RX descriptor head cannot fit the entire packet header.
+        {
+            create_context!(test_ctx, handler_ctx);
+            handler_ctx.guest_rxvq.dtable[0]
+                .len
+                .set(VSOCK_PKT_HDR_SIZE as u32 - 1);
+            expect_asm_error!(rx, test_ctx, handler_ctx, VsockError::HdrDescTooSmall(_));
+        }
+
+        // Test case: RX descriptor chain is missing the packet buffer descriptor.
+        {
+            create_context!(test_ctx, handler_ctx);
+            handler_ctx.guest_rxvq.dtable[0]
+                .flags
+                .set(VIRTQ_DESC_F_WRITE);
+            expect_asm_error!(rx, test_ctx, handler_ctx, VsockError::BufDescMissing);
+        }
+    }
+
+    #[test]
+    #[allow(clippy::cognitive_complexity)]
+    fn test_packet_hdr_accessors() {
+        const SRC_CID: u64 = 1;
+        const DST_CID: u64 = 2;
+        const SRC_PORT: u32 = 3;
+        const DST_PORT: u32 = 4;
+        const LEN: u32 = 5;
+        const TYPE: u16 = 6;
+        const OP: u16 = 7;
+        const FLAGS: u32 = 8;
+        const BUF_ALLOC: u32 = 9;
+        const FWD_CNT: u32 = 10;
+
+        create_context!(test_ctx, handler_ctx);
+        let mut pkt = VsockPacket::from_rx_virtq_head(
+            &handler_ctx.handler.queues[0]
+                .iter(&test_ctx.mem)
+                .next()
+                .unwrap(),
+        )
+        .unwrap();
+
+        // Test field accessors.
+        pkt.set_src_cid(SRC_CID)
+            .set_dst_cid(DST_CID)
+            .set_src_port(SRC_PORT)
+            .set_dst_port(DST_PORT)
+            .set_len(LEN)
+            .set_type(TYPE)
+            .set_op(OP)
+            .set_flags(FLAGS)
+            .set_buf_alloc(BUF_ALLOC)
+            .set_fwd_cnt(FWD_CNT);
+
+        assert_eq!(pkt.src_cid(), SRC_CID);
+        assert_eq!(pkt.dst_cid(), DST_CID);
+        assert_eq!(pkt.src_port(), SRC_PORT);
+        assert_eq!(pkt.dst_port(), DST_PORT);
+        assert_eq!(pkt.len(), LEN);
+        assert_eq!(pkt.type_(), TYPE);
+        assert_eq!(pkt.op(), OP);
+        assert_eq!(pkt.flags(), FLAGS);
+        assert_eq!(pkt.buf_alloc(), BUF_ALLOC);
+        assert_eq!(pkt.fwd_cnt(), FWD_CNT);
+
+        // Test individual flag setting.
+        let flags = pkt.flags() | 0b1000;
+        pkt.set_flag(0b1000);
+        assert_eq!(pkt.flags(), flags);
+
+        // Test packet header as-slice access.
+        //
+
+        assert_eq!(pkt.hdr().len(), VSOCK_PKT_HDR_SIZE);
+
+        assert_eq!(
+            SRC_CID,
+            LittleEndian::read_u64(&pkt.hdr()[HDROFF_SRC_CID..])
+        );
+        assert_eq!(
+            DST_CID,
+            LittleEndian::read_u64(&pkt.hdr()[HDROFF_DST_CID..])
+        );
+        assert_eq!(
+            SRC_PORT,
+            LittleEndian::read_u32(&pkt.hdr()[HDROFF_SRC_PORT..])
+        );
+        assert_eq!(
+            DST_PORT,
+            LittleEndian::read_u32(&pkt.hdr()[HDROFF_DST_PORT..])
+        );
+        assert_eq!(LEN, LittleEndian::read_u32(&pkt.hdr()[HDROFF_LEN..]));
+        assert_eq!(TYPE, LittleEndian::read_u16(&pkt.hdr()[HDROFF_TYPE..]));
+        assert_eq!(OP, LittleEndian::read_u16(&pkt.hdr()[HDROFF_OP..]));
+        assert_eq!(FLAGS, LittleEndian::read_u32(&pkt.hdr()[HDROFF_FLAGS..]));
+        assert_eq!(
+            BUF_ALLOC,
+            LittleEndian::read_u32(&pkt.hdr()[HDROFF_BUF_ALLOC..])
+        );
+        assert_eq!(
+            FWD_CNT,
+            LittleEndian::read_u32(&pkt.hdr()[HDROFF_FWD_CNT..])
+        );
+
+        assert_eq!(pkt.hdr_mut().len(), VSOCK_PKT_HDR_SIZE);
+        for b in pkt.hdr_mut() {
+            *b = 0;
+        }
+        assert_eq!(pkt.src_cid(), 0);
+        assert_eq!(pkt.dst_cid(), 0);
+        assert_eq!(pkt.src_port(), 0);
+        assert_eq!(pkt.dst_port(), 0);
+        assert_eq!(pkt.len(), 0);
+        assert_eq!(pkt.type_(), 0);
+        assert_eq!(pkt.op(), 0);
+        assert_eq!(pkt.flags(), 0);
+        assert_eq!(pkt.buf_alloc(), 0);
+        assert_eq!(pkt.fwd_cnt(), 0);
+    }
+
+    #[test]
+    fn test_packet_buf() {
+        create_context!(test_ctx, handler_ctx);
+        let mut pkt = VsockPacket::from_rx_virtq_head(
+            &handler_ctx.handler.queues[0]
+                .iter(&test_ctx.mem)
+                .next()
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            pkt.buf().unwrap().len(),
+            handler_ctx.guest_rxvq.dtable[1].len.get() as usize
+        );
+        assert_eq!(
+            pkt.buf_mut().unwrap().len(),
+            handler_ctx.guest_rxvq.dtable[1].len.get() as usize
+        );
+
+        for i in 0..pkt.buf().unwrap().len() {
+            pkt.buf_mut().unwrap()[i] = (i % 0x100) as u8;
+            assert_eq!(pkt.buf().unwrap()[i], (i % 0x100) as u8);
+        }
+    }
+}

--- a/vm-virtio/src/vsock/unix/mod.rs
+++ b/vm-virtio/src/vsock/unix/mod.rs
@@ -1,0 +1,49 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// This module implements the Unix Domain Sockets backend for vsock - a mediator between
+/// guest-side AF_VSOCK sockets and host-side AF_UNIX sockets. The heavy lifting is performed by
+/// `muxer::VsockMuxer`, a connection multiplexer that uses `super::csm::VsockConnection` for
+/// handling vsock connection states.
+/// Check out `muxer.rs` for a more detailed explanation of the inner workings of this backend.
+///
+mod muxer;
+mod muxer_killq;
+mod muxer_rxq;
+
+pub use muxer::VsockMuxer as VsockUnixBackend;
+
+mod defs {
+    /// Maximum number of established connections that we can handle.
+    pub const MAX_CONNECTIONS: usize = 1023;
+
+    /// Size of the muxer RX packet queue.
+    pub const MUXER_RXQ_SIZE: usize = 256;
+
+    /// Size of the muxer connection kill queue.
+    pub const MUXER_KILLQ_SIZE: usize = 128;
+}
+
+#[derive(Debug)]
+pub enum Error {
+    /// Error registering a new epoll-listening FD.
+    EpollAdd(std::io::Error),
+    /// Error creating an epoll FD.
+    EpollFdCreate(std::io::Error),
+    /// The host made an invalid vsock port connection request.
+    InvalidPortRequest,
+    /// Error accepting a new connection from the host-side Unix socket.
+    UnixAccept(std::io::Error),
+    /// Error binding to the host-side Unix socket.
+    UnixBind(std::io::Error),
+    /// Error connecting to a host-side Unix socket.
+    UnixConnect(std::io::Error),
+    /// Error reading from host-side Unix socket.
+    UnixRead(std::io::Error),
+    /// Muxer connection limit reached.
+    TooManyConnections,
+}
+
+type Result<T> = std::result::Result<T, Error>;
+type MuxerConnection = super::csm::VsockConnection<std::os::unix::net::UnixStream>;

--- a/vm-virtio/src/vsock/unix/mod.rs
+++ b/vm-virtio/src/vsock/unix/mod.rs
@@ -13,6 +13,7 @@ mod muxer_killq;
 mod muxer_rxq;
 
 pub use muxer::VsockMuxer as VsockUnixBackend;
+pub use Error as VsockUnixError;
 
 mod defs {
     /// Maximum number of established connections that we can handle.

--- a/vm-virtio/src/vsock/unix/muxer.rs
+++ b/vm-virtio/src/vsock/unix/muxer.rs
@@ -1,0 +1,769 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// `VsockMuxer` is the device-facing component of the Unix domain sockets vsock backend. I.e.
+/// by implementing the `VsockBackend` trait, it abstracts away the gory details of translating
+/// between AF_VSOCK and AF_UNIX, and presents a clean interface to the rest of the vsock
+/// device model.
+///
+/// The vsock muxer has two main roles:
+/// 1. Vsock connection multiplexer:
+///    It's the muxer's job to create, manage, and terminate `VsockConnection` objects. The
+///    muxer also routes packets to their owning connections. It does so via a connection
+///    `HashMap`, keyed by what is basically a (host_port, guest_port) tuple.
+///    Vsock packet traffic needs to be inspected, in order to detect connection request
+///    packets (leading to the creation of a new connection), and connection reset packets
+///    (leading to the termination of an existing connection). All other packets, though, must
+///    belong to an existing connection and, as such, the muxer simply forwards them.
+/// 2. Event dispatcher
+///    There are three event categories that the vsock backend is interested it:
+///    1. A new host-initiated connection is ready to be accepted from the listening host Unix
+///       socket;
+///    2. Data is available for reading from a newly-accepted host-initiated connection (i.e.
+///       the host is ready to issue a vsock connection request, informing us of the
+///       destination port to which it wants to connect);
+///    3. Some event was triggered for a connected Unix socket, that belongs to a
+///       `VsockConnection`.
+///    The muxer gets notified about all of these events, because, as a `VsockEpollListener`
+///    implementor, it gets to register a nested epoll FD into the main VMM epolling loop. All
+///    other pollable FDs are then registered under this nested epoll FD.
+///    To route all these events to their handlers, the muxer uses another `HashMap` object,
+///    mapping `RawFd`s to `EpollListener`s.
+///
+use std::collections::{HashMap, HashSet};
+use std::io::Read;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::net::{UnixListener, UnixStream};
+
+use super::super::defs::uapi;
+use super::super::packet::VsockPacket;
+use super::super::{
+    Result as VsockResult, VsockBackend, VsockChannel, VsockEpollListener, VsockError,
+};
+use super::defs;
+use super::muxer_killq::MuxerKillQ;
+use super::muxer_rxq::MuxerRxQ;
+use super::MuxerConnection;
+use super::{Error, Result};
+
+/// A unique identifier of a `MuxerConnection` object. Connections are stored in a hash map,
+/// keyed by a `ConnMapKey` object.
+///
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ConnMapKey {
+    local_port: u32,
+    peer_port: u32,
+}
+
+/// A muxer RX queue item.
+///
+#[derive(Debug)]
+pub enum MuxerRx {
+    /// The packet must be fetched from the connection identified by `ConnMapKey`.
+    ConnRx(ConnMapKey),
+    /// The muxer must produce an RST packet.
+    RstPkt { local_port: u32, peer_port: u32 },
+}
+
+/// An epoll listener, registered under the muxer's nested epoll FD.
+///
+enum EpollListener {
+    /// The listener is a `MuxerConnection`, identified by `key`, and interested in the events
+    /// in `evset`. Since `MuxerConnection` implements `VsockEpollListener`, notifications will
+    /// be forwarded to the listener via `VsockEpollListener::notify()`.
+    Connection {
+        key: ConnMapKey,
+        evset: epoll::Events,
+    },
+    /// A listener interested in new host-initiated connections.
+    HostSock,
+    /// A listener interested in reading host "connect <port>" commands from a freshly
+    /// connected host socket.
+    LocalStream(UnixStream),
+}
+
+/// The vsock connection multiplexer.
+///
+pub struct VsockMuxer {
+    /// Guest CID.
+    cid: u64,
+    /// A hash map used to store the active connections.
+    conn_map: HashMap<ConnMapKey, MuxerConnection>,
+    /// A hash map used to store epoll event listeners / handlers.
+    listener_map: HashMap<RawFd, EpollListener>,
+    /// The RX queue. Items in this queue are consumed by `VsockMuxer::recv_pkt()`, and
+    /// produced
+    /// - by `VsockMuxer::send_pkt()` (e.g. RST in response to a connection request packet);
+    ///   and
+    /// - in response to EPOLLIN events (e.g. data available to be read from an AF_UNIX
+    ///   socket).
+    rxq: MuxerRxQ,
+    /// A queue used for terminating connections that are taking too long to shut down.
+    killq: MuxerKillQ,
+    /// The Unix socket, through which host-initiated connections are accepted.
+    host_sock: UnixListener,
+    /// The file system path of the host-side Unix socket. This is used to figure out the path
+    /// to Unix sockets listening on specific ports. I.e. "<this path>_<port number>".
+    host_sock_path: String,
+    /// The nested epoll FD, used to register epoll listeners.
+    epoll_fd: RawFd,
+    /// A hash set used to keep track of used host-side (local) ports, in order to assign local
+    /// ports to host-initiated connections.
+    local_port_set: HashSet<u32>,
+    /// The last used host-side port.
+    local_port_last: u32,
+}
+
+impl VsockChannel for VsockMuxer {
+    /// Deliver a vsock packet to the guest vsock driver.
+    ///
+    /// Retuns:
+    /// - `Ok(())`: `pkt` has been successfully filled in; or
+    /// - `Err(VsockError::NoData)`: there was no available data with which to fill in the
+    ///   packet.
+    ///
+    fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> VsockResult<()> {
+        // We'll look for instructions on how to build the RX packet in the RX queue. If the
+        // queue is empty, that doesn't necessarily mean we don't have any pending RX, since
+        // the queue might be out-of-sync. If that's the case, we'll attempt to sync it first,
+        // and then try to pop something out again.
+        if self.rxq.is_empty() && !self.rxq.is_synced() {
+            self.rxq = MuxerRxQ::from_conn_map(&self.conn_map);
+        }
+
+        while let Some(rx) = self.rxq.pop() {
+            let res = match rx {
+                // We need to build an RST packet, going from `local_port` to `peer_port`.
+                MuxerRx::RstPkt {
+                    local_port,
+                    peer_port,
+                } => {
+                    pkt.set_op(uapi::VSOCK_OP_RST)
+                        .set_src_cid(uapi::VSOCK_HOST_CID)
+                        .set_dst_cid(self.cid)
+                        .set_src_port(local_port)
+                        .set_dst_port(peer_port)
+                        .set_len(0)
+                        .set_type(uapi::VSOCK_TYPE_STREAM)
+                        .set_flags(0)
+                        .set_buf_alloc(0)
+                        .set_fwd_cnt(0);
+                    return Ok(());
+                }
+
+                // We'll defer building the packet to this connection, since it has something
+                // to say.
+                MuxerRx::ConnRx(key) => {
+                    let mut conn_res = Err(VsockError::NoData);
+                    self.apply_conn_mutation(key, |conn| {
+                        conn_res = conn.recv_pkt(pkt);
+                    });
+                    conn_res
+                }
+            };
+
+            if res.is_ok() {
+                // Inspect traffic, looking for RST packets, since that means we have to
+                // terminate and remove this connection from the active connection pool.
+                //
+                if pkt.op() == uapi::VSOCK_OP_RST {
+                    self.remove_connection(ConnMapKey {
+                        local_port: pkt.src_port(),
+                        peer_port: pkt.dst_port(),
+                    });
+                }
+
+                debug!("vsock muxer: RX pkt: {:?}", pkt.hdr());
+                return Ok(());
+            }
+        }
+
+        Err(VsockError::NoData)
+    }
+
+    /// Deliver a guest-generated packet to its destination in the vsock backend.
+    ///
+    /// This absorbs unexpected packets, handles RSTs (by dropping connections), and forwards
+    /// all the rest to their owning `MuxerConnection`.
+    ///
+    /// Returns:
+    /// always `Ok(())` - the packet has been consumed, and its virtio TX buffers can be
+    /// returned to the guest vsock driver.
+    ///
+    fn send_pkt(&mut self, pkt: &VsockPacket) -> VsockResult<()> {
+        let conn_key = ConnMapKey {
+            local_port: pkt.dst_port(),
+            peer_port: pkt.src_port(),
+        };
+
+        debug!(
+            "vsock: muxer.send[rxq.len={}]: {:?}",
+            self.rxq.len(),
+            pkt.hdr()
+        );
+
+        // If this packet has an unsupported type (!=stream), we must send back an RST.
+        //
+        if pkt.type_() != uapi::VSOCK_TYPE_STREAM {
+            self.enq_rst(pkt.dst_port(), pkt.src_port());
+            return Ok(());
+        }
+
+        // We don't know how to handle packets addressed to other CIDs. We only handle the host
+        // part of the guest - host communication here.
+        if pkt.dst_cid() != uapi::VSOCK_HOST_CID {
+            info!(
+                "vsock: dropping guest packet for unknown CID: {:?}",
+                pkt.hdr()
+            );
+            return Ok(());
+        }
+
+        if !self.conn_map.contains_key(&conn_key) {
+            // This packet can't be routed to any active connection (based on its src and dst
+            // ports).  The only orphan / unroutable packets we know how to handle are
+            // connection requests.
+            if pkt.op() == uapi::VSOCK_OP_REQUEST {
+                // Oh, this is a connection request!
+                self.handle_peer_request_pkt(&pkt);
+            } else {
+                // Send back an RST, to let the drive know we weren't expecting this packet.
+                self.enq_rst(pkt.dst_port(), pkt.src_port());
+            }
+            return Ok(());
+        }
+
+        // Right, we know where to send this packet, then (to `conn_key`).
+        // However, if this is an RST, we have to forcefully terminate the connection, so
+        // there's no point in forwarding it the packet.
+        if pkt.op() == uapi::VSOCK_OP_RST {
+            self.remove_connection(conn_key);
+            return Ok(());
+        }
+
+        // Alright, everything looks in order - forward this packet to its owning connection.
+        let mut res: VsockResult<()> = Ok(());
+        self.apply_conn_mutation(conn_key, |conn| {
+            res = conn.send_pkt(pkt);
+        });
+
+        res
+    }
+
+    /// Check if the muxer has any pending RX data, with which to fill a guest-provided RX
+    /// buffer.
+    ///
+    fn has_pending_rx(&self) -> bool {
+        !self.rxq.is_empty() || !self.rxq.is_synced()
+    }
+}
+
+impl VsockEpollListener for VsockMuxer {
+    /// Get the FD to be registered for polling upstream (in the main VMM epoll loop, in this
+    /// case).
+    ///
+    /// This will be the muxer's nested epoll FD.
+    ///
+    fn get_polled_fd(&self) -> RawFd {
+        self.epoll_fd
+    }
+
+    /// Get the epoll events to be polled upstream.
+    ///
+    /// Since the polled FD is a nested epoll FD, we're only interested in EPOLLIN events (i.e.
+    /// some event occured on one of the FDs registered under our epoll FD).
+    ///
+    fn get_polled_evset(&self) -> epoll::Events {
+        epoll::Events::EPOLLIN
+    }
+
+    /// Notify the muxer about a pending event having occured under its nested epoll FD.
+    ///
+    fn notify(&mut self, _: epoll::Events) {
+        debug!("vsock: muxer received kick");
+
+        let mut epoll_events = vec![epoll::Event::new(epoll::Events::empty(), 0); 32];
+        match epoll::wait(self.epoll_fd, 0, epoll_events.as_mut_slice()) {
+            Ok(ev_cnt) => {
+                #[allow(clippy::needless_range_loop)]
+                for i in 0..ev_cnt {
+                    self.handle_event(
+                        epoll_events[i].data as RawFd,
+                        // It's ok to unwrap here, since the `epoll_events[i].events` is filled
+                        // in by `epoll::wait()`, and therefore contains only valid epoll
+                        // flags.
+                        epoll::Events::from_bits(epoll_events[i].events).unwrap(),
+                    );
+                }
+            }
+            Err(e) => {
+                warn!("vsock: failed to consume muxer epoll event: {}", e);
+            }
+        }
+    }
+}
+
+impl VsockBackend for VsockMuxer {}
+
+impl VsockMuxer {
+    /// Muxer constructor.
+    ///
+    pub fn new(cid: u64, host_sock_path: String) -> Result<Self> {
+        // Create the nested epoll FD. This FD will be added to the VMM `EpollContext`, at
+        // device activation time.
+        let epoll_fd = epoll::create(true).map_err(Error::EpollFdCreate)?;
+
+        // Open/bind/listen on the host Unix socket, so we can accept host-initiated
+        // connections.
+        let host_sock = UnixListener::bind(&host_sock_path)
+            .and_then(|sock| sock.set_nonblocking(true).map(|_| sock))
+            .map_err(Error::UnixBind)?;
+
+        let mut muxer = Self {
+            cid,
+            host_sock,
+            host_sock_path,
+            epoll_fd,
+            rxq: MuxerRxQ::new(),
+            conn_map: HashMap::with_capacity(defs::MAX_CONNECTIONS),
+            listener_map: HashMap::with_capacity(defs::MAX_CONNECTIONS + 1),
+            killq: MuxerKillQ::new(),
+            local_port_last: (1u32 << 30) - 1,
+            local_port_set: HashSet::with_capacity(defs::MAX_CONNECTIONS),
+        };
+
+        muxer.add_listener(muxer.host_sock.as_raw_fd(), EpollListener::HostSock)?;
+        Ok(muxer)
+    }
+
+    /// Handle/dispatch an epoll event to its listener.
+    ///
+    fn handle_event(&mut self, fd: RawFd, evset: epoll::Events) {
+        debug!(
+            "vsock: muxer processing event: fd={}, evset={:?}",
+            fd, evset
+        );
+
+        match self.listener_map.get_mut(&fd) {
+            // This event needs to be forwarded to a `MuxerConnection` that is listening for
+            // it.
+            //
+            Some(EpollListener::Connection { key, evset }) => {
+                let key_copy = *key;
+                let evset_copy = *evset;
+                // The handling of this event will most probably mutate the state of the
+                // receiving conection. We'll need to check for new pending RX, event set
+                // mutation, and all that, so we're wrapping the event delivery inside those
+                // checks.
+                self.apply_conn_mutation(key_copy, |conn| {
+                    conn.notify(evset_copy);
+                });
+            }
+
+            // A new host-initiated connection is ready to be accepted.
+            //
+            Some(EpollListener::HostSock) => {
+                if self.conn_map.len() == defs::MAX_CONNECTIONS {
+                    // If we're already maxed-out on connections, we'll just accept and
+                    // immediately discard this potentially new one.
+                    warn!("vsock: connection limit reached; refusing new host connection");
+                    self.host_sock.accept().map(|_| 0).unwrap_or(0);
+                    return;
+                }
+                self.host_sock
+                    .accept()
+                    .map_err(Error::UnixAccept)
+                    .and_then(|(stream, _)| {
+                        stream
+                            .set_nonblocking(true)
+                            .map(|_| stream)
+                            .map_err(Error::UnixAccept)
+                    })
+                    .and_then(|stream| {
+                        // Before forwarding this connection to a listening AF_VSOCK socket on
+                        // the guest side, we need to know the destination port. We'll read
+                        // that port from a "connect" command received on this socket, so the
+                        // next step is to ask to be notified the moment we can read from it.
+                        self.add_listener(stream.as_raw_fd(), EpollListener::LocalStream(stream))
+                    })
+                    .unwrap_or_else(|err| {
+                        warn!("vsock: unable to accept local connection: {:?}", err);
+                    });
+            }
+
+            // Data is ready to be read from a host-initiated connection. That would be the
+            // "connect" command that we're expecting.
+            Some(EpollListener::LocalStream(_)) => {
+                if let Some(EpollListener::LocalStream(mut stream)) = self.remove_listener(fd) {
+                    Self::read_local_stream_port(&mut stream)
+                        .and_then(|peer_port| Ok((self.allocate_local_port(), peer_port)))
+                        .and_then(|(local_port, peer_port)| {
+                            self.add_connection(
+                                ConnMapKey {
+                                    local_port,
+                                    peer_port,
+                                },
+                                MuxerConnection::new_local_init(
+                                    stream,
+                                    uapi::VSOCK_HOST_CID,
+                                    self.cid,
+                                    local_port,
+                                    peer_port,
+                                ),
+                            )
+                        })
+                        .unwrap_or_else(|err| {
+                            info!("vsock: error adding local-init connection: {:?}", err);
+                        })
+                }
+            }
+
+            _ => {
+                info!("vsock: unexpected event: fd={:?}, evset={:?}", fd, evset);
+            }
+        }
+    }
+
+    /// Parse a host "connect" command, and extract the destination vsock port.
+    ///
+    fn read_local_stream_port(stream: &mut UnixStream) -> Result<u32> {
+        let mut buf = [0u8; 32];
+
+        // This is the minimum number of bytes that we should be able to read, when parsing a
+        // valid connection request. I.e. `b"connect 0\n".len()`.
+        const MIN_READ_LEN: usize = 10;
+
+        // Bring in the minimum number of bytes that we should be able to read.
+        stream
+            .read_exact(&mut buf[..MIN_READ_LEN])
+            .map_err(Error::UnixRead)?;
+
+        // Now, finish reading the destination port number, by bringing in one byte at a time,
+        // until we reach an EOL terminator (or our buffer space runs out).  Yeah, not
+        // particularly proud of this approach, but it will have to do for now.
+        let mut blen = MIN_READ_LEN;
+        while buf[blen - 1] != b'\n' && blen < buf.len() {
+            stream
+                .read_exact(&mut buf[blen..=blen])
+                .map_err(Error::UnixRead)?;
+            blen += 1;
+        }
+
+        let mut word_iter = std::str::from_utf8(&buf[..blen])
+            .map_err(|_| Error::InvalidPortRequest)?
+            .split_whitespace();
+
+        word_iter
+            .next()
+            .ok_or(Error::InvalidPortRequest)
+            .and_then(|word| {
+                if word.to_lowercase() == "connect" {
+                    Ok(())
+                } else {
+                    Err(Error::InvalidPortRequest)
+                }
+            })
+            .and_then(|_| word_iter.next().ok_or(Error::InvalidPortRequest))
+            .and_then(|word| word.parse::<u32>().map_err(|_| Error::InvalidPortRequest))
+            .map_err(|_| Error::InvalidPortRequest)
+    }
+
+    /// Add a new connection to the active connection pool.
+    ///
+    fn add_connection(&mut self, key: ConnMapKey, conn: MuxerConnection) -> Result<()> {
+        // We might need to make room for this new connection, so let's sweep the kill queue
+        // first.  It's fine to do this here because:
+        // - unless the kill queue is out of sync, this is a pretty inexpensive operation; and
+        // - we are under no pressure to respect any accurate timing for connection
+        //   termination.
+        self.sweep_killq();
+
+        if self.conn_map.len() >= defs::MAX_CONNECTIONS {
+            info!(
+                "vsock: muxer connection limit reached ({})",
+                defs::MAX_CONNECTIONS
+            );
+            return Err(Error::TooManyConnections);
+        }
+
+        self.add_listener(
+            conn.get_polled_fd(),
+            EpollListener::Connection {
+                key,
+                evset: conn.get_polled_evset(),
+            },
+        )
+        .and_then(|_| {
+            if conn.has_pending_rx() {
+                // We can safely ignore any error in adding a connection RX indication. Worst
+                // case scenario, the RX queue will get desynchronized, but we'll handle that
+                // the next time we need to yield an RX packet.
+                self.rxq.push(MuxerRx::ConnRx(key));
+            }
+            self.conn_map.insert(key, conn);
+            Ok(())
+        })
+    }
+
+    /// Remove a connection from the active connection poll.
+    ///
+    fn remove_connection(&mut self, key: ConnMapKey) {
+        if let Some(conn) = self.conn_map.remove(&key) {
+            self.remove_listener(conn.get_polled_fd());
+        }
+        self.free_local_port(key.local_port);
+    }
+
+    /// Schedule a connection for immediate termination.
+    /// I.e. as soon as we can also let our peer know we're dropping the connection, by sending
+    /// it an RST packet.
+    ///
+    fn kill_connection(&mut self, key: ConnMapKey) {
+        let mut had_rx = false;
+        self.conn_map.entry(key).and_modify(|conn| {
+            had_rx = conn.has_pending_rx();
+            conn.kill();
+        });
+        // This connection will now have an RST packet to yield, so we need to add it to the RX
+        // queue.  However, there's no point in doing that if it was already in the queue.
+        if !had_rx {
+            // We can safely ignore any error in adding a connection RX indication. Worst case
+            // scenario, the RX queue will get desynchronized, but we'll handle that the next
+            // time we need to yield an RX packet.
+            self.rxq.push(MuxerRx::ConnRx(key));
+        }
+    }
+
+    /// Register a new epoll listener under the muxer's nested epoll FD.
+    ///
+    fn add_listener(&mut self, fd: RawFd, listener: EpollListener) -> Result<()> {
+        let evset = match listener {
+            EpollListener::Connection { evset, .. } => evset,
+            EpollListener::LocalStream(_) => epoll::Events::EPOLLIN,
+            EpollListener::HostSock => epoll::Events::EPOLLIN,
+        };
+
+        epoll::ctl(
+            self.epoll_fd,
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            fd,
+            epoll::Event::new(evset, fd as u64),
+        )
+        .and_then(|_| {
+            self.listener_map.insert(fd, listener);
+            Ok(())
+        })
+        .map_err(Error::EpollAdd)?;
+
+        Ok(())
+    }
+
+    /// Remove (and return) a previously registered epoll listener.
+    ///
+    fn remove_listener(&mut self, fd: RawFd) -> Option<EpollListener> {
+        let maybe_listener = self.listener_map.remove(&fd);
+
+        if maybe_listener.is_some() {
+            epoll::ctl(
+                self.epoll_fd,
+                epoll::ControlOptions::EPOLL_CTL_DEL,
+                fd,
+                epoll::Event::new(epoll::Events::empty(), 0),
+            )
+            .unwrap_or_else(|err| {
+                warn!(
+                    "vosck muxer: error removing epoll listener for fd {:?}: {:?}",
+                    fd, err
+                );
+            });
+        }
+
+        maybe_listener
+    }
+
+    /// Allocate a host-side port to be assigned to a new host-initiated connection.
+    ///
+    ///
+    fn allocate_local_port(&mut self) -> u32 {
+        // TODO: this doesn't seem very space-efficient.
+        // Mybe rewrite this to limit port range and use a bitmap?
+        //
+
+        loop {
+            self.local_port_last = (self.local_port_last + 1) & !(1 << 31) | (1 << 30);
+            if self.local_port_set.insert(self.local_port_last) {
+                break;
+            }
+        }
+        self.local_port_last
+    }
+
+    /// Mark a previously used host-side port as free.
+    ///
+    fn free_local_port(&mut self, port: u32) {
+        self.local_port_set.remove(&port);
+    }
+
+    /// Handle a new connection request comming from our peer (the guest vsock driver).
+    ///
+    /// This will attempt to connect to a host-side Unix socket, expected to be listening at
+    /// the file system path corresponing to the destination port. If successful, a new
+    /// connection object will be created and added to the connection pool. On failure, a new
+    /// RST packet will be scheduled for delivery to the guest.
+    ///
+    fn handle_peer_request_pkt(&mut self, pkt: &VsockPacket) {
+        let port_path = format!("{}_{}", self.host_sock_path, pkt.dst_port());
+
+        UnixStream::connect(port_path)
+            .and_then(|stream| stream.set_nonblocking(true).map(|_| stream))
+            .map_err(Error::UnixConnect)
+            .and_then(|stream| {
+                self.add_connection(
+                    ConnMapKey {
+                        local_port: pkt.dst_port(),
+                        peer_port: pkt.src_port(),
+                    },
+                    MuxerConnection::new_peer_init(
+                        stream,
+                        uapi::VSOCK_HOST_CID,
+                        self.cid,
+                        pkt.dst_port(),
+                        pkt.src_port(),
+                        pkt.buf_alloc(),
+                    ),
+                )
+            })
+            .unwrap_or_else(|_| self.enq_rst(pkt.dst_port(), pkt.src_port()));
+    }
+
+    /// Perform an action that might mutate a connection's state.
+    ///
+    /// This is used as shorthand for repetitive tasks that need to be performed after a
+    /// connection object mutates. E.g.
+    /// - update the connection's epoll listener;
+    /// - schedule the connection to be queried for RX data;
+    /// - kill the connection if an unrecoverable error occurs.
+    ///
+    fn apply_conn_mutation<F>(&mut self, key: ConnMapKey, mut_fn: F)
+    where
+        F: FnOnce(&mut MuxerConnection),
+    {
+        if let Some(conn) = self.conn_map.get_mut(&key) {
+            let had_rx = conn.has_pending_rx();
+            let was_expiring = conn.will_expire();
+
+            mut_fn(conn);
+
+            // If the connection wasn't previously scheduled for RX, add it to our RX queue.
+            if !had_rx && conn.has_pending_rx() {
+                self.rxq.push(MuxerRx::ConnRx(key));
+            }
+
+            // If the connection wasn't previously scheduled for termination, add it to the
+            // kill queue.
+            if !was_expiring && conn.will_expire() {
+                // It's safe to unwrap here, since `conn.will_expire()` already guaranteed that
+                // an `conn.expiry` is available.
+                self.killq.push(key, conn.expiry().unwrap());
+            }
+
+            let fd = conn.get_polled_fd();
+            let new_evset = conn.get_polled_evset();
+            if new_evset.is_empty() {
+                // If the connection no longer needs epoll notifications, remove its listener
+                // from our list.
+                self.remove_listener(fd);
+                return;
+            }
+            if let Some(EpollListener::Connection { evset, .. }) = self.listener_map.get_mut(&fd) {
+                if *evset != new_evset {
+                    // If the set of events that the connection is interested in has changed,
+                    // we need to update its epoll listener.
+                    debug!(
+                        "vsock: updating listener for (lp={}, pp={}): old={:?}, new={:?}",
+                        key.local_port, key.peer_port, *evset, new_evset
+                    );
+
+                    *evset = new_evset;
+                    epoll::ctl(
+                        self.epoll_fd,
+                        epoll::ControlOptions::EPOLL_CTL_MOD,
+                        fd,
+                        epoll::Event::new(new_evset, fd as u64),
+                    )
+                    .unwrap_or_else(|err| {
+                        // This really shouldn't happen, like, ever. However, "famous last
+                        // words" and all that, so let's just kill it with fire, and walk away.
+                        self.kill_connection(key);
+                        error!(
+                            "vsock: error updating epoll listener for (lp={}, pp={}): {:?}",
+                            key.local_port, key.peer_port, err
+                        );
+                    });
+                }
+            } else {
+                // The connection had previously asked to be removed from the listener map (by
+                // returning an empty event set via `get_polled_fd()`), but now wants back in.
+                self.add_listener(
+                    fd,
+                    EpollListener::Connection {
+                        key,
+                        evset: new_evset,
+                    },
+                )
+                .unwrap_or_else(|err| {
+                    self.kill_connection(key);
+                    error!(
+                        "vsock: error updating epoll listener for (lp={}, pp={}): {:?}",
+                        key.local_port, key.peer_port, err
+                    );
+                });
+            }
+        }
+    }
+
+    /// Check if any connections have timed out, and if so, schedule them for immediate
+    /// termination.
+    ///
+    fn sweep_killq(&mut self) {
+        while let Some(key) = self.killq.pop() {
+            // Connections don't get removed from the kill queue when their kill timer is
+            // disarmed, since that would be a costly operation. This means we must check if
+            // the connection has indeed expired, prior to killing it.
+            let mut kill = false;
+            self.conn_map
+                .entry(key)
+                .and_modify(|conn| kill = conn.has_expired());
+            if kill {
+                self.kill_connection(key);
+            }
+        }
+
+        if self.killq.is_empty() && !self.killq.is_synced() {
+            self.killq = MuxerKillQ::from_conn_map(&self.conn_map);
+            // If we've just re-created the kill queue, we can sweep it again; maybe there's
+            // more to kill.
+            self.sweep_killq();
+        }
+    }
+
+    /// Enqueue an RST packet into `self.rxq`.
+    ///
+    /// Enqueue errors aren't propagated up the call chain, since there is nothing we can do to
+    /// handle them. We do, however, log a warning, since not being able to enqueue an RST
+    /// packet means we have to drop it, which is not normal operation.
+    ///
+    fn enq_rst(&mut self, local_port: u32, peer_port: u32) {
+        let pushed = self.rxq.push(MuxerRx::RstPkt {
+            local_port,
+            peer_port,
+        });
+        if !pushed {
+            warn!(
+                "vsock: muxer.rxq full; dropping RST packet for lp={}, pp={}",
+                local_port, peer_port
+            );
+        }
+    }
+}

--- a/vm-virtio/src/vsock/unix/muxer.rs
+++ b/vm-virtio/src/vsock/unix/muxer.rs
@@ -767,3 +767,546 @@ impl VsockMuxer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::ops::Drop;
+    use std::os::unix::net::{UnixListener, UnixStream};
+    use std::path::{Path, PathBuf};
+
+    use super::super::super::csm::defs as csm_defs;
+    use super::super::super::tests::TestContext as VsockTestContext;
+    use super::*;
+
+    const PEER_CID: u64 = 3;
+    const PEER_BUF_ALLOC: u32 = 64 * 1024;
+
+    struct MuxerTestContext {
+        _vsock_test_ctx: VsockTestContext,
+        pkt: VsockPacket,
+        muxer: VsockMuxer,
+    }
+
+    impl Drop for MuxerTestContext {
+        fn drop(&mut self) {
+            std::fs::remove_file(self.muxer.host_sock_path.as_str()).unwrap();
+        }
+    }
+
+    impl MuxerTestContext {
+        fn new(name: &str) -> Self {
+            let vsock_test_ctx = VsockTestContext::new();
+            let mut handler_ctx = vsock_test_ctx.create_epoll_handler_context();
+            let pkt = VsockPacket::from_rx_virtq_head(
+                &handler_ctx.handler.queues[0]
+                    .iter(&vsock_test_ctx.mem)
+                    .next()
+                    .unwrap(),
+            )
+            .unwrap();
+            let uds_path = format!("test_vsock_{}.sock", name);
+            let muxer = VsockMuxer::new(PEER_CID, uds_path).unwrap();
+
+            Self {
+                _vsock_test_ctx: vsock_test_ctx,
+                pkt,
+                muxer,
+            }
+        }
+
+        fn init_pkt(&mut self, local_port: u32, peer_port: u32, op: u16) -> &mut VsockPacket {
+            for b in self.pkt.hdr_mut() {
+                *b = 0;
+            }
+            self.pkt
+                .set_type(uapi::VSOCK_TYPE_STREAM)
+                .set_src_cid(PEER_CID)
+                .set_dst_cid(uapi::VSOCK_HOST_CID)
+                .set_src_port(peer_port)
+                .set_dst_port(local_port)
+                .set_op(op)
+                .set_buf_alloc(PEER_BUF_ALLOC)
+        }
+
+        fn init_data_pkt(
+            &mut self,
+            local_port: u32,
+            peer_port: u32,
+            data: &[u8],
+        ) -> &mut VsockPacket {
+            assert!(data.len() <= self.pkt.buf().unwrap().len() as usize);
+            self.init_pkt(local_port, peer_port, uapi::VSOCK_OP_RW)
+                .set_len(data.len() as u32);
+            self.pkt.buf_mut().unwrap()[..data.len()].copy_from_slice(data);
+            &mut self.pkt
+        }
+
+        fn send(&mut self) {
+            self.muxer.send_pkt(&self.pkt).unwrap();
+        }
+
+        fn recv(&mut self) {
+            self.muxer.recv_pkt(&mut self.pkt).unwrap();
+        }
+
+        fn notify_muxer(&mut self) {
+            self.muxer.notify(epoll::Events::EPOLLIN);
+        }
+
+        fn count_epoll_listeners(&self) -> (usize, usize) {
+            let mut local_lsn_count = 0usize;
+            let mut conn_lsn_count = 0usize;
+            for key in self.muxer.listener_map.values() {
+                match key {
+                    EpollListener::LocalStream(_) => local_lsn_count += 1,
+                    EpollListener::Connection { .. } => conn_lsn_count += 1,
+                    _ => (),
+                };
+            }
+            (local_lsn_count, conn_lsn_count)
+        }
+
+        fn create_local_listener(&self, port: u32) -> LocalListener {
+            LocalListener::new(format!("{}_{}", self.muxer.host_sock_path, port))
+        }
+
+        fn local_connect(&mut self, peer_port: u32) -> (UnixStream, u32) {
+            let (init_local_lsn_count, init_conn_lsn_count) = self.count_epoll_listeners();
+
+            let mut stream = UnixStream::connect(self.muxer.host_sock_path.clone()).unwrap();
+            stream.set_nonblocking(true).unwrap();
+            // The muxer would now get notified of a new connection having arrived at its Unix
+            // socket, so it can accept it.
+            self.notify_muxer();
+
+            // Just after having accepted a new local connection, the muxer should've added a new
+            // `LocalStream` listener to its `listener_map`.
+            let (local_lsn_count, _) = self.count_epoll_listeners();
+            assert_eq!(local_lsn_count, init_local_lsn_count + 1);
+
+            let buf = format!("CONNECT {}\n", peer_port);
+            stream.write_all(buf.as_bytes()).unwrap();
+            // The muxer would now get notified that data is available for reading from the locally
+            // initiated connection.
+            self.notify_muxer();
+
+            // Successfully reading and parsing the connection request should have removed the
+            // LocalStream epoll listener and added a Connection epoll listener.
+            let (local_lsn_count, conn_lsn_count) = self.count_epoll_listeners();
+            assert_eq!(local_lsn_count, init_local_lsn_count);
+            assert_eq!(conn_lsn_count, init_conn_lsn_count + 1);
+
+            // A LocalInit connection should've been added to the muxer connection map.  A new
+            // local port should also have been allocated for the new LocalInit connection.
+            let local_port = self.muxer.local_port_last;
+            let key = ConnMapKey {
+                local_port,
+                peer_port,
+            };
+            assert!(self.muxer.conn_map.contains_key(&key));
+            assert!(self.muxer.local_port_set.contains(&local_port));
+
+            // A connection request for the peer should now be available from the muxer.
+            assert!(self.muxer.has_pending_rx());
+            self.recv();
+            assert_eq!(self.pkt.op(), uapi::VSOCK_OP_REQUEST);
+            assert_eq!(self.pkt.dst_port(), peer_port);
+            assert_eq!(self.pkt.src_port(), local_port);
+
+            self.init_pkt(local_port, peer_port, uapi::VSOCK_OP_RESPONSE);
+            self.send();
+
+            (stream, local_port)
+        }
+    }
+
+    struct LocalListener {
+        path: PathBuf,
+        sock: UnixListener,
+    }
+    impl LocalListener {
+        fn new<P: AsRef<Path> + Clone>(path: P) -> Self {
+            let path_buf = path.clone().as_ref().to_path_buf();
+            let sock = UnixListener::bind(path).unwrap();
+            sock.set_nonblocking(true).unwrap();
+            Self {
+                path: path_buf,
+                sock,
+            }
+        }
+        fn accept(&mut self) -> UnixStream {
+            let (stream, _) = self.sock.accept().unwrap();
+            stream.set_nonblocking(true).unwrap();
+            stream
+        }
+    }
+    impl Drop for LocalListener {
+        fn drop(&mut self) {
+            std::fs::remove_file(&self.path).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_muxer_epoll_listener() {
+        let ctx = MuxerTestContext::new("muxer_epoll_listener");
+        assert_eq!(ctx.muxer.get_polled_fd(), ctx.muxer.epoll_fd);
+        assert_eq!(ctx.muxer.get_polled_evset(), epoll::Events::EPOLLIN);
+    }
+
+    #[test]
+    fn test_bad_peer_pkt() {
+        const LOCAL_PORT: u32 = 1026;
+        const PEER_PORT: u32 = 1025;
+        const SOCK_DGRAM: u16 = 2;
+
+        let mut ctx = MuxerTestContext::new("bad_peer_pkt");
+        ctx.init_pkt(LOCAL_PORT, PEER_PORT, uapi::VSOCK_OP_REQUEST)
+            .set_type(SOCK_DGRAM);
+        ctx.send();
+
+        // The guest sent a SOCK_DGRAM packet. Per the vsock spec, we need to reply with an RST
+        // packet, since vsock only supports stream sockets.
+        assert!(ctx.muxer.has_pending_rx());
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RST);
+        assert_eq!(ctx.pkt.src_cid(), uapi::VSOCK_HOST_CID);
+        assert_eq!(ctx.pkt.dst_cid(), PEER_CID);
+        assert_eq!(ctx.pkt.src_port(), LOCAL_PORT);
+        assert_eq!(ctx.pkt.dst_port(), PEER_PORT);
+
+        // Any orphan (i.e. without a connection), non-RST packet, should be replied to with an
+        // RST.
+        let bad_ops = [
+            uapi::VSOCK_OP_RESPONSE,
+            uapi::VSOCK_OP_CREDIT_REQUEST,
+            uapi::VSOCK_OP_CREDIT_UPDATE,
+            uapi::VSOCK_OP_SHUTDOWN,
+            uapi::VSOCK_OP_RW,
+        ];
+        for op in bad_ops.iter() {
+            ctx.init_pkt(LOCAL_PORT, PEER_PORT, *op);
+            ctx.send();
+            assert!(ctx.muxer.has_pending_rx());
+            ctx.recv();
+            assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RST);
+            assert_eq!(ctx.pkt.src_port(), LOCAL_PORT);
+            assert_eq!(ctx.pkt.dst_port(), PEER_PORT);
+        }
+
+        // Any packet addressed to anything other than VSOCK_VHOST_CID should get dropped.
+        assert!(!ctx.muxer.has_pending_rx());
+        ctx.init_pkt(LOCAL_PORT, PEER_PORT, uapi::VSOCK_OP_REQUEST)
+            .set_dst_cid(uapi::VSOCK_HOST_CID + 1);
+        ctx.send();
+        assert!(!ctx.muxer.has_pending_rx());
+    }
+
+    #[test]
+    fn test_peer_connection() {
+        const LOCAL_PORT: u32 = 1026;
+        const PEER_PORT: u32 = 1025;
+
+        let mut ctx = MuxerTestContext::new("peer_connection");
+
+        // Test peer connection refused.
+        ctx.init_pkt(LOCAL_PORT, PEER_PORT, uapi::VSOCK_OP_REQUEST);
+        ctx.send();
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RST);
+        assert_eq!(ctx.pkt.len(), 0);
+        assert_eq!(ctx.pkt.src_cid(), uapi::VSOCK_HOST_CID);
+        assert_eq!(ctx.pkt.dst_cid(), PEER_CID);
+        assert_eq!(ctx.pkt.src_port(), LOCAL_PORT);
+        assert_eq!(ctx.pkt.dst_port(), PEER_PORT);
+
+        // Test peer connection accepted.
+        let mut listener = ctx.create_local_listener(LOCAL_PORT);
+        ctx.init_pkt(LOCAL_PORT, PEER_PORT, uapi::VSOCK_OP_REQUEST);
+        ctx.send();
+        assert_eq!(ctx.muxer.conn_map.len(), 1);
+        let mut stream = listener.accept();
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RESPONSE);
+        assert_eq!(ctx.pkt.len(), 0);
+        assert_eq!(ctx.pkt.src_cid(), uapi::VSOCK_HOST_CID);
+        assert_eq!(ctx.pkt.dst_cid(), PEER_CID);
+        assert_eq!(ctx.pkt.src_port(), LOCAL_PORT);
+        assert_eq!(ctx.pkt.dst_port(), PEER_PORT);
+        let key = ConnMapKey {
+            local_port: LOCAL_PORT,
+            peer_port: PEER_PORT,
+        };
+        assert!(ctx.muxer.conn_map.contains_key(&key));
+
+        // Test guest -> host data flow.
+        let data = [1, 2, 3, 4];
+        ctx.init_data_pkt(LOCAL_PORT, PEER_PORT, &data);
+        ctx.send();
+        let mut buf = vec![0; data.len()];
+        stream.read_exact(buf.as_mut_slice()).unwrap();
+        assert_eq!(buf.as_slice(), data);
+
+        // Test host -> guest data flow.
+        let data = [5u8, 6, 7, 8];
+        stream.write_all(&data).unwrap();
+
+        // When data is available on the local stream, an EPOLLIN event would normally be delivered
+        // to the muxer's nested epoll FD. For testing only, we can fake that event notification
+        // here.
+        ctx.notify_muxer();
+        // After being notified, the muxer should've figured out that RX data was available for one
+        // of its connections, so it should now be reporting that it can fill in an RX packet.
+        assert!(ctx.muxer.has_pending_rx());
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RW);
+        assert_eq!(ctx.pkt.buf().unwrap()[..data.len()], data);
+        assert_eq!(ctx.pkt.src_port(), LOCAL_PORT);
+        assert_eq!(ctx.pkt.dst_port(), PEER_PORT);
+
+        assert!(!ctx.muxer.has_pending_rx());
+    }
+
+    #[test]
+    fn test_local_connection() {
+        let mut ctx = MuxerTestContext::new("local_connection");
+        let peer_port = 1025;
+        let (mut stream, local_port) = ctx.local_connect(peer_port);
+
+        // Test guest -> host data flow.
+        let data = [1, 2, 3, 4];
+        ctx.init_data_pkt(local_port, peer_port, &data);
+        ctx.send();
+
+        let mut buf = vec![0u8; data.len()];
+        stream.read_exact(buf.as_mut_slice()).unwrap();
+        assert_eq!(buf.as_slice(), &data);
+
+        // Test host -> guest data flow.
+        let data = [5, 6, 7, 8];
+        stream.write_all(&data).unwrap();
+        ctx.notify_muxer();
+
+        assert!(ctx.muxer.has_pending_rx());
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RW);
+        assert_eq!(ctx.pkt.src_port(), local_port);
+        assert_eq!(ctx.pkt.dst_port(), peer_port);
+        assert_eq!(ctx.pkt.buf().unwrap()[..data.len()], data);
+    }
+
+    #[test]
+    fn test_local_close() {
+        let peer_port = 1025;
+        let mut ctx = MuxerTestContext::new("local_close");
+        let local_port;
+        {
+            let (_stream, local_port_) = ctx.local_connect(peer_port);
+            local_port = local_port_;
+        }
+        // Local var `_stream` was now dropped, thus closing the local stream. After the muxer gets
+        // notified via EPOLLIN, it should attempt to gracefully shutdown the connection, issuing a
+        // VSOCK_OP_SHUTDOWN with both no-more-send and no-more-recv indications set.
+        ctx.notify_muxer();
+        assert!(ctx.muxer.has_pending_rx());
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_SHUTDOWN);
+        assert_ne!(ctx.pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_SEND, 0);
+        assert_ne!(ctx.pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_RCV, 0);
+        assert_eq!(ctx.pkt.src_port(), local_port);
+        assert_eq!(ctx.pkt.dst_port(), peer_port);
+
+        // The connection should get removed (and its local port freed), after the peer replies
+        // with an RST.
+        ctx.init_pkt(local_port, peer_port, uapi::VSOCK_OP_RST);
+        ctx.send();
+        let key = ConnMapKey {
+            local_port,
+            peer_port,
+        };
+        assert!(!ctx.muxer.conn_map.contains_key(&key));
+        assert!(!ctx.muxer.local_port_set.contains(&local_port));
+    }
+
+    #[test]
+    fn test_peer_close() {
+        let peer_port = 1025;
+        let local_port = 1026;
+        let mut ctx = MuxerTestContext::new("peer_close");
+
+        let mut sock = ctx.create_local_listener(local_port);
+        ctx.init_pkt(local_port, peer_port, uapi::VSOCK_OP_REQUEST);
+        ctx.send();
+        let mut stream = sock.accept();
+
+        assert!(ctx.muxer.has_pending_rx());
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RESPONSE);
+        assert_eq!(ctx.pkt.src_port(), local_port);
+        assert_eq!(ctx.pkt.dst_port(), peer_port);
+        let key = ConnMapKey {
+            local_port,
+            peer_port,
+        };
+        assert!(ctx.muxer.conn_map.contains_key(&key));
+
+        // Emulate a full shutdown from the peer (no-more-send + no-more-recv).
+        ctx.init_pkt(local_port, peer_port, uapi::VSOCK_OP_SHUTDOWN)
+            .set_flag(uapi::VSOCK_FLAGS_SHUTDOWN_SEND)
+            .set_flag(uapi::VSOCK_FLAGS_SHUTDOWN_RCV);
+        ctx.send();
+
+        // Now, the muxer should remove the connection from its map, and reply with an RST.
+        assert!(ctx.muxer.has_pending_rx());
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RST);
+        assert_eq!(ctx.pkt.src_port(), local_port);
+        assert_eq!(ctx.pkt.dst_port(), peer_port);
+        let key = ConnMapKey {
+            local_port,
+            peer_port,
+        };
+        assert!(!ctx.muxer.conn_map.contains_key(&key));
+
+        // The muxer should also drop / close the local Unix socket for this connection.
+        let mut buf = vec![0u8; 16];
+        assert_eq!(stream.read(buf.as_mut_slice()).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_muxer_rxq() {
+        let mut ctx = MuxerTestContext::new("muxer_rxq");
+        let local_port = 1026;
+        let peer_port_first = 1025;
+        let mut listener = ctx.create_local_listener(local_port);
+        let mut streams: Vec<UnixStream> = Vec::new();
+
+        for peer_port in peer_port_first..peer_port_first + defs::MUXER_RXQ_SIZE {
+            ctx.init_pkt(local_port, peer_port as u32, uapi::VSOCK_OP_REQUEST);
+            ctx.send();
+            streams.push(listener.accept());
+        }
+
+        // The muxer RX queue should now be full (with connection reponses), but still
+        // synchronized.
+        assert!(ctx.muxer.rxq.is_synced());
+
+        // One more queued reply should desync the RX queue.
+        ctx.init_pkt(
+            local_port,
+            (peer_port_first + defs::MUXER_RXQ_SIZE) as u32,
+            uapi::VSOCK_OP_REQUEST,
+        );
+        ctx.send();
+        assert!(!ctx.muxer.rxq.is_synced());
+
+        // With an out-of-sync queue, an RST should evict any non-RST packet from the queue, and
+        // take its place. We'll check that by making sure that the last packet popped from the
+        // queue is an RST.
+        ctx.init_pkt(
+            local_port + 1,
+            peer_port_first as u32,
+            uapi::VSOCK_OP_REQUEST,
+        );
+        ctx.send();
+
+        for peer_port in peer_port_first..peer_port_first + defs::MUXER_RXQ_SIZE - 1 {
+            ctx.recv();
+            assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RESPONSE);
+            // The response order should hold. The evicted response should have been the last
+            // enqueued.
+            assert_eq!(ctx.pkt.dst_port(), peer_port as u32);
+        }
+        // There should be one more packet in the queue: the RST.
+        assert_eq!(ctx.muxer.rxq.len(), 1);
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RST);
+
+        // The queue should now be empty, but out-of-sync, so the muxer should report it has some
+        // pending RX.
+        assert!(ctx.muxer.rxq.is_empty());
+        assert!(!ctx.muxer.rxq.is_synced());
+        assert!(ctx.muxer.has_pending_rx());
+
+        // The next recv should sync the queue back up. It should also yield one of the two
+        // responses that are still left:
+        // - the one that desynchronized the queue; and
+        // - the one that got evicted by the RST.
+        ctx.recv();
+        assert!(ctx.muxer.rxq.is_synced());
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RESPONSE);
+
+        assert!(ctx.muxer.has_pending_rx());
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RESPONSE);
+    }
+
+    #[test]
+    fn test_muxer_killq() {
+        let mut ctx = MuxerTestContext::new("muxer_killq");
+        let local_port = 1026;
+        let peer_port_first = 1025;
+        let peer_port_last = peer_port_first + defs::MUXER_KILLQ_SIZE;
+        let mut listener = ctx.create_local_listener(local_port);
+
+        for peer_port in peer_port_first..=peer_port_last {
+            ctx.init_pkt(local_port, peer_port as u32, uapi::VSOCK_OP_REQUEST);
+            ctx.send();
+            ctx.notify_muxer();
+            ctx.recv();
+            assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RESPONSE);
+            assert_eq!(ctx.pkt.src_port(), local_port);
+            assert_eq!(ctx.pkt.dst_port(), peer_port as u32);
+            {
+                let _stream = listener.accept();
+            }
+            ctx.notify_muxer();
+            ctx.recv();
+            assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_SHUTDOWN);
+            assert_eq!(ctx.pkt.src_port(), local_port);
+            assert_eq!(ctx.pkt.dst_port(), peer_port as u32);
+            // The kill queue should be synchronized, up until the `defs::MUXER_KILLQ_SIZE`th
+            // connection we schedule for termination.
+            assert_eq!(
+                ctx.muxer.killq.is_synced(),
+                peer_port < peer_port_first + defs::MUXER_KILLQ_SIZE
+            );
+        }
+
+        assert!(!ctx.muxer.killq.is_synced());
+        assert!(!ctx.muxer.has_pending_rx());
+
+        // Wait for the kill timers to expire.
+        std::thread::sleep(std::time::Duration::from_millis(
+            csm_defs::CONN_SHUTDOWN_TIMEOUT_MS,
+        ));
+
+        // Trigger a kill queue sweep, by requesting a new connection.
+        ctx.init_pkt(
+            local_port,
+            peer_port_last as u32 + 1,
+            uapi::VSOCK_OP_REQUEST,
+        );
+        ctx.send();
+
+        // After sweeping the kill queue, it should now be synced (assuming the RX queue is larger
+        // than the kill queue, since an RST packet will be queued for each killed connection).
+        assert!(ctx.muxer.killq.is_synced());
+        assert!(ctx.muxer.has_pending_rx());
+        // There should be `defs::MUXER_KILLQ_SIZE` RSTs in the RX queue, from terminating the
+        // dying connections in the recent killq sweep.
+        for _p in peer_port_first..peer_port_last {
+            ctx.recv();
+            assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RST);
+            assert_eq!(ctx.pkt.src_port(), local_port);
+        }
+
+        // There should be one more packet in the RX queue: the connection response our request
+        // that triggered the kill queue sweep.
+        ctx.recv();
+        assert_eq!(ctx.pkt.op(), uapi::VSOCK_OP_RESPONSE);
+        assert_eq!(ctx.pkt.dst_port(), peer_port_last as u32 + 1);
+
+        assert!(!ctx.muxer.has_pending_rx());
+    }
+}

--- a/vm-virtio/src/vsock/unix/muxer_killq.rs
+++ b/vm-virtio/src/vsock/unix/muxer_killq.rs
@@ -1,0 +1,140 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// `MuxerKillQ` implements a helper object that `VsockMuxer` can use for scheduling forced
+/// connection termination. I.e. after one peer issues a clean shutdown request
+/// (VSOCK_OP_SHUTDOWN), the concerned connection is queued for termination (VSOCK_OP_RST) in
+/// the near future (herein implemented via an expiring timer).
+///
+/// Whenever the muxer needs to schedule a connection for termination, it pushes it (or rather
+/// an identifier - the connection key) to this queue. A subsequent pop() operation will
+/// succeed if and only if the first connection in the queue is ready to be terminated (i.e.
+/// its kill timer expired).
+///
+/// Without using this queue, the muxer would have to walk its entire connection pool
+/// (hashmap), whenever it needs to check for expired kill timers. With this queue, both
+/// scheduling and termination are performed in constant time. However, since we don't want to
+/// waste space on a kill queue that's as big as the connection hashmap itself, it is possible
+/// that this queue may become full at times.  We call this kill queue "synchronized" if we are
+/// certain that all connections that are awaiting termination are present in the queue. This
+/// means a simple constant-time pop() operation is enough to check whether any connections
+/// need to be terminated.  When the kill queue becomes full, though, pushing fails, so
+/// connections that should be terminated are left out. The queue is not synchronized anymore.
+/// When that happens, the muxer will first drain the queue, and then replace it with a new
+/// queue, created by walking the connection pool, looking for connections that will be
+/// expiring in the future.
+///
+use std::collections::{HashMap, VecDeque};
+use std::time::Instant;
+
+use super::defs;
+use super::muxer::ConnMapKey;
+use super::MuxerConnection;
+
+/// A kill queue item, holding the connection key and the scheduled time for termination.
+///
+#[derive(Clone, Copy)]
+struct MuxerKillQItem {
+    key: ConnMapKey,
+    kill_time: Instant,
+}
+
+/// The connection kill queue: a FIFO structure, storing the connections that are scheduled for
+/// termination.
+///
+pub struct MuxerKillQ {
+    /// The kill queue contents.
+    q: VecDeque<MuxerKillQItem>,
+
+    /// The kill queue sync status:
+    /// - when true, all connections that are awaiting termination are guaranteed to be in this
+    ///   queue;
+    /// - when false, some connections may have been left out.
+    ///
+    synced: bool,
+}
+
+impl MuxerKillQ {
+    const SIZE: usize = defs::MUXER_KILLQ_SIZE;
+
+    /// Trivial kill queue constructor.
+    ///
+    pub fn new() -> Self {
+        Self {
+            q: VecDeque::with_capacity(Self::SIZE),
+            synced: true,
+        }
+    }
+
+    /// Create a kill queue by walking the connection pool, looking for connections that are
+    /// set to expire at some point in the future.
+    /// Note: if more than `Self::SIZE` connections are found, the queue will be created in an
+    ///       out-of-sync state, and will be discarded after it is emptied.
+    ///
+    pub fn from_conn_map(conn_map: &HashMap<ConnMapKey, MuxerConnection>) -> Self {
+        let mut q_buf: Vec<MuxerKillQItem> = Vec::with_capacity(Self::SIZE);
+        let mut synced = true;
+        for (key, conn) in conn_map.iter() {
+            if !conn.will_expire() {
+                continue;
+            }
+            if q_buf.len() >= Self::SIZE {
+                synced = false;
+                break;
+            }
+            q_buf.push(MuxerKillQItem {
+                key: *key,
+                kill_time: conn.expiry().unwrap(),
+            });
+        }
+        q_buf.sort_unstable_by_key(|it| it.kill_time);
+        Self {
+            q: q_buf.into(),
+            synced,
+        }
+    }
+
+    /// Push a connection key to the queue, scheduling it for termination at
+    /// `CONN_SHUTDOWN_TIMEOUT_MS` from now (the push time).
+    ///
+    pub fn push(&mut self, key: ConnMapKey, kill_time: Instant) {
+        if !self.is_synced() || self.is_full() {
+            self.synced = false;
+            return;
+        }
+        self.q.push_back(MuxerKillQItem { key, kill_time });
+    }
+
+    /// Attempt to pop an expired connection from the kill queue.
+    ///
+    /// This will succeed and return a connection key, only if the connection at the front of
+    /// the queue has expired. Otherwise, `None` is returned.
+    ///
+    pub fn pop(&mut self) -> Option<ConnMapKey> {
+        if let Some(item) = self.q.front() {
+            if Instant::now() > item.kill_time {
+                return Some(self.q.pop_front().unwrap().key);
+            }
+        }
+        None
+    }
+
+    /// Check if the kill queue is synchronized with the connection pool.
+    ///
+    pub fn is_synced(&self) -> bool {
+        self.synced
+    }
+
+    /// Check if the kill queue is empty, obviously.
+    ///
+    pub fn is_empty(&self) -> bool {
+        self.q.len() == 0
+    }
+
+    /// Check if the kill queue is full.
+    ///
+    pub fn is_full(&self) -> bool {
+        self.q.len() == Self::SIZE
+    }
+}

--- a/vm-virtio/src/vsock/unix/muxer_rxq.rs
+++ b/vm-virtio/src/vsock/unix/muxer_rxq.rs
@@ -1,0 +1,139 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// `MuxerRxQ` implements a helper object that `VsockMuxer` can use for queuing RX (host -> guest)
+/// packets (or rather instructions on how to build said packets).
+///
+/// Under ideal operation, every connection, that has pending RX data, will be present in the muxer
+/// RX queue. However, since the RX queue is smaller than the connection pool, it may, under some
+/// conditions, become full, meaning that it can no longer account for all the connections that can
+/// yield RX data.  When that happens, we say that it is no longer "synchronized" (i.e. with the
+/// connection pool).  A desynchronized RX queue still holds valid data, and the muxer will
+/// continue to pop packets from it. However, when a desynchronized queue is drained, additional
+/// data may still be available, so the muxer will have to perform a more costly walk of the entire
+/// connection pool to find it.  This walk is performed here, as part of building an RX queue from
+/// the connection pool. When an out-of-sync is drained, the muxer will discard it, and attempt to
+/// rebuild a synced one.
+///
+use std::collections::{HashMap, VecDeque};
+
+use super::super::VsockChannel;
+use super::defs;
+use super::muxer::{ConnMapKey, MuxerRx};
+use super::MuxerConnection;
+
+/// The muxer RX queue.
+///
+pub struct MuxerRxQ {
+    /// The RX queue data.
+    q: VecDeque<MuxerRx>,
+    /// The RX queue sync status.
+    synced: bool,
+}
+
+impl MuxerRxQ {
+    const SIZE: usize = defs::MUXER_RXQ_SIZE;
+
+    /// Trivial RX queue constructor.
+    ///
+    pub fn new() -> Self {
+        Self {
+            q: VecDeque::with_capacity(Self::SIZE),
+            synced: true,
+        }
+    }
+
+    /// Attempt to build an RX queue, that is synchronized to the connection pool.
+    /// Note: the resulting queue may still be desynchronized, if there are too many connections
+    ///       that have pending RX data. In that case, the muxer will first drain this queue, and
+    ///       then try again to build a synchronized one.
+    ///
+    pub fn from_conn_map(conn_map: &HashMap<ConnMapKey, MuxerConnection>) -> Self {
+        let mut q = VecDeque::new();
+        let mut synced = true;
+
+        for (key, conn) in conn_map.iter() {
+            if !conn.has_pending_rx() {
+                continue;
+            }
+            if q.len() >= Self::SIZE {
+                synced = false;
+                break;
+            }
+            q.push_back(MuxerRx::ConnRx(*key));
+        }
+        Self { q, synced }
+    }
+
+    /// Push a new RX item to the queue.
+    ///
+    /// A push will fail when:
+    /// - trying to push a connection key onto an out-of-sync, or full queue; or
+    /// - trying to push an RST onto a queue already full of RSTs.
+    /// RSTs take precedence over connections, because connections can always be queried for
+    /// pending RX data later. Aside from this queue, there is no other storage for RSTs, so
+    /// failing to push one means that we have to drop the packet.
+    ///
+    /// Returns:
+    /// - `true` if the new item has been successfully queued; or
+    /// - `false` if there was no room left in the queue.
+    ///
+    pub fn push(&mut self, rx: MuxerRx) -> bool {
+        // Pushing to a non-full, synchronized queue will always succeed.
+        if self.is_synced() && !self.is_full() {
+            self.q.push_back(rx);
+            return true;
+        }
+
+        match rx {
+            MuxerRx::RstPkt { .. } => {
+                // If we just failed to push an RST packet, we'll look through the queue, trying to
+                // find a connection key that we could evict. This way, the queue does lose sync,
+                // but we don't drop any packets.
+                for qi in self.q.iter_mut().rev() {
+                    if let MuxerRx::ConnRx(_) = qi {
+                        *qi = rx;
+                        self.synced = false;
+                        return true;
+                    }
+                }
+            }
+            MuxerRx::ConnRx(_) => {
+                self.synced = false;
+            }
+        };
+
+        false
+    }
+
+    /// Pop an RX item from the front of the queue.
+    ///
+    pub fn pop(&mut self) -> Option<MuxerRx> {
+        self.q.pop_front()
+    }
+
+    /// Check if the RX queue is synchronized with the connection pool.
+    ///
+    pub fn is_synced(&self) -> bool {
+        self.synced
+    }
+
+    /// Get the total number of items in the queue.
+    ///
+    pub fn len(&self) -> usize {
+        self.q.len()
+    }
+
+    /// Check if the queue is empty.
+    ///
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Check if the queue is full.
+    ///
+    pub fn is_full(&self) -> bool {
+        self.len() == Self::SIZE
+    }
+}

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -39,8 +39,6 @@ use vm_virtio::transport::VirtioPciDevice;
 use vm_virtio::{VirtioSharedMemory, VirtioSharedMemoryList};
 use vmm_sys_util::eventfd::EventFd;
 
-const DEFAULT_MSIX_VEC_NUM: u16 = 2;
-
 // IOAPIC address range
 const IOAPIC_RANGE_ADDR: u64 = 0xfec0_0000;
 const IOAPIC_RANGE_SIZE: u64 = 0x20;
@@ -849,7 +847,10 @@ impl DeviceManager {
         interrupt_info: &InterruptInfo,
     ) -> DeviceManagerResult<()> {
         let msix_num = if interrupt_info.msi_capable {
-            DEFAULT_MSIX_VEC_NUM
+            // Allows support for one MSI-X vector per queue. It also adds 1
+            // as we need to take into account the dedicated vector to notify
+            // about a virtio config change.
+            (virtio_device.queue_max_sizes().len() + 1) as u16
         } else {
             0
         };


### PR DESCRIPTION
This pull request implement `virtio-vsock`. It is entirely based off of Firecracker's hybrid implementation of `virtio-vsock`. It ports both the code and the unit tests over to Cloud-Hypervisor.
The interesting approach with this specific implementation is the absence of backend running in the host kernel. The goal being to prevent any malicious guest from exploiting the host over the virtqueues from the vsock device.
In details, the backend that was `vhost` so far, has been replaced with some code proxying an `AF_UNIX` socket on the host into `AF_VSOCK` socket in the guest. The guest remains unchanged compared to a standard `vhost-vsock` implementation, but the host application now needs to connect to an `AF_UNIX` socket and send a special frame at first to initiate the connection.
The rest of the communication remains unchanged.

All code is based off of Firecracker commit `1e1cb6f8f8003e0bdce11d265f0feb23249a03f6`.

Fixes #102 