### PR TITLE
vmm: If acpi feature is disabled make "reboot" shutdown

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -61,9 +61,13 @@ pub fn boot_kernel(config: VmConfig) -> Result<()> {
         let mut vm = Vm::new(&vmm.kvm, &config).map_err(Error::VmNew)?;
 
         let entry = vm.load_kernel().map_err(Error::LoadKernel)?;
+
         if vm.start(entry).map_err(Error::VmStart)? == ExitBehaviour::Shutdown {
             break;
         }
+
+        #[cfg(not(feature = "acpi"))]
+        break;
     }
 
     Ok(())


### PR DESCRIPTION
With ACPI disabled there is no way to support both reset and shutdown so
make the VMM exit if the VM is rebootet (via i8042 or triple-fault
reset.)

Signed-off-by: Rob Bradford <robert.bradford@intel.com>