### PR TITLE
README: Update rust-hypervisor-firmware link

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ We need to get the latest `rust-hypervisor-firmware` release and also a working 
 $ pushd $CLOUDH
 $ wget https://download.clearlinux.org/releases/29160/clear/clear-29160-kvm.img.xz
 $ unxz clear-29160-kvm.img.xz
-$ wget https://github.com/intel/rust-hypervisor-firmware/releases/download/0.1.0/hypervisor-fw
+$ wget https://github.com/intel/rust-hypervisor-firmware/releases/download/0.2.0/hypervisor-fw
 $ popd
 ```
 


### PR DESCRIPTION
We should use the 0.2.0 firmware.

Fixes: #258

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>