### PR TITLE
ci: Allow tests to print some useful information with println

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -135,7 +135,7 @@ sudo setcap cap_net_admin+ep /usr/bin/qemu-system-x86_64
 sudo adduser $USER kvm
 newgrp kvm << EOF
 export RUST_BACKTRACE=1
-cargo test --features "integration_tests"
+cargo test --features "integration_tests" -- --nocapture
 EOF
 RES=$?
 


### PR DESCRIPTION
In order to make the tests more verbose and help identify more quickly
where a test might be failing, this patch adds the ability for the unit
tests to print useful information with println.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>