### PR TITLE
vmm: Call DeviceManager's register_devices() on creation

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -411,7 +411,7 @@ impl DeviceManager {
 
         let pci = Arc::new(Mutex::new(pci));
 
-        Ok(DeviceManager {
+        let mut dm = DeviceManager {
             io_bus,
             mmio_bus,
             console,
@@ -421,7 +421,11 @@ impl DeviceManager {
             ioapic,
             pci,
             mmap_regions,
-        })
+        };
+
+        dm.register_devices()?;
+
+        Ok(dm)
     }
 
     fn make_virtio_devices(
@@ -911,7 +915,7 @@ impl DeviceManager {
         Ok(())
     }
 
-    pub fn register_devices(&mut self) -> DeviceManagerResult<()> {
+    fn register_devices(&mut self) -> DeviceManagerResult<()> {
         if self.console.serial.is_some() {
             // Insert serial device
             self.io_bus

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -936,10 +936,6 @@ impl<'a> Vm<'a> {
     }
 
     pub fn start(&mut self, entry_addr: GuestAddress) -> Result<ExitBehaviour> {
-        self.devices
-            .register_devices()
-            .map_err(Error::DeviceManager)?;
-
         let vcpu_count = u8::from(&self.config.cpus);
 
         //        let vcpus: Vec<thread::JoinHandle<()>> = Vec::with_capacity(vcpu_count as usize);


### PR DESCRIPTION
Rather than calling it at the very start of the VM execution (i.e. when
the VCPUs are created) do it as part of the DeviceManager creation.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>