### PR TITLE
Add support for virtio-mmio based transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static= "1.4.0"
 default = ["acpi", "pci"]
 acpi = ["vmm/acpi"]
 pci = ["vmm/pci_support"]
+mmio = ["vmm/mmio_support"]
 
 # Integration tests require a special environment to run in
 integration_tests = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,9 @@ tempdir= "0.3.7"
 lazy_static= "1.4.0"
 
 [features]
-default = ["acpi"]
+default = ["acpi", "pci"]
 acpi = ["vmm/acpi"]
+pci = ["vmm/pci_support"]
 
 # Integration tests require a special environment to run in
 integration_tests = []

--- a/devices/src/lib.rs
+++ b/devices/src/lib.rs
@@ -67,6 +67,6 @@ pub enum Error {
     IoError(io::Error),
 }
 
-pub trait Interrupt: Send {
+pub trait Interrupt: Send + Sync {
     fn deliver(&self) -> result::Result<(), std::io::Error>;
 }

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -138,6 +138,19 @@ cargo test --features "integration_tests" -- --nocapture
 EOF
 RES=$?
 
+if [ $RES -eq 0 ]; then
+    # virtio-mmio based testing
+    cargo build --no-default-features --features "mmio"
+    sudo setcap cap_net_admin+ep target/debug/cloud-hypervisor
+
+    newgrp kvm << EOF
+export RUST_BACKTRACE=1
+cargo test --features "integration_tests,mmio" -- --nocapture
+EOF
+
+    RES=$?
+fi
+
 # Tear VFIO test network down
 sudo ip link del vfio-br0
 sudo ip link del vfio-tap0

--- a/src/main.rs
+++ b/src/main.rs
@@ -2226,9 +2226,6 @@ mod tests {
             let mut workload_path = dirs::home_dir().unwrap();
             workload_path.push("workloads");
 
-            let mut kernel_path = workload_path.clone();
-            kernel_path.push("vmlinux");
-
             let sock = temp_vsock_path(&guest.tmp_dir);
 
             let mut child = Command::new("target/debug/cloud-hypervisor")

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,6 +288,7 @@ extern crate lazy_static;
 #[cfg(test)]
 #[cfg(feature = "integration_tests")]
 mod tests {
+    #![allow(dead_code)]
     use ssh2::Session;
     use std::fs;
     use std::io::{Read, Write};
@@ -811,7 +812,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_simple_launch() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -870,7 +871,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_multi_cpu() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -908,7 +909,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_large_memory() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -946,7 +947,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_pci_msi() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1031,6 +1032,8 @@ mod tests {
             aver_eq!(tb, guest.get_cpu_count().unwrap_or_default(), 1);
             aver!(tb, guest.get_total_memory().unwrap_or_default() > 496_000);
             aver!(tb, guest.get_entropy().unwrap_or_default() >= 900);
+
+            #[cfg(not(feature = "mmio"))]
             aver_eq!(
                 tb,
                 guest
@@ -1088,6 +1091,8 @@ mod tests {
             aver_eq!(tb, guest.get_cpu_count().unwrap_or_default(), 1);
             aver!(tb, guest.get_total_memory().unwrap_or_default() > 496_000);
             aver!(tb, guest.get_entropy().unwrap_or_default() >= 900);
+
+            #[cfg(not(feature = "mmio"))]
             aver_eq!(
                 tb,
                 guest
@@ -1107,7 +1112,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_vhost_user_net() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1173,7 +1178,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_split_irqchip() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1348,17 +1353,17 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_fs_dax_on_default_cache_size() {
         test_virtio_fs(true, None, "always")
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_fs_dax_on_cache_size_1_gib() {
         test_virtio_fs(true, Some(0x4000_0000), "always")
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_fs_dax_off() {
         test_virtio_fs(false, None, "none")
     }
@@ -1472,7 +1477,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_multiple_network_interfaces() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1525,7 +1530,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_serial_off() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1586,7 +1591,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_serial_null() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1647,7 +1652,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_serial_tty() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1708,7 +1713,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_serial_file() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1772,7 +1777,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_console() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1804,6 +1809,7 @@ mod tests {
 
             thread::sleep(std::time::Duration::new(20, 0));
 
+            #[cfg(not(feature = "mmio"))]
             aver!(
                 tb,
                 guest
@@ -1830,7 +1836,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_console_file() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -1881,7 +1887,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     // The VFIO integration test starts a qemu guest and then direct assigns
     // one of the virtio-PCI device to a cloud-hypervisor nested guest. The
     // test assigns one of the 2 virtio-pci networking interface, and thus
@@ -2020,7 +2026,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_vmlinux_boot_noacpi() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -2077,7 +2083,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_reboot() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -2151,7 +2157,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_bzimage_reboot() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
@@ -2218,7 +2224,7 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "mmio"), test)]
     fn test_virtio_vsock() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [features]
 default = []
 pci_support = ["pci"]
+mmio_support = []
 
 [dependencies]
 byteorder = "1.3.2"

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Samuel Ortiz <sameo@linux.intel.com>"]
 edition = "2018"
 
+[features]
+default = []
+pci_support = ["pci"]
+
 [dependencies]
 byteorder = "1.3.2"
 devices = { path = "../devices" }
@@ -12,7 +16,7 @@ libc = "0.2.60"
 log = "0.4.8"
 net_gen = { path = "../net_gen" }
 net_util = { path = "../net_util" }
-pci = { path = "../pci" }
+pci = { path = "../pci", optional = true }
 tempfile = "3.1.0"
 virtio-bindings = { path = "../virtio-bindings" }
 vm-allocator = { path = "../vm-allocator" }

--- a/vm-virtio/src/lib.rs
+++ b/vm-virtio/src/lib.rs
@@ -12,6 +12,7 @@
 extern crate epoll;
 #[macro_use]
 extern crate log;
+#[cfg(feature = "pci_support")]
 extern crate pci;
 extern crate vhost_rs;
 extern crate virtio_bindings;

--- a/vm-virtio/src/transport/mmio.rs
+++ b/vm-virtio/src/transport/mmio.rs
@@ -1,0 +1,249 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, RwLock};
+
+use byteorder::{ByteOrder, LittleEndian};
+use libc::EFD_NONBLOCK;
+
+use crate::{
+    Queue, VirtioDevice, VirtioInterrupt, VirtioInterruptType, DEVICE_ACKNOWLEDGE, DEVICE_DRIVER,
+    DEVICE_DRIVER_OK, DEVICE_FAILED, DEVICE_FEATURES_OK, INTERRUPT_STATUS_CONFIG_CHANGED,
+    INTERRUPT_STATUS_USED_RING,
+};
+use devices::{BusDevice, Interrupt};
+use vm_memory::{GuestAddress, GuestMemoryMmap};
+use vmm_sys_util::{errno::Result, eventfd::EventFd};
+
+const VENDOR_ID: u32 = 0;
+
+const MMIO_MAGIC_VALUE: u32 = 0x7472_6976;
+const MMIO_VERSION: u32 = 2;
+
+/// Implements the
+/// [MMIO](http://docs.oasis-open.org/virtio/virtio/v1.0/cs04/virtio-v1.0-cs04.html#x1-1090002)
+/// transport for virtio devices.
+///
+/// This requires 3 points of installation to work with a VM:
+///
+/// 1. Mmio reads and writes must be sent to this device at what is referred to here as MMIO base.
+/// 1. `Mmio::queue_evts` must be installed at `virtio::NOTIFY_REG_OFFSET` offset from the MMIO
+/// base. Each event in the array must be signaled if the index is written at that offset.
+/// 1. `Mmio::interrupt_evt` must signal an interrupt that the guest driver is listening to when it
+/// is written to.
+///
+/// Typically one page (4096 bytes) of MMIO address space is sufficient to handle this transport
+/// and inner virtio device.
+pub struct MmioDevice {
+    device: Box<dyn VirtioDevice>,
+    device_activated: bool,
+
+    features_select: u32,
+    acked_features_select: u32,
+    queue_select: u32,
+    interrupt_status: Arc<AtomicUsize>,
+    interrupt_cb: Option<Arc<VirtioInterrupt>>,
+    driver_status: u32,
+    config_generation: u32,
+    queues: Vec<Queue>,
+    queue_evts: Vec<EventFd>,
+    mem: Option<Arc<RwLock<GuestMemoryMmap>>>,
+}
+
+impl MmioDevice {
+    /// Constructs a new MMIO transport for the given virtio device.
+    pub fn new(
+        mem: Arc<RwLock<GuestMemoryMmap>>,
+        device: Box<dyn VirtioDevice>,
+    ) -> Result<MmioDevice> {
+        let mut queue_evts = Vec::new();
+        for _ in device.queue_max_sizes().iter() {
+            queue_evts.push(EventFd::new(EFD_NONBLOCK)?)
+        }
+        let queues = device
+            .queue_max_sizes()
+            .iter()
+            .map(|&s| Queue::new(s))
+            .collect();
+        Ok(MmioDevice {
+            device,
+            device_activated: false,
+            features_select: 0,
+            acked_features_select: 0,
+            queue_select: 0,
+            interrupt_status: Arc::new(AtomicUsize::new(0)),
+            interrupt_cb: None,
+
+            driver_status: 0,
+            config_generation: 0,
+            queues,
+            queue_evts,
+            mem: Some(mem),
+        })
+    }
+
+    /// Gets the list of queue events that must be triggered whenever the VM writes to
+    /// `virtio::NOTIFY_REG_OFFSET` past the MMIO base. Each event must be triggered when the
+    /// value being written equals the index of the event in this list.
+    pub fn queue_evts(&self) -> &[EventFd] {
+        self.queue_evts.as_slice()
+    }
+
+    fn is_driver_ready(&self) -> bool {
+        let ready_bits = DEVICE_ACKNOWLEDGE | DEVICE_DRIVER | DEVICE_DRIVER_OK | DEVICE_FEATURES_OK;
+        self.driver_status == ready_bits && self.driver_status & DEVICE_FAILED == 0
+    }
+
+    fn are_queues_valid(&self) -> bool {
+        if let Some(mem) = self.mem.as_ref() {
+            self.queues.iter().all(|q| q.is_valid(&mem.read().unwrap()))
+        } else {
+            false
+        }
+    }
+
+    fn with_queue<U, F>(&self, d: U, f: F) -> U
+    where
+        F: FnOnce(&Queue) -> U,
+    {
+        match self.queues.get(self.queue_select as usize) {
+            Some(queue) => f(queue),
+            None => d,
+        }
+    }
+
+    fn with_queue_mut<F: FnOnce(&mut Queue)>(&mut self, f: F) -> bool {
+        if let Some(queue) = self.queues.get_mut(self.queue_select as usize) {
+            f(queue);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn assign_interrupt(&mut self, interrupt: Box<dyn Interrupt>) {
+        let interrupt_status = self.interrupt_status.clone();
+        let cb = Arc::new(Box::new(
+            move |int_type: &VirtioInterruptType, _queue: Option<&Queue>| {
+                let status = match int_type {
+                    VirtioInterruptType::Config => INTERRUPT_STATUS_CONFIG_CHANGED,
+                    VirtioInterruptType::Queue => INTERRUPT_STATUS_USED_RING,
+                };
+                interrupt_status.fetch_or(status as usize, Ordering::SeqCst);
+
+                interrupt.deliver()
+            },
+        ) as VirtioInterrupt);
+
+        self.interrupt_cb = Some(cb);
+    }
+}
+
+impl BusDevice for MmioDevice {
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
+        match offset {
+            0x00..=0xff if data.len() == 4 => {
+                let v = match offset {
+                    0x0 => MMIO_MAGIC_VALUE,
+                    0x04 => MMIO_VERSION,
+                    0x08 => self.device.device_type(),
+                    0x0c => VENDOR_ID, // vendor id
+                    0x10 => {
+                        self.device.features(self.features_select)
+                            | if self.features_select == 1 { 0x1 } else { 0x0 }
+                    }
+                    0x34 => self.with_queue(0, |q| u32::from(q.get_max_size())),
+                    0x44 => self.with_queue(0, |q| q.ready as u32),
+                    0x60 => self.interrupt_status.load(Ordering::SeqCst) as u32,
+                    0x70 => self.driver_status,
+                    0xfc => self.config_generation,
+                    _ => {
+                        warn!("unknown virtio mmio register read: 0x{:x}", offset);
+                        return;
+                    }
+                };
+                LittleEndian::write_u32(data, v);
+            }
+            0x100..=0xfff => self.device.read_config(offset - 0x100, data),
+            _ => {
+                warn!(
+                    "invalid virtio mmio read: 0x{:x}:0x{:x}",
+                    offset,
+                    data.len()
+                );
+            }
+        };
+    }
+
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) {
+        fn hi(v: &mut GuestAddress, x: u32) {
+            *v = (*v & 0xffff_ffff) | (u64::from(x) << 32)
+        }
+
+        fn lo(v: &mut GuestAddress, x: u32) {
+            *v = (*v & !0xffff_ffff) | u64::from(x)
+        }
+
+        let mut mut_q = false;
+        match offset {
+            0x00..=0xff if data.len() == 4 => {
+                let v = LittleEndian::read_u32(data);
+                match offset {
+                    0x14 => self.features_select = v,
+                    0x20 => self.device.ack_features(self.acked_features_select, v),
+                    0x24 => self.acked_features_select = v,
+                    0x30 => self.queue_select = v,
+                    0x38 => mut_q = self.with_queue_mut(|q| q.size = v as u16),
+                    0x44 => mut_q = self.with_queue_mut(|q| q.ready = v == 1),
+                    0x64 => {
+                        self.interrupt_status
+                            .fetch_and(!(v as usize), Ordering::SeqCst);
+                    }
+                    0x70 => self.driver_status = v,
+                    0x80 => mut_q = self.with_queue_mut(|q| lo(&mut q.desc_table, v)),
+                    0x84 => mut_q = self.with_queue_mut(|q| hi(&mut q.desc_table, v)),
+                    0x90 => mut_q = self.with_queue_mut(|q| lo(&mut q.avail_ring, v)),
+                    0x94 => mut_q = self.with_queue_mut(|q| hi(&mut q.avail_ring, v)),
+                    0xa0 => mut_q = self.with_queue_mut(|q| lo(&mut q.used_ring, v)),
+                    0xa4 => mut_q = self.with_queue_mut(|q| hi(&mut q.used_ring, v)),
+                    _ => {
+                        warn!("unknown virtio mmio register write: 0x{:x}", offset);
+                        return;
+                    }
+                }
+            }
+            0x100..=0xfff => return self.device.write_config(offset - 0x100, data),
+            _ => {
+                warn!(
+                    "invalid virtio mmio write: 0x{:x}:0x{:x}",
+                    offset,
+                    data.len()
+                );
+                return;
+            }
+        }
+
+        if self.device_activated && mut_q {
+            warn!("virtio queue was changed after device was activated");
+        }
+
+        if !self.device_activated && self.is_driver_ready() && self.are_queues_valid() {
+            if let Some(interrupt_cb) = self.interrupt_cb.take() {
+                if self.mem.is_some() {
+                    let mem = self.mem.as_ref().unwrap().clone();
+                    self.device
+                        .activate(
+                            mem,
+                            interrupt_cb,
+                            self.queues.clone(),
+                            self.queue_evts.split_off(0),
+                        )
+                        .expect("Failed to activate device");
+                    self.device_activated = true;
+                }
+            }
+        }
+    }
+}

--- a/vm-virtio/src/transport/mod.rs
+++ b/vm-virtio/src/transport/mod.rs
@@ -10,3 +10,10 @@ mod pci_device;
 pub use pci_common_config::VirtioPciCommonConfig;
 #[cfg(feature = "pci_support")]
 pub use pci_device::VirtioPciDevice;
+
+#[cfg(feature = "mmio_support")]
+mod mmio;
+#[cfg(feature = "mmio_support")]
+pub use mmio::MmioDevice;
+#[cfg(feature = "mmio_support")]
+pub const NOTIFY_REG_OFFSET: u32 = 0x50;

--- a/vm-virtio/src/transport/mod.rs
+++ b/vm-virtio/src/transport/mod.rs
@@ -2,8 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "pci_support")]
 mod pci_common_config;
+#[cfg(feature = "pci_support")]
 mod pci_device;
-
+#[cfg(feature = "pci_support")]
 pub use pci_common_config::VirtioPciCommonConfig;
+#[cfg(feature = "pci_support")]
 pub use pci_device::VirtioPciDevice;

--- a/vm-virtio/src/transport/pci_device.rs
+++ b/vm-virtio/src/transport/pci_device.rs
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 extern crate devices;
+#[cfg(feature = "pci_support")]
 extern crate pci;
 extern crate vm_allocator;
 extern crate vm_memory;

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 default = []
 acpi = ["acpi_tables","devices/acpi", "arch/acpi"]
 pci_support = ["pci", "vfio", "vm-virtio/pci_support"]
+mmio_support = ["vm-virtio/mmio_support"]
 
 [dependencies]
 acpi_tables = { path = "../acpi_tables", optional = true }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [features]
 default = []
 acpi = ["acpi_tables","devices/acpi", "arch/acpi"]
+pci_support = ["pci", "vfio", "vm-virtio/pci_support"]
 
 [dependencies]
 acpi_tables = { path = "../acpi_tables", optional = true }
@@ -18,9 +19,9 @@ kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master"
 libc = "0.2.62"
 log = "0.4.8"
 net_util = { path = "../net_util" }
-pci = {path = "../pci"}
+pci = {path = "../pci", optional = true}
 qcow = { path = "../qcow" }
-vfio = { path = "../vfio" }
+vfio = { path = "../vfio", optional = true }
 vm-virtio = { path = "../vm-virtio" }
 vm-allocator = { path = "../vm-allocator" }
 vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -277,6 +277,9 @@ pub struct DeviceManager {
 
     // mmap()ed region to unmap on drop
     mmap_regions: Vec<(*mut libc::c_void, usize)>,
+
+    // Things to be added to the commandline (i.e. for virtio-mmio)
+    cmdline_additions: Vec<String>,
 }
 
 impl DeviceManager {
@@ -392,6 +395,8 @@ impl DeviceManager {
             &mut mmap_regions,
         )?);
 
+        let mut cmdline_additions = Vec::new();
+
         let pci_root = PciRoot::new(None);
         let mut pci = PciConfigIo::new(pci_root);
 
@@ -421,6 +426,7 @@ impl DeviceManager {
             ioapic,
             pci,
             mmap_regions,
+            cmdline_additions,
         };
 
         dm.register_devices()?;
@@ -962,6 +968,10 @@ impl DeviceManager {
 
     pub fn console(&self) -> &Arc<Console> {
         &self.console
+    }
+
+    pub fn cmdline_additions(&self) -> &[String] {
+        self.cmdline_additions.as_slice()
     }
 }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -752,8 +752,12 @@ impl<'a> Vm<'a> {
     }
 
     pub fn load_kernel(&mut self) -> Result<GuestAddress> {
-        let cmdline_cstring =
-            CString::new(self.config.cmdline.args.clone()).map_err(|_| Error::CmdLine)?;
+        let mut cmdline = self.config.cmdline.args.clone();
+        for entry in self.devices.cmdline_additions() {
+            cmdline.insert_str(entry).map_err(|_| Error::CmdLine)?;
+        }
+
+        let cmdline_cstring = CString::new(cmdline).map_err(|_| Error::CmdLine)?;
         let mem = self.memory.read().unwrap();
         let entry_addr = match linux_loader::loader::Elf::load(
             mem.deref(),

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -17,6 +17,7 @@ extern crate libc;
 extern crate linux_loader;
 extern crate net_util;
 extern crate signal_hook;
+#[cfg(feature = "pci_support")]
 extern crate vfio;
 extern crate vm_allocator;
 extern crate vm_memory;


### PR DESCRIPTION
This PR still needs some polish as there are various clippy warnings due to conditional compilation. And it also lacks some new integration tests that will require us to build an alternative version of the binary.