### PR TITLE
Cloud  Hypervisor HTTP API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,10 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "micro_http"
+version = "0.1.0"
+
+[[package]]
 name = "net_gen"
 version = "0.1.0"
 dependencies = [
@@ -428,6 +432,14 @@ dependencies = [
 name = "nodrop"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num_cpus"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "openssl-sys"
@@ -922,6 +934,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,13 +1076,16 @@ dependencies = [
  "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-ioctls 0.2.0 (git+https://github.com/rust-vmm/kvm-ioctls)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "linux-loader 0.1.0 (git+https://github.com/rust-vmm/linux-loader)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "micro_http 0.1.0",
  "net_util 0.1.0",
  "pci 0.1.0",
  "qcow 0.1.0",
  "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vfio 0.0.1",
  "vm-allocator 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
@@ -1167,6 +1190,7 @@ dependencies = [
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum openssl-sys 0.9.50 (registry+https://github.com/rust-lang/crates.io-index)" = "2c42dcccb832556b5926bc9ae61e8775f2a61e725ab07ab3d1e7fcf8ae62c3b6"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 "checksum pnet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63d693c84430248366146e3181ff9d330243464fa9e6146c372b2f3eb2e2d8e7"
@@ -1219,6 +1243,7 @@ dependencies = [
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,6 +768,16 @@ version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde_derive"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1094,9 @@ dependencies = [
  "net_util 0.1.0",
  "pci 0.1.0",
  "qcow 0.1.0",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vfio 0.0.1",
@@ -1226,6 +1239,7 @@ dependencies = [
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
+"checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4f61c4d59f3aaa9f61bba6450a9b80ba48362fd7d651689e7a10c453b1f6dc68"
 "checksum signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc"

--- a/micro_http/Cargo.toml
+++ b/micro_http/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "micro_http"
+version = "0.1.0"
+authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+
+[dependencies]

--- a/micro_http/src/common/headers.rs
+++ b/micro_http/src/common/headers.rs
@@ -16,6 +16,8 @@ pub enum Header {
     Expect,
     /// Header `Transfer-Encoding`.
     TransferEncoding,
+    /// Header `Server`.
+    Server,
 }
 
 impl Header {
@@ -25,6 +27,7 @@ impl Header {
             Header::ContentType => b"Content-Type",
             Header::Expect => b"Expect",
             Header::TransferEncoding => b"Transfer-Encoding",
+            Header::Server => b"Server",
         }
     }
 
@@ -35,6 +38,7 @@ impl Header {
                 "Content-Type" => Ok(Header::ContentType),
                 "Expect" => Ok(Header::Expect),
                 "Transfer-Encoding" => Ok(Header::TransferEncoding),
+                "Server" => Ok(Header::Server),
                 _ => Err(RequestError::InvalidHeader),
             }
         } else {
@@ -130,6 +134,7 @@ impl Headers {
                             }
                             _ => Err(RequestError::InvalidHeader),
                         },
+                        Header::Server => Ok(()),
                     }
                 } else {
                     Err(RequestError::UnsupportedHeader)

--- a/micro_http/src/common/headers.rs
+++ b/micro_http/src/common/headers.rs
@@ -102,8 +102,8 @@ impl Headers {
                         Header::ContentLength => {
                             let try_numeric: Result<i32, std::num::ParseIntError> =
                                 std::str::FromStr::from_str(entry[1].trim());
-                            if try_numeric.is_ok() {
-                                self.content_length = try_numeric.unwrap();
+                            if let Ok(content_length) = try_numeric {
+                                self.content_length = content_length;
                                 Ok(())
                             } else {
                                 Err(RequestError::InvalidHeader)

--- a/micro_http/src/common/headers.rs
+++ b/micro_http/src/common/headers.rs
@@ -1,0 +1,392 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::result::Result;
+
+use RequestError;
+
+/// Wrapper over an HTTP Header type.
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub enum Header {
+    /// Header `Content-Length`.
+    ContentLength,
+    /// Header `Content-Type`.
+    ContentType,
+    /// Header `Expect`.
+    Expect,
+    /// Header `Transfer-Encoding`.
+    TransferEncoding,
+}
+
+impl Header {
+    pub fn raw(&self) -> &'static [u8] {
+        match self {
+            Header::ContentLength => b"Content-Length",
+            Header::ContentType => b"Content-Type",
+            Header::Expect => b"Expect",
+            Header::TransferEncoding => b"Transfer-Encoding",
+        }
+    }
+
+    fn try_from(string: &[u8]) -> Result<Self, RequestError> {
+        if let Ok(utf8_string) = String::from_utf8(string.to_vec()) {
+            match utf8_string.trim() {
+                "Content-Length" => Ok(Header::ContentLength),
+                "Content-Type" => Ok(Header::ContentType),
+                "Expect" => Ok(Header::Expect),
+                "Transfer-Encoding" => Ok(Header::TransferEncoding),
+                _ => Err(RequestError::InvalidHeader),
+            }
+        } else {
+            Err(RequestError::InvalidRequest)
+        }
+    }
+}
+
+/// Wrapper over the list of headers associated with a Request that we need
+/// in order to parse the request correctly and be able to respond to it.
+///
+/// The only `Content-Type`s supported are `text/plain` and `application/json`, which are both
+/// in plain text actually and don't influence our parsing process.
+///
+/// All the other possible header fields are not necessary in order to serve this connection
+/// and, thus, are not of interest to us. However, we still look for header fields that might
+/// invalidate our request as we don't support the full set of HTTP/1.1 specification.
+/// Such header entries are "Transfer-Encoding: identity; q=0", which means a compression
+/// algorithm is applied to the body of the request, or "Expect: 103-checkpoint".
+#[derive(Debug)]
+pub struct Headers {
+    /// The `Content-Length` header field tells us how many bytes we need to receive
+    /// from the source after the headers.
+    content_length: i32,
+    /// The `Expect` header field is set when the headers contain the entry "Expect: 100-continue".
+    /// This means that, per HTTP/1.1 specifications, we must send a response with the status code
+    /// 100 after we have received the headers in order to receive the body of the request. This
+    /// field should be known immediately after parsing the headers.
+    expect: bool,
+    /// `Chunked` is a possible value of the `Transfer-Encoding` header field and every HTTP/1.1
+    /// server must support it. It is useful only when receiving the body of the request and should
+    /// be known immediately after parsing the headers.
+    chunked: bool,
+}
+
+impl Headers {
+    /// By default Requests are created with no headers.
+    pub fn default() -> Headers {
+        Headers {
+            content_length: 0,
+            expect: false,
+            chunked: false,
+        }
+    }
+
+    /// Expects one header line and parses it, updating the header structure or returning an
+    /// error if the header is invalid.
+    ///
+    /// # Errors
+    /// `UnsupportedHeader` is returned when the parsed header line is not of interest
+    /// to us or when it is unrecognizable.
+    /// `InvalidHeader` is returned when the parsed header is formatted incorrectly or suggests
+    /// that the client is using HTTP features that we do not support in this implementation,
+    /// which invalidates the request.
+    pub fn parse_header_line(&mut self, header_line: &[u8]) -> Result<(), RequestError> {
+        // Headers must be ASCII, so also UTF-8 valid.
+        match std::str::from_utf8(header_line) {
+            Ok(headers_str) => {
+                let entry = headers_str.split(": ").collect::<Vec<&str>>();
+                if entry.len() != 2 {
+                    return Err(RequestError::InvalidHeader);
+                }
+                if let Ok(head) = Header::try_from(entry[0].as_bytes()) {
+                    match head {
+                        Header::ContentLength => {
+                            let try_numeric: Result<i32, std::num::ParseIntError> =
+                                std::str::FromStr::from_str(entry[1].trim());
+                            if try_numeric.is_ok() {
+                                self.content_length = try_numeric.unwrap();
+                                Ok(())
+                            } else {
+                                Err(RequestError::InvalidHeader)
+                            }
+                        }
+                        Header::ContentType => {
+                            match MediaType::try_from(entry[1].trim().as_bytes()) {
+                                Ok(_) => Ok(()),
+                                Err(_) => Err(RequestError::InvalidHeader),
+                            }
+                        }
+                        Header::TransferEncoding => match entry[1].trim() {
+                            "chunked" => {
+                                self.chunked = true;
+                                Ok(())
+                            }
+                            "identity; q=0" => Err(RequestError::InvalidHeader),
+                            _ => Err(RequestError::UnsupportedHeader),
+                        },
+                        Header::Expect => match entry[1].trim() {
+                            "100-continue" => {
+                                self.expect = true;
+                                Ok(())
+                            }
+                            _ => Err(RequestError::InvalidHeader),
+                        },
+                    }
+                } else {
+                    Err(RequestError::UnsupportedHeader)
+                }
+            }
+            _ => Err(RequestError::InvalidHeader),
+        }
+    }
+
+    /// Returns the content length of the body.
+    pub fn content_length(&self) -> i32 {
+        self.content_length
+    }
+
+    /// Returns `true` if the transfer encoding is chunked.
+    #[allow(unused)]
+    pub fn chunked(&self) -> bool {
+        self.chunked
+    }
+
+    /// Returns `true` if the client is expecting the code 100.
+    #[allow(unused)]
+    pub fn expect(&self) -> bool {
+        self.expect
+    }
+
+    #[cfg(test)]
+    pub fn new(content_length: i32, expect: bool, chunked: bool) -> Self {
+        Headers {
+            content_length,
+            expect,
+            chunked,
+        }
+    }
+
+    /// Parses a byte slice into a Headers structure for a HTTP request.
+    ///
+    /// The byte slice is expected to have the following format: </br>
+    ///     * Request Header Lines "<header_line> CRLF"- Optional </br>
+    /// There can be any number of request headers, including none, followed by
+    /// an extra sequence of Carriage Return and Line Feed.
+    /// All header fields are parsed. However, only the ones present in the
+    /// [`Headers`](struct.Headers.html) struct are relevant to us and stored
+    /// for future use.
+    ///
+    /// # Errors
+    /// The function returns `InvalidHeader` when parsing the byte stream fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate micro_http;
+    /// use micro_http::Headers;
+    ///
+    /// let request_headers = Headers::try_from(b"Content-Length: 55\r\n\r\n");
+    /// ```
+    pub fn try_from(bytes: &[u8]) -> Result<Headers, RequestError> {
+        // Headers must be ASCII, so also UTF-8 valid.
+        if let Ok(text) = std::str::from_utf8(bytes) {
+            let mut headers = Headers::default();
+
+            let header_lines = text.split("\r\n");
+            for header_line in header_lines {
+                if header_line.is_empty() {
+                    break;
+                }
+                match headers.parse_header_line(header_line.as_bytes()) {
+                    Ok(_) | Err(RequestError::UnsupportedHeader) => continue,
+                    Err(e) => return Err(e),
+                };
+            }
+            return Ok(headers);
+        }
+        Err(RequestError::InvalidRequest)
+    }
+}
+
+/// Wrapper over supported Media Types.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MediaType {
+    /// Media Type: "text/plain".
+    PlainText,
+    /// Media Type: "application/json".
+    ApplicationJson,
+}
+
+impl Default for MediaType {
+    fn default() -> Self {
+        MediaType::PlainText
+    }
+}
+
+impl MediaType {
+    fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
+        if bytes.is_empty() {
+            return Err(RequestError::InvalidRequest);
+        }
+        let utf8_slice =
+            String::from_utf8(bytes.to_vec()).map_err(|_| RequestError::InvalidRequest)?;
+        match utf8_slice.as_str() {
+            "text/plain" => Ok(MediaType::PlainText),
+            "application/json" => Ok(MediaType::ApplicationJson),
+            _ => Err(RequestError::InvalidRequest),
+        }
+    }
+
+    /// Returns a static string representation of the object.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            MediaType::PlainText => "text/plain",
+            MediaType::ApplicationJson => "application/json",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default() {
+        let headers = Headers::default();
+        assert_eq!(headers.content_length(), 0);
+        assert_eq!(headers.chunked(), false);
+        assert_eq!(headers.expect(), false);
+    }
+
+    #[test]
+    fn test_try_from_media() {
+        assert_eq!(
+            MediaType::try_from(b"application/json").unwrap(),
+            MediaType::ApplicationJson
+        );
+
+        assert_eq!(
+            MediaType::try_from(b"text/plain").unwrap(),
+            MediaType::PlainText
+        );
+
+        assert_eq!(
+            MediaType::try_from(b"").unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        assert_eq!(
+            MediaType::try_from(b"application/json-patch").unwrap_err(),
+            RequestError::InvalidRequest
+        );
+    }
+
+    #[test]
+    fn test_media_as_str() {
+        let media_type = MediaType::ApplicationJson;
+        assert_eq!(media_type.as_str(), "application/json");
+
+        let media_type = MediaType::PlainText;
+        assert_eq!(media_type.as_str(), "text/plain");
+    }
+
+    #[test]
+    fn test_try_from_headers() {
+        // Valid headers.
+        assert_eq!(
+            Headers::try_from(
+                b"Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\nContent-Length: 55\r\n\r\n"
+            )
+            .unwrap()
+            .content_length,
+            55
+        );
+
+        let bytes: [u8; 10] = [130, 140, 150, 130, 140, 150, 130, 140, 150, 160];
+        // Invalid headers.
+        assert!(Headers::try_from(&bytes[..]).is_err());
+    }
+
+    #[test]
+    fn test_parse_header_line() {
+        let mut header = Headers::default();
+
+        // Invalid header syntax.
+        assert_eq!(
+            header.parse_header_line(b"Expect"),
+            Err(RequestError::InvalidHeader)
+        );
+
+        // Invalid content length.
+        assert_eq!(
+            header.parse_header_line(b"Content-Length: five"),
+            Err(RequestError::InvalidHeader)
+        );
+
+        // Invalid transfer encoding.
+        assert_eq!(
+            header.parse_header_line(b"Transfer-Encoding: gzip"),
+            Err(RequestError::UnsupportedHeader)
+        );
+
+        // Invalid expect.
+        assert_eq!(
+            header
+                .parse_header_line(b"Expect: 102-processing")
+                .unwrap_err(),
+            RequestError::InvalidHeader
+        );
+
+        // Invalid media type.
+        assert_eq!(
+            header
+                .parse_header_line(b"Content-Type: application/json-patch")
+                .unwrap_err(),
+            RequestError::InvalidHeader
+        );
+
+        // Invalid input format.
+        let input: [u8; 10] = [130, 140, 150, 130, 140, 150, 130, 140, 150, 160];
+        assert_eq!(
+            header.parse_header_line(&input[..]).unwrap_err(),
+            RequestError::InvalidHeader
+        );
+
+        // Test valid transfer encoding.
+        assert!(header
+            .parse_header_line(b"Transfer-Encoding: chunked")
+            .is_ok());
+        assert!(header.chunked());
+
+        // Test valid expect.
+        assert!(header.parse_header_line(b"Expect: 100-continue").is_ok());
+        assert!(header.expect());
+
+        // Test valid media type.
+        assert!(header
+            .parse_header_line(b"Content-Type: application/json")
+            .is_ok());
+    }
+
+    #[test]
+    fn test_header_try_from() {
+        // Bad header.
+        assert_eq!(
+            Header::try_from(b"Encoding").unwrap_err(),
+            RequestError::InvalidHeader
+        );
+
+        // Invalid encoding.
+        let input: [u8; 10] = [130, 140, 150, 130, 140, 150, 130, 140, 150, 160];
+        assert_eq!(
+            Header::try_from(&input[..]).unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        // Test valid headers.
+        let header = Header::try_from(b"Expect").unwrap();
+        assert_eq!(header.raw(), b"Expect");
+
+        let header = Header::try_from(b"Transfer-Encoding").unwrap();
+        assert_eq!(header.raw(), b"Transfer-Encoding");
+    }
+}

--- a/micro_http/src/common/mod.rs
+++ b/micro_http/src/common/mod.rs
@@ -1,0 +1,236 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod headers;
+
+pub mod ascii {
+    pub const CR: u8 = b'\r';
+    pub const COLON: u8 = b':';
+    pub const LF: u8 = b'\n';
+    pub const SP: u8 = b' ';
+    pub const CRLF_LEN: usize = 2;
+}
+
+/// Errors associated with parsing the HTTP Request from a u8 slice.
+#[derive(Debug, PartialEq)]
+pub enum RequestError {
+    /// The HTTP Method is not supported or it is invalid.
+    InvalidHttpMethod(&'static str),
+    /// Request URI is invalid.
+    InvalidUri(&'static str),
+    /// The HTTP Version in the Request is not supported or it is invalid.
+    InvalidHttpVersion(&'static str),
+    /// The header specified may be valid, but is not supported by this HTTP implementation.
+    UnsupportedHeader,
+    /// Header specified is invalid.
+    InvalidHeader,
+    /// The Request is invalid and cannot be served.
+    InvalidRequest,
+}
+
+/// Errors associated with a HTTP Connection.
+#[derive(Debug)]
+pub enum ConnectionError {
+    /// The request parsing has failed.
+    ParseError(RequestError),
+    /// Could not perform a stream operation successfully.
+    StreamError(std::io::Error),
+    /// Attempted to read or write on a closed connection.
+    ConnectionClosed,
+    /// Attempted to write on a stream when there was nothing to write.
+    InvalidWrite,
+}
+
+/// The Body associated with an HTTP Request or Response.
+///
+/// ## Examples
+/// ```
+/// extern crate micro_http;
+/// use micro_http::Body;
+/// let body = Body::new("This is a test body.".to_string());
+/// assert_eq!(body.raw(), b"This is a test body.");
+/// assert_eq!(body.len(), 20);
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct Body {
+    /// Body of the HTTP message as bytes.
+    pub body: Vec<u8>,
+}
+
+impl Body {
+    /// Creates a new `Body` from a `String` input.
+    pub fn new<T: Into<Vec<u8>>>(body: T) -> Self {
+        Body { body: body.into() }
+    }
+
+    /// Returns the body as an `u8 slice`.
+    pub fn raw(&self) -> &[u8] {
+        self.body.as_slice()
+    }
+
+    /// Returns the length of the `Body`.
+    pub fn len(&self) -> usize {
+        self.body.len()
+    }
+
+    /// Checks if the body is empty, ie with zero length
+    pub fn is_empty(&self) -> bool {
+        self.body.len() == 0
+    }
+}
+
+/// Supported HTTP Methods.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Method {
+    /// GET Method.
+    Get,
+    /// PUT Method.
+    Put,
+    /// PATCH Method.
+    Patch,
+}
+
+impl Method {
+    /// Returns a `Method` object if the parsing of `bytes` is successful.
+    ///
+    /// The method is case sensitive. A call to try_from with the input b"get" will return
+    /// an error, but when using the input b"GET", it returns Method::Get.
+    ///
+    /// # Errors
+    /// Returns `RequestError` if the method specified by `bytes` is unsupported.
+    pub fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
+        match bytes {
+            b"GET" => Ok(Method::Get),
+            b"PUT" => Ok(Method::Put),
+            b"PATCH" => Ok(Method::Patch),
+            _ => Err(RequestError::InvalidHttpMethod("Unsupported HTTP method.")),
+        }
+    }
+
+    /// Returns an `u8 slice` corresponding to the Method.
+    pub fn raw(self) -> &'static [u8] {
+        match self {
+            Method::Get => b"GET",
+            Method::Put => b"PUT",
+            Method::Patch => b"PATCH",
+        }
+    }
+}
+
+/// Supported HTTP Versions.
+///
+/// # Examples
+/// ```
+/// extern crate micro_http;
+/// use micro_http::Version;
+/// let version = Version::try_from(b"HTTP/1.1");
+/// assert!(version.is_ok());
+///
+/// let version = Version::try_from(b"http/1.1");
+/// assert!(version.is_err());
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Version {
+    /// HTTP/1.0
+    Http10,
+    /// HTTP/1.1
+    Http11,
+}
+
+impl Version {
+    /// HTTP Version as an `u8 slice`.
+    pub fn raw(self) -> &'static [u8] {
+        match self {
+            Version::Http10 => b"HTTP/1.0",
+            Version::Http11 => b"HTTP/1.1",
+        }
+    }
+
+    /// Creates a new HTTP Version from an `u8 slice`.
+    ///
+    /// The supported versions are HTTP/1.0 and HTTP/1.1.
+    /// The version is case sensitive and the accepted input is upper case.
+    ///
+    /// # Errors
+    /// Returns a `RequestError` when the version is not supported.
+    ///
+    pub fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
+        match bytes {
+            b"HTTP/1.0" => Ok(Version::Http10),
+            b"HTTP/1.1" => Ok(Version::Http11),
+            _ => Err(RequestError::InvalidHttpVersion(
+                "Unsupported HTTP version.",
+            )),
+        }
+    }
+
+    /// Returns the default HTTP version = HTTP/1.1.
+    pub fn default() -> Self {
+        Version::Http11
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl PartialEq for ConnectionError {
+        fn eq(&self, other: &Self) -> bool {
+            use self::ConnectionError::*;
+            match (self, other) {
+                (ParseError(_), ParseError(_)) => true,
+                (ConnectionClosed, ConnectionClosed) => true,
+                (StreamError(_), StreamError(_)) => true,
+                (InvalidWrite, InvalidWrite) => true,
+                _ => false,
+            }
+        }
+    }
+
+    #[test]
+    fn test_version() {
+        // Tests for raw()
+        assert_eq!(Version::Http10.raw(), b"HTTP/1.0");
+        assert_eq!(Version::Http11.raw(), b"HTTP/1.1");
+
+        // Tests for try_from()
+        assert_eq!(Version::try_from(b"HTTP/1.0").unwrap(), Version::Http10);
+        assert_eq!(Version::try_from(b"HTTP/1.1").unwrap(), Version::Http11);
+        assert_eq!(
+            Version::try_from(b"HTTP/2.0").unwrap_err(),
+            RequestError::InvalidHttpVersion("Unsupported HTTP version.")
+        );
+
+        // Test for default()
+        assert_eq!(Version::default(), Version::Http11);
+    }
+
+    #[test]
+    fn test_method() {
+        // Test for raw
+        assert_eq!(Method::Get.raw(), b"GET");
+        assert_eq!(Method::Put.raw(), b"PUT");
+        assert_eq!(Method::Patch.raw(), b"PATCH");
+
+        // Tests for try_from
+        assert_eq!(Method::try_from(b"GET").unwrap(), Method::Get);
+        assert_eq!(Method::try_from(b"PUT").unwrap(), Method::Put);
+        assert_eq!(Method::try_from(b"PATCH").unwrap(), Method::Patch);
+        assert_eq!(
+            Method::try_from(b"POST").unwrap_err(),
+            RequestError::InvalidHttpMethod("Unsupported HTTP method.")
+        );
+    }
+
+    #[test]
+    fn test_body() {
+        let body = Body::new("".to_string());
+        // Test for is_empty
+        assert!(body.is_empty());
+        let body = Body::new("This is a body.".to_string());
+        // Test for len
+        assert_eq!(body.len(), 15);
+        // Test for raw
+        assert_eq!(body.raw(), b"This is a body.");
+    }
+}

--- a/micro_http/src/connection.rs
+++ b/micro_http/src/connection.rs
@@ -1,0 +1,760 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::VecDeque;
+use std::io::{Read, Write};
+
+use common::ascii::{CR, CRLF_LEN, LF};
+use common::Body;
+pub use common::{ConnectionError, RequestError};
+use headers::Headers;
+use request::{find, Request, RequestLine};
+use response::{Response, StatusCode};
+
+const BUFFER_SIZE: usize = 1024;
+
+/// Describes the state machine of an HTTP connection.
+pub enum ConnectionState {
+    WaitingForRequestLine,
+    WaitingForHeaders,
+    WaitingForBody,
+    RequestReady,
+}
+
+/// A wrapper over a HTTP Connection.
+pub struct HttpConnection<T> {
+    /// A partial request that is still being received.
+    pending_request: Option<Request>,
+    /// Stream implementing `Read` and `Write`, capable of sending and
+    /// receiving bytes.
+    stream: T,
+    /// The state of the connection regarding the current request that
+    /// is being processed.
+    state: ConnectionState,
+    /// Buffer where we store the bytes we read from the stream.
+    buffer: [u8; BUFFER_SIZE],
+    /// The index in the buffer from where we have to start reading in
+    /// the next `try_read` call.
+    read_cursor: usize,
+    /// Contains all bytes pertaining to the body of the request that
+    /// is currently being processed.
+    body_vec: Vec<u8>,
+    /// Represents how many bytes from the body of the request are still
+    /// to be read.
+    body_bytes_to_be_read: i32,
+    /// A queue of all requests that have been fully received and parsed.
+    parsed_requests: VecDeque<Request>,
+    /// A queue of requests that are waiting to be sent.
+    response_queue: VecDeque<Response>,
+    /// A buffer containing the bytes of a response that is currently
+    /// being sent.
+    response_buffer: Option<Vec<u8>>,
+}
+
+impl<T: Read + Write> HttpConnection<T> {
+    /// Creates an empty connection.
+    pub fn new(stream: T) -> Self {
+        HttpConnection {
+            pending_request: None,
+            stream,
+            state: ConnectionState::WaitingForRequestLine,
+            buffer: [0; BUFFER_SIZE],
+            read_cursor: 0,
+            body_vec: vec![],
+            body_bytes_to_be_read: 0,
+            parsed_requests: VecDeque::new(),
+            response_queue: VecDeque::new(),
+            response_buffer: None,
+        }
+    }
+
+    /// Tries to read new bytes from the stream and automatically update the request.
+    /// Meant to be used only with non-blocking streams and an `EPOLL` structure.
+    /// Should be called whenever an `EPOLLIN` event is signaled.
+    pub fn try_read(&mut self) -> Result<(), ConnectionError> {
+        // Read some bytes from the stream, which will be appended to what is already
+        // present in the buffer from a previous call of `try_read`. There are already
+        // `read_cursor` bytes present in the buffer.
+        let end_cursor = self.read_bytes()?;
+
+        let mut line_start_index = 0;
+        loop {
+            match self.state {
+                ConnectionState::WaitingForRequestLine => {
+                    if !self.parse_request_line(&mut line_start_index, end_cursor)? {
+                        return Ok(());
+                    }
+                }
+                ConnectionState::WaitingForHeaders => {
+                    if !self.parse_headers(&mut line_start_index, end_cursor)? {
+                        return Ok(());
+                    }
+                }
+                ConnectionState::WaitingForBody => {
+                    if !self.parse_body(&mut line_start_index, end_cursor)? {
+                        return Ok(());
+                    }
+                }
+                ConnectionState::RequestReady => {
+                    // This request is ready to be passed for handling.
+                    // Update the state machine to expect a new request and push this request into
+                    // the `parsed_requests` queue.
+                    self.state = ConnectionState::WaitingForRequestLine;
+                    self.body_bytes_to_be_read = 0;
+                    self.parsed_requests
+                        .push_back(self.pending_request.take().unwrap());
+                }
+            };
+        }
+    }
+
+    // Reads a maximum of 1024 bytes from the stream into `buffer`.
+    // The return value represents the end index of what we have just appended.
+    fn read_bytes(&mut self) -> Result<usize, ConnectionError> {
+        // Append new bytes to what we already have in the buffer.
+        let bytes_read = self
+            .stream
+            .read(&mut self.buffer[self.read_cursor..])
+            .map_err(ConnectionError::StreamError)?;
+
+        // If the read returned 0 then the client has closed the connection.
+        if bytes_read == 0 {
+            return Err(ConnectionError::ConnectionClosed);
+        }
+
+        Ok(bytes_read + self.read_cursor)
+    }
+
+    // Parses bytes in `buffer` for a valid request line.
+    // Returns `false` if there are no more bytes to be parsed in the buffer.
+    fn parse_request_line(
+        &mut self,
+        start: &mut usize,
+        end: usize,
+    ) -> Result<bool, ConnectionError> {
+        match find(&self.buffer[*start..end], &[CR, LF]) {
+            Some(line_end_index) => {
+                let line = &self.buffer[*start..(*start + line_end_index)];
+
+                *start = *start + line_end_index + CRLF_LEN;
+                let request_line =
+                    RequestLine::try_from(line).map_err(ConnectionError::ParseError)?;
+
+                // Form the request with a valid request line, which is the bare minimum
+                // for a valid request.
+                self.pending_request = Some(Request {
+                    request_line,
+                    headers: Headers::default(),
+                    body: None,
+                });
+                self.state = ConnectionState::WaitingForHeaders;
+                Ok(true)
+            }
+            None => {
+                // The request line is longer than BUFFER_SIZE bytes, so the request is invalid.
+                if end == BUFFER_SIZE && *start == 0 {
+                    return Err(ConnectionError::ParseError(RequestError::InvalidRequest));
+                } else {
+                    // Move the incomplete request line to the beginning of the buffer and wait
+                    // for the next `try_read` call to complete it.
+                    // This can only happen if another request was sent before this one, as the
+                    // limit for the length of a request line in this implementation is 1024 bytes.
+                    self.shift_buffer_left(*start, end);
+                }
+                Ok(false)
+            }
+        }
+    }
+
+    // Parses bytes in `buffer` for header fields.
+    // Returns `false` if there are no more bytes to be parsed in the buffer.
+    fn parse_headers(
+        &mut self,
+        line_start_index: &mut usize,
+        end_cursor: usize,
+    ) -> Result<bool, ConnectionError> {
+        match find(&self.buffer[*line_start_index..end_cursor], &[CR, LF]) {
+            // We have found the end of the headers.
+            // `line_start_index` points to the end of the most recently found CR LF
+            // sequence. That means that if we found the next CR LF sequence at this index,
+            // they are, in fact, a CR LF CR LF sequence, which marks the end of the header
+            // fields, per HTTP specification.
+            Some(0) => {
+                // If our current state is `WaitingForHeaders`, it means that we already have
+                // a valid request formed from a request line, so it's safe to unwrap.
+                let request = self.pending_request.as_mut().unwrap();
+                if request.headers.content_length() == 0 {
+                    self.state = ConnectionState::RequestReady;
+                } else {
+                    if request.headers.expect() {
+                        // Send expect.
+                        let expect_response =
+                            Response::new(request.http_version(), StatusCode::Continue);
+                        self.response_queue.push_back(expect_response);
+                    }
+
+                    self.body_bytes_to_be_read = request.headers.content_length();
+                    request.body = Some(Body::new(vec![]));
+                    self.state = ConnectionState::WaitingForBody;
+                }
+
+                // Update the index for the next header.
+                *line_start_index += CRLF_LEN;
+                Ok(true)
+            }
+            // We have found the end of a header line.
+            Some(relative_line_end_index) => {
+                let request = self.pending_request.as_mut().unwrap();
+                // The `line_end_index` relative to the whole buffer.
+                let line_end_index = relative_line_end_index + *line_start_index;
+
+                // Get the line slice and parse it.
+                let line = &self.buffer[*line_start_index..line_end_index];
+                match request.headers.parse_header_line(line) {
+                    // If a header is unsupported we ignore it.
+                    Ok(_) | Err(RequestError::UnsupportedHeader) => {}
+                    // If parsing the header invalidates the request, we propagate
+                    // the error.
+                    Err(e) => return Err(ConnectionError::ParseError(e)),
+                };
+
+                // Update the `line_start_index` to where we finished parsing.
+                *line_start_index = line_end_index + CRLF_LEN;
+                Ok(true)
+            }
+            // If we have an incomplete header line.
+            None => {
+                // If we have parsed BUFFER_SIZE bytes and still haven't found the header
+                // line end sequence.
+                if *line_start_index == 0 && end_cursor == BUFFER_SIZE {
+                    // Header line is longer than BUFFER_SIZE bytes, so it is invalid.
+                    return Err(ConnectionError::ParseError(RequestError::InvalidHeader));
+                }
+                // Move the incomplete header line from the end of the buffer to
+                // the beginning, so that we can append the rest of the line and
+                // parse it in the next `try_read` call.
+                self.shift_buffer_left(*line_start_index, end_cursor);
+                Ok(false)
+            }
+        }
+    }
+
+    // Parses bytes in `buffer` to be put into the request body, if there should be one.
+    // Returns `false` if there are no more bytes to be parsed in the buffer.
+    fn parse_body(
+        &mut self,
+        line_start_index: &mut usize,
+        end_cursor: usize,
+    ) -> Result<bool, ConnectionError> {
+        // If what we have just read is not enough to complete the request and
+        // there are more bytes pertaining to the body of the request.
+        if self.body_bytes_to_be_read > end_cursor as i32 - *line_start_index as i32 {
+            // Append everything that we read to our current incomplete body and update
+            // `body_bytes_to_be_read`.
+            self.body_vec
+                .extend_from_slice(&self.buffer[*line_start_index..end_cursor]);
+            self.body_bytes_to_be_read -= end_cursor as i32 - *line_start_index as i32;
+
+            // Clear the buffer and reset the starting index.
+            for i in 0..BUFFER_SIZE {
+                self.buffer[i] = 0;
+            }
+            self.read_cursor = 0;
+
+            return Ok(false);
+        }
+
+        // Append only the remaining necessary bytes to the body of the request.
+        self.body_vec.extend_from_slice(
+            &self.buffer
+                [*line_start_index..(*line_start_index + self.body_bytes_to_be_read as usize)],
+        );
+        *line_start_index += self.body_bytes_to_be_read as usize;
+        self.body_bytes_to_be_read = 0;
+
+        let request = self.pending_request.as_mut().unwrap();
+        // If there are no more bytes to be read for this request.
+        // Assign the body of the request.
+        let placeholder: Vec<_> = self
+            .body_vec
+            .drain(..request.headers.content_length() as usize)
+            .collect();
+        request.body = Some(Body::new(placeholder));
+
+        // If we read more bytes than we should have into the body of the request.
+        if !self.body_vec.is_empty() {
+            return Err(ConnectionError::ParseError(RequestError::InvalidRequest));
+        }
+
+        self.state = ConnectionState::RequestReady;
+        Ok(true)
+    }
+
+    /// Tries to write the first available response to the provided stream.
+    /// Meant to be used only with non-blocking streams and an `EPOLL` structure.
+    /// Should be called whenever an `EPOLLOUT` event is signaled.
+    pub fn try_write(&mut self) -> Result<(), ConnectionError> {
+        if self.response_buffer.is_none() {
+            if let Some(response) = self.response_queue.pop_front() {
+                let mut response_buffer_vec: Vec<u8> = Vec::new();
+                response
+                    .write_all(&mut response_buffer_vec)
+                    .map_err(ConnectionError::StreamError)?;
+                self.response_buffer = Some(response_buffer_vec);
+            } else {
+                return Err(ConnectionError::InvalidWrite);
+            }
+        }
+
+        let mut response_fully_written = false;
+
+        if let Some(response_buffer_vec) = self.response_buffer.as_mut() {
+            let bytes_to_be_written = response_buffer_vec.len();
+            match self.stream.write(response_buffer_vec.as_slice()) {
+                Ok(0) => {
+                    return Err(ConnectionError::ConnectionClosed);
+                }
+                Ok(bytes_written) => {
+                    if bytes_written != bytes_to_be_written {
+                        response_buffer_vec.drain(..bytes_written);
+                    } else {
+                        response_fully_written = true;
+                    }
+                }
+                Err(io_error) => {
+                    return Err(ConnectionError::StreamError(io_error));
+                }
+            }
+        }
+
+        if response_fully_written {
+            self.response_buffer.take();
+        }
+
+        Ok(())
+    }
+
+    /// Send a response back to the source of a request.
+    pub fn enqueue_response(&mut self, response: Response) {
+        self.response_queue.push_back(response);
+    }
+
+    fn shift_buffer_left(&mut self, line_start_index: usize, end_cursor: usize) {
+        // We don't want to shift something that is already at the beginning.
+        if line_start_index != 0 {
+            // Move the bytes from `line_start_index` to the beginning of the buffer.
+            for cursor in 0..(end_cursor - line_start_index) {
+                self.buffer[cursor] = self.buffer[line_start_index + cursor];
+            }
+
+            // Clear the rest of the buffer.
+            for cursor in (end_cursor - line_start_index)..end_cursor {
+                self.buffer[cursor] = 0;
+            }
+        }
+
+        // Update `read_cursor`.
+        self.read_cursor = end_cursor - line_start_index;
+    }
+
+    /// Returns the first parsed request in the queue.
+    pub fn pop_parsed_request(&mut self) -> Option<Request> {
+        self.parsed_requests.pop_front()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::{Method, Version};
+    use std::os::unix::net::UnixStream;
+
+    #[test]
+    fn test_try_read_expect() {
+        // Test request with `Expect` header.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n \
+                                 Expect: 100-continue\r\n \
+                                 Content-Length: 26\r\n \
+                                 Transfer-Encoding: chunked\r\n\r\n",
+            )
+            .unwrap();
+        assert!(conn.try_read().is_ok());
+
+        sender.write_all(b"this is not\n\r\na json \nbody").unwrap();
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(26, true, true),
+            body: Some(Body::new(b"this is not\n\r\na json \nbody".to_vec())),
+        };
+
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_long_headers() {
+        // Long request headers.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n \
+                                 Expect: 100-continue\r\n \
+                                 Transfer-Encoding: chunked\r\n",
+            )
+            .unwrap();
+
+        for i in 0..90 {
+            sender.write_all(b"Custom-Header-Testing: 1").unwrap();
+            sender.write_all(i.to_string().as_bytes()).unwrap();
+            sender.write_all(b"\r\n").unwrap();
+        }
+        sender
+            .write_all(b"Content-Length: 26\r\n\r\nthis is not\n\r\na json \nbody")
+            .unwrap();
+        assert!(conn.try_read().is_ok());
+        assert!(conn.try_read().is_ok());
+        assert!(conn.try_read().is_ok());
+        let request = conn.pop_parsed_request().unwrap();
+
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(26, true, true),
+            body: Some(Body::new(b"this is not\n\r\na json \nbody".to_vec())),
+        };
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_split_ending() {
+        // Long request with '\r\n' on BUFFER_SIZEth and 1025th positions in the request.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n \
+                                 Expect: 100-continue\r\n \
+                                 Transfer-Encoding: chunked\r\n",
+            )
+            .unwrap();
+
+        for i in 0..32 {
+            sender.write_all(b"Custom-Header-Testing: 1").unwrap();
+            sender.write_all(i.to_string().as_bytes()).unwrap();
+            sender.write_all(b"\r\n").unwrap();
+        }
+        sender
+            .write_all(b"Head: aaaaa\r\nContent-Length: 26\r\n\r\nthis is not\n\r\na json \nbody")
+            .unwrap();
+        assert!(conn.try_read().is_ok());
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(26, true, true),
+            body: Some(Body::new(b"this is not\n\r\na json \nbody".to_vec())),
+        };
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_invalid_request() {
+        // Invalid request.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n \
+                                 Expect: 100-continue\r\n \
+                                 Transfer-Encoding: chunked\r\n",
+            )
+            .unwrap();
+
+        for i in 0..40 {
+            sender.write_all(b"Custom-Header-Testing: 1").unwrap();
+            sender.write_all(i.to_string().as_bytes()).unwrap();
+            sender.write_all(b"\r\n").unwrap();
+        }
+        sender
+            .write_all(b"Content-Length: alpha\r\n\r\nthis is not\n\r\na json \nbody")
+            .unwrap();
+        assert!(conn.try_read().is_ok());
+        let request_error = conn.try_read().unwrap_err();
+        assert_eq!(
+            request_error,
+            ConnectionError::ParseError(RequestError::InvalidHeader)
+        );
+    }
+
+    #[test]
+    fn test_try_read_long_request_body() {
+        // Long request body.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n \
+                                 Expect: 100-continue\r\n \
+                                 Transfer-Encoding: chunked\r\n \
+                                 Content-Length: 1400\r\n\r\n",
+            )
+            .unwrap();
+
+        let mut request_body: Vec<u8> = Vec::with_capacity(1400);
+        for _ in 0..100 {
+            request_body.write_all(b"This is a test").unwrap();
+        }
+        sender.write_all(request_body.as_slice()).unwrap();
+        assert!(conn.try_read().is_ok());
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(1400, true, true),
+            body: Some(Body::new(request_body)),
+        };
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_large_req_line() {
+        // Request line longer than BUFFER_SIZE bytes.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender.write_all(b"PATCH http://localhost/home").unwrap();
+
+        let mut request_body: Vec<u8> = Vec::with_capacity(1400);
+        for _ in 0..200 {
+            request_body.write_all(b"/home").unwrap();
+        }
+        sender.write_all(request_body.as_slice()).unwrap();
+        assert_eq!(
+            conn.try_read().unwrap_err(),
+            ConnectionError::ParseError(RequestError::InvalidRequest)
+        );
+    }
+
+    #[test]
+    fn test_try_read_large_header_line() {
+        // Header line longer than BUFFER_SIZE bytes.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(b"PATCH http://localhost/home HTTP/1.1\r\nhead: ")
+            .unwrap();
+
+        let mut request_body: Vec<u8> = Vec::with_capacity(1030);
+        for _ in 0..86 {
+            request_body.write_all(b"abcdefghijkl").unwrap();
+        }
+        request_body.write_all(b"\r\n\r\n").unwrap();
+        sender.write_all(request_body.as_slice()).unwrap();
+        assert!(conn.try_read().is_ok());
+        assert_eq!(
+            conn.try_read().unwrap_err(),
+            ConnectionError::ParseError(RequestError::InvalidHeader)
+        );
+    }
+
+    #[test]
+    fn test_try_read_no_body_request() {
+        // Request without body.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n \
+                                 Expect: 100-continue\r\n \
+                                 Transfer-Encoding: chunked\r\n\r\n",
+            )
+            .unwrap();
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(0, true, true),
+            body: None,
+        };
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_segmented_req_line() {
+        // Segmented request line.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender.write_all(b"PATCH http://local").unwrap();
+        assert!(conn.try_read().is_ok());
+
+        sender.write_all(b"host/home HTTP/1.1\r\n\r\n").unwrap();
+
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(0, false, false),
+            body: None,
+        };
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_long_req_line_b2b() {
+        // Long request line after another request.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        // Req line 23 + 10*x + 13 = 36 + 10* x    984 free in first try read
+        sender
+            .write_all(b"PATCH http://localhost/home HTTP/1.1\r\n\r\nPATCH http://localhost/")
+            .unwrap();
+
+        let mut request_line: Vec<u8> = Vec::with_capacity(980);
+        for _ in 0..98 {
+            request_line.write_all(b"localhost/").unwrap();
+        }
+        request_line.write_all(b" HTTP/1.1\r\n\r\n").unwrap();
+        sender.write_all(request_line.as_slice()).unwrap();
+
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+        let expected_request = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(0, false, false),
+            body: None,
+        };
+        assert_eq!(request, expected_request);
+
+        conn.try_read().unwrap();
+        let request = conn.pop_parsed_request().unwrap();
+        let mut expected_request_as_bytes = Vec::new();
+        expected_request_as_bytes
+            .write_all(b"http://localhost/")
+            .unwrap();
+        expected_request_as_bytes.append(request_line.as_mut());
+        let expected_request = Request {
+            request_line: RequestLine::new(
+                Method::Patch,
+                std::str::from_utf8(&expected_request_as_bytes[..997]).unwrap(),
+                Version::Http11,
+            ),
+            headers: Headers::new(0, false, false),
+            body: None,
+        };
+        assert_eq!(request, expected_request);
+    }
+
+    #[test]
+    fn test_try_read_double_request() {
+        // Double request in a single read.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n \
+                                 Transfer-Encoding: chunked\r\n \
+                                 Content-Length: 26\r\n\r\nthis is not\n\r\na json \nbody",
+            )
+            .unwrap();
+        sender
+            .write_all(
+                b"PUT http://farhost/away HTTP/1.1\r\nContent-Length: 23\r\n\r\nthis is another request",
+            )
+            .unwrap();
+
+        let expected_request_first = Request {
+            request_line: RequestLine::new(Method::Patch, "http://localhost/home", Version::Http11),
+            headers: Headers::new(26, false, true),
+            body: Some(Body::new(b"this is not\n\r\na json \nbody".to_vec())),
+        };
+
+        conn.try_read().unwrap();
+        let request_first = conn.pop_parsed_request().unwrap();
+        let request_second = conn.pop_parsed_request().unwrap();
+
+        let expected_request_second = Request {
+            request_line: RequestLine::new(Method::Put, "http://farhost/away", Version::Http11),
+            headers: Headers::new(23, false, false),
+            body: Some(Body::new(b"this is another request".to_vec())),
+        };
+        assert_eq!(request_first, expected_request_first);
+        assert_eq!(request_second, expected_request_second);
+    }
+
+    #[test]
+    fn test_try_read_connection_closed() {
+        // Connection abruptly closed.
+        let (mut sender, receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(receiver);
+        sender
+            .write_all(
+                b"PATCH http://localhost/home HTTP/1.1\r\n \
+                                 Transfer-Encoding: chunked\r\n \
+                                 Content-Len",
+            )
+            .unwrap();
+
+        conn.try_read().unwrap();
+        sender.shutdown(std::net::Shutdown::Both).unwrap();
+
+        assert_eq!(
+            conn.try_read().unwrap_err(),
+            ConnectionError::ConnectionClosed
+        );
+    }
+
+    #[test]
+    fn test_enqueue_response() {
+        // Response without body.
+        let (sender, mut receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(sender);
+
+        let response = Response::new(Version::Http11, StatusCode::OK);
+        let mut expected_response: Vec<u8> = vec![];
+        response.write_all(&mut expected_response).unwrap();
+
+        conn.enqueue_response(response);
+        assert!(conn.try_write().is_ok());
+
+        let mut response_buffer = vec![0u8; expected_response.len()];
+        receiver.read_exact(&mut response_buffer).unwrap();
+        assert_eq!(response_buffer, expected_response);
+
+        // Response with body.
+        let (sender, mut receiver) = UnixStream::pair().unwrap();
+        receiver.set_nonblocking(true).expect("Can't modify socket");
+        let mut conn = HttpConnection::new(sender);
+        let mut response = Response::new(Version::Http11, StatusCode::OK);
+        let mut body: Vec<u8> = vec![];
+        body.write_all(br#"{ "json": "body", "hello": "world" }"#)
+            .unwrap();
+        response.set_body(Body::new(body));
+        let mut expected_response: Vec<u8> = vec![];
+        response.write_all(&mut expected_response).unwrap();
+
+        conn.enqueue_response(response);
+        assert!(conn.try_write().is_ok());
+
+        let mut response_buffer = vec![0u8; expected_response.len()];
+        receiver.read_exact(&mut response_buffer).unwrap();
+        assert_eq!(response_buffer, expected_response);
+    }
+}

--- a/micro_http/src/lib.rs
+++ b/micro_http/src/lib.rs
@@ -82,4 +82,4 @@ pub use request::{Request, RequestError};
 pub use response::{Response, StatusCode};
 
 pub use common::headers::Headers;
-pub use common::{Body, Version};
+pub use common::{Body, Method, Version};

--- a/micro_http/src/lib.rs
+++ b/micro_http/src/lib.rs
@@ -1,0 +1,85 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#![deny(missing_docs)]
+//! Minimal implementation of the [HTTP/1.0](https://tools.ietf.org/html/rfc1945)
+//! and [HTTP/1.1](https://www.ietf.org/rfc/rfc2616.txt) protocols.
+//!
+//! HTTP/1.1 has a mandatory header **Host**, but as this crate is only used
+//! for parsing MMDS requests, this header (if present) is ignored.
+//!
+//! This HTTP implementation is stateless thus it does not support chunking or
+//! compression.
+//!
+//! ## Supported Headers
+//! The **micro_http** crate has support for parsing the following **Request**
+//! headers:
+//! - Content-Length
+//! - Expect
+//! - Transfer-Encoding
+//!
+//! The **Response** does not have a public interface for adding headers, but whenever
+//! a write to the **Body** is made, the headers **ContentLength** and **MediaType**
+//! are automatically updated.
+//!
+//! ### Media Types
+//! The supported media types are:
+//! - text/plain
+//! - application/json
+//!
+//! ## Supported Methods
+//! The supported HTTP Methods are:
+//! - GET
+//! - PUT
+//! - PATCH
+//!
+//! ## Supported Status Codes
+//! The supported status codes are:
+//!
+//! - Continue - 100
+//! - OK - 200
+//! - No Content - 204
+//! - Bad Request - 400
+//! - Not Found - 404
+//! - Internal Server Error - 500
+//! - Not Implemented - 501
+//!
+//! ## Example for parsing an HTTP Request from a slice
+//! ```
+//! extern crate micro_http;
+//! use micro_http::{Request, Version};
+//!
+//! let http_request = Request::try_from(b"GET http://localhost/home HTTP/1.0\r\n\r\n").unwrap();
+//! assert_eq!(http_request.http_version(), Version::Http10);
+//! assert_eq!(http_request.uri().get_abs_path(), "/home");
+//! ```
+//!
+//! ## Example for creating an HTTP Response
+//! ```
+//! extern crate micro_http;
+//! use micro_http::{Body, Response, StatusCode, Version};
+//!
+//! let mut response = Response::new(Version::Http10, StatusCode::OK);
+//! let body = String::from("This is a test");
+//! response.set_body(Body::new(body.clone()));
+//!
+//! assert!(response.status() == StatusCode::OK);
+//! assert_eq!(response.body().unwrap(), Body::new(body));
+//! assert_eq!(response.http_version(), Version::Http10);
+//!
+//! let mut response_buf: [u8; 126] = [0; 126];
+//! assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
+//! ```
+
+mod common;
+mod connection;
+mod request;
+mod response;
+use common::ascii;
+use common::headers;
+
+pub use connection::HttpConnection;
+pub use request::{Request, RequestError};
+pub use response::{Response, StatusCode};
+
+pub use common::headers::Headers;
+pub use common::{Body, Version};

--- a/micro_http/src/request.rs
+++ b/micro_http/src/request.rs
@@ -1,0 +1,474 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::from_utf8;
+
+use common::ascii::{CR, CRLF_LEN, LF, SP};
+pub use common::RequestError;
+use common::{Body, Method, Version};
+use headers::Headers;
+
+/// Finds the first occurence of `sequence` in the `bytes` slice.
+///
+/// Returns the starting position of the `sequence` in `bytes` or `None` if the
+/// `sequence` is not found.
+pub fn find(bytes: &[u8], sequence: &[u8]) -> Option<usize> {
+    bytes
+        .windows(sequence.len())
+        .position(|window| window == sequence)
+}
+
+/// Wrapper over HTTP URIs.
+///
+/// The `Uri` can not be used directly and it is only accessible from an HTTP Request.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Uri {
+    string: String,
+}
+
+impl Uri {
+    fn new(slice: &str) -> Self {
+        Uri {
+            string: String::from(slice),
+        }
+    }
+
+    fn try_from(bytes: &[u8]) -> Result<Self, RequestError> {
+        if bytes.is_empty() {
+            return Err(RequestError::InvalidUri("Empty URI not allowed."));
+        }
+        let utf8_slice =
+            from_utf8(bytes).map_err(|_| RequestError::InvalidUri("Cannot parse URI as UTF-8."))?;
+        Ok(Uri::new(utf8_slice))
+    }
+
+    /// Returns the absolute path of the `Uri`.
+    ///
+    /// URIs can be represented in absolute form or relative form. The absolute form includes
+    /// the HTTP scheme, followed by the absolute path as follows:
+    /// "http:" "//" host [ ":" port ] [ abs_path ]
+    /// The relative URIs can be one of net_path | abs_path | rel_path.
+    /// This method only handles absolute URIs and relative URIs specified by abs_path.
+    /// The abs_path is expected to start with '/'.
+    ///
+    /// # Errors
+    /// Returns an empty byte array when the host or the path are empty/invalid.
+    ///
+    pub fn get_abs_path(&self) -> &str {
+        const HTTP_SCHEME_PREFIX: &str = "http://";
+
+        if self.string.starts_with(HTTP_SCHEME_PREFIX) {
+            let without_scheme = &self.string[HTTP_SCHEME_PREFIX.len()..];
+            if without_scheme.is_empty() {
+                return "";
+            }
+            // The host in this case includes the port and contains the bytes after http:// up to
+            // the next '/'.
+            match without_scheme.bytes().position(|byte| byte == b'/') {
+                Some(len) => &without_scheme[len..],
+                None => "",
+            }
+        } else {
+            if self.string.starts_with('/') {
+                return self.string.as_str();
+            }
+
+            ""
+        }
+    }
+}
+
+/// Wrapper over an HTTP Request Line.
+#[derive(Debug, PartialEq)]
+pub struct RequestLine {
+    method: Method,
+    uri: Uri,
+    http_version: Version,
+}
+
+impl RequestLine {
+    fn parse_request_line(request_line: &[u8]) -> (&[u8], &[u8], &[u8]) {
+        if let Some(method_end) = find(request_line, &[SP]) {
+            let method = &request_line[..method_end];
+
+            let uri_and_version = &request_line[(method_end + 1)..];
+
+            if let Some(uri_end) = find(uri_and_version, &[SP]) {
+                let uri = &uri_and_version[..uri_end];
+
+                let version = &uri_and_version[(uri_end + 1)..];
+
+                return (method, uri, version);
+            }
+
+            return (method, uri_and_version, b"");
+        }
+
+        (b"", b"", b"")
+    }
+
+    /// Tries to parse a byte stream in a request line. Fails if the request line is malformed.
+    pub fn try_from(request_line: &[u8]) -> Result<Self, RequestError> {
+        let (method, uri, version) = RequestLine::parse_request_line(request_line);
+
+        Ok(RequestLine {
+            method: Method::try_from(method)?,
+            uri: Uri::try_from(uri)?,
+            http_version: Version::try_from(version)?,
+        })
+    }
+
+    // Returns the minimum length of a valid request. The request must contain
+    // the method (GET), the URI (minmum 1 character), the HTTP version(HTTP/DIGIT.DIGIT) and
+    // 2 separators (SP).
+    fn min_len() -> usize {
+        Method::Get.raw().len() + 1 + Version::Http10.raw().len() + 2
+    }
+
+    #[cfg(test)]
+    pub fn new(method: Method, uri: &str, http_version: Version) -> Self {
+        RequestLine {
+            method,
+            uri: Uri::new(uri),
+            http_version,
+        }
+    }
+}
+
+/// Wrapper over an HTTP Request.
+#[allow(unused)]
+#[derive(Debug)]
+pub struct Request {
+    /// The request line of the request.
+    pub request_line: RequestLine,
+    /// The headers of the request.
+    pub headers: Headers,
+    /// The body of the request.
+    pub body: Option<Body>,
+}
+
+impl Request {
+    /// Parses a byte slice into a HTTP Request.
+    ///
+    /// The byte slice is expected to have the following format: </br>
+    ///     * Request Line: "GET SP Request-uri SP HTTP/1.0 CRLF" - Mandatory </br>
+    ///     * Request Headers "<headers> CRLF"- Optional </br>
+    ///     * Entity Body - Optional </br>
+    /// The request headers and the entity body is not parsed and None is returned because
+    /// these are not used by the MMDS server.
+    /// The only supported method is GET and the HTTP protocol is expected to be HTTP/1.0
+    /// or HTTP/1.1.
+    ///
+    /// # Errors
+    /// The function returns InvalidRequest when parsing the byte stream fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate micro_http;
+    /// use micro_http::Request;
+    ///
+    /// let http_request = Request::try_from(b"GET http://localhost/home HTTP/1.0\r\n");
+    /// ```
+    pub fn try_from(byte_stream: &[u8]) -> Result<Self, RequestError> {
+        // The first line of the request is the Request Line. The line ending is CR LF.
+        let request_line_end = match find(byte_stream, &[CR, LF]) {
+            Some(len) => len,
+            // If no CR LF is found in the stream, the request format is invalid.
+            None => return Err(RequestError::InvalidRequest),
+        };
+
+        let request_line_bytes = &byte_stream[..request_line_end];
+        if request_line_bytes.len() < RequestLine::min_len() {
+            return Err(RequestError::InvalidRequest);
+        }
+
+        let request_line = RequestLine::try_from(request_line_bytes)?;
+
+        // Find the next CR LF CR LF sequence in our buffer starting at the end on the Request
+        // Line, including the trailing CR LF previously found.
+        match find(&byte_stream[request_line_end..], &[CR, LF, CR, LF]) {
+            // If we have found a CR LF CR LF at the end of the Request Line, the request
+            // is complete.
+            Some(0) => Ok(Request {
+                request_line,
+                headers: Headers::default(),
+                body: None,
+            }),
+            Some(headers_end) => {
+                // Parse the request headers.
+                // Start by removing the leading CR LF from them.
+                let headers_and_body = &byte_stream[(request_line_end + CRLF_LEN)..];
+                let headers_end = headers_end - CRLF_LEN;
+                let headers = Headers::try_from(&headers_and_body[..headers_end])?;
+
+                // Parse the body of the request.
+                // Firstly check if we have a body.
+                let body = match headers.content_length() {
+                    0 => {
+                        // No request body.
+                        None
+                    }
+                    content_length => {
+                        // Headers suggest we have a body, but the buffer is shorter than the specified
+                        // content length.
+                        if headers_and_body.len() - (headers_end + 2 * CRLF_LEN)
+                            < content_length as usize
+                        {
+                            return Err(RequestError::InvalidRequest);
+                        }
+                        let body_as_bytes = &headers_and_body[(headers_end + 2 * CRLF_LEN)..];
+                        // If the actual length of the body is different than the `Content-Length` value
+                        // in the headers then this request is invalid.
+                        if body_as_bytes.len() == content_length as usize {
+                            Some(Body::new(body_as_bytes))
+                        } else {
+                            return Err(RequestError::InvalidRequest);
+                        }
+                    }
+                };
+
+                Ok(Request {
+                    request_line,
+                    headers,
+                    body,
+                })
+            }
+            // If we can't find a CR LF CR LF even though the request should have headers
+            // the request format is invalid.
+            None => Err(RequestError::InvalidRequest),
+        }
+    }
+
+    /// Returns the `Uri` from the parsed `Request`.
+    ///
+    /// The return value can be used to get the absolute path of the URI.
+    pub fn uri(&self) -> &Uri {
+        &self.request_line.uri
+    }
+
+    /// Returns the HTTP `Version` of the `Request`.
+    pub fn http_version(&self) -> Version {
+        self.request_line.http_version
+    }
+
+    /// Returns the HTTP `Method` of the `Request`.
+    pub fn method(&self) -> Method {
+        self.request_line.method
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl PartialEq for Request {
+        fn eq(&self, other: &Request) -> bool {
+            // Ignore the other fields of Request for now because they are not used.
+            self.request_line == other.request_line
+                && self.headers.content_length() == other.headers.content_length()
+                && self.headers.expect() == other.headers.expect()
+                && self.headers.chunked() == other.headers.chunked()
+        }
+    }
+
+    #[test]
+    fn test_uri() {
+        let uri = Uri::new("http://localhost/home");
+        assert_eq!(uri.get_abs_path(), "/home");
+
+        let uri = Uri::new("/home");
+        assert_eq!(uri.get_abs_path(), "/home");
+
+        let uri = Uri::new("home");
+        assert_eq!(uri.get_abs_path(), "");
+
+        let uri = Uri::new("http://");
+        assert_eq!(uri.get_abs_path(), "");
+
+        let uri = Uri::new("http://192.168.0.0");
+        assert_eq!(uri.get_abs_path(), "");
+    }
+
+    #[test]
+    fn test_find() {
+        let bytes: &[u8; 13] = b"abcacrgbabsjl";
+        let i = find(&bytes[..], b"ac");
+        assert_eq!(i.unwrap(), 3);
+
+        let i = find(&bytes[..], b"rgb");
+        assert_eq!(i.unwrap(), 5);
+
+        let i = find(&bytes[..], b"ab");
+        assert_eq!(i.unwrap(), 0);
+
+        let i = find(&bytes[..], b"l");
+        assert_eq!(i.unwrap(), 12);
+
+        let i = find(&bytes[..], b"jle");
+        assert!(i.is_none());
+
+        let i = find(&bytes[..], b"asdkjhasjhdjhgsadg");
+        assert!(i.is_none());
+
+        let i = find(&bytes[..], b"abcacrgbabsjl");
+        assert_eq!(i.unwrap(), 0);
+    }
+
+    #[test]
+    // Allow assertions on constants so we can have asserts on the values returned
+    // when result is Ok.
+    #[allow(clippy::assertions_on_constants)]
+    fn test_into_request_line() {
+        let expected_request_line = RequestLine {
+            http_version: Version::Http10,
+            method: Method::Get,
+            uri: Uri::new("http://localhost/home"),
+        };
+
+        let request_line = b"GET http://localhost/home HTTP/1.0";
+        match RequestLine::try_from(request_line) {
+            Ok(request) => assert_eq!(request, expected_request_line),
+            Err(_) => assert!(false),
+        };
+
+        let expected_request_line = RequestLine {
+            http_version: Version::Http11,
+            method: Method::Get,
+            uri: Uri::new("http://localhost/home"),
+        };
+
+        // Happy case with request line ending in CRLF.
+        let request_line = b"GET http://localhost/home HTTP/1.1";
+        match RequestLine::try_from(request_line) {
+            Ok(request) => assert_eq!(request, expected_request_line),
+            Err(_) => assert!(false),
+        };
+
+        // Happy case with request line ending in LF instead of CRLF.
+        let request_line = b"GET http://localhost/home HTTP/1.1";
+        match RequestLine::try_from(request_line) {
+            Ok(request) => assert_eq!(request, expected_request_line),
+            Err(_) => assert!(false),
+        };
+
+        // Test for invalid method.
+        let request_line = b"POST http://localhost/home HTTP/1.0";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap_err(),
+            RequestError::InvalidHttpMethod("Unsupported HTTP method.")
+        );
+
+        // Test for invalid uri.
+        let request_line = b"GET  HTTP/1.0";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap_err(),
+            RequestError::InvalidUri("Empty URI not allowed.")
+        );
+
+        // Test for invalid HTTP version.
+        let request_line = b"GET http://localhost/home HTTP/2.0";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap_err(),
+            RequestError::InvalidHttpVersion("Unsupported HTTP version.")
+        );
+
+        // Test for invalid format with no method, uri or version.
+        let request_line = b"nothing";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap_err(),
+            RequestError::InvalidHttpMethod("Unsupported HTTP method.")
+        );
+
+        // Test for invalid format with no version.
+        let request_line = b"GET /";
+        assert_eq!(
+            RequestLine::try_from(request_line).unwrap_err(),
+            RequestError::InvalidHttpVersion("Unsupported HTTP version.")
+        );
+    }
+
+    #[test]
+    fn test_into_request() {
+        let expected_request = Request {
+            request_line: RequestLine {
+                http_version: Version::Http10,
+                method: Method::Get,
+                uri: Uri::new("http://localhost/home"),
+            },
+            body: None,
+            headers: Headers::default(),
+        };
+        let request_bytes = b"GET http://localhost/home HTTP/1.0\r\n \
+                                     Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT\r\n\r\n";
+        let request = Request::try_from(request_bytes).unwrap();
+        assert_eq!(request, expected_request);
+        assert_eq!(request.uri(), &Uri::new("http://localhost/home"));
+        assert_eq!(request.http_version(), Version::Http10);
+        assert!(request.body.is_none());
+
+        // Test for invalid Request (length is less than minimum).
+        let request_bytes = b"GET";
+        assert_eq!(
+            Request::try_from(request_bytes).unwrap_err(),
+            RequestError::InvalidRequest
+        );
+
+        // Test for a request with the headers we are looking for.
+        let request = Request::try_from(
+            b"PATCH http://localhost/home HTTP/1.1\r\n \
+                                     Expect: 100-continue\r\n \
+                                     Transfer-Encoding: chunked\r\n \
+                                     Content-Length: 26\r\n\r\nthis is not\n\r\na json \nbody",
+        )
+        .unwrap();
+        assert_eq!(request.uri(), &Uri::new("http://localhost/home"));
+        assert_eq!(request.http_version(), Version::Http11);
+        assert_eq!(request.method(), Method::Patch);
+        assert_eq!(request.headers.chunked(), true);
+        assert_eq!(request.headers.expect(), true);
+        assert_eq!(request.headers.content_length(), 26);
+        assert_eq!(
+            request.body.unwrap().body,
+            String::from("this is not\n\r\na json \nbody")
+                .as_bytes()
+                .to_vec()
+        );
+
+        // Test for an invalid request format.
+        Request::try_from(b"PATCH http://localhost/home HTTP/1.1\r\n").unwrap_err();
+
+        // Test for an invalid encoding.
+        let request = Request::try_from(
+            b"PATCH http://localhost/home HTTP/1.1\r\n \
+                                     Expect: 100-continue\r\n \
+                                     Transfer-Encoding: identity; q=0\r\n \
+                                     Content-Length: 26\r\n\r\nthis is not\n\r\na json \nbody",
+        )
+        .unwrap_err();
+        assert_eq!(request, RequestError::InvalidHeader);
+
+        // Test for an invalid content length.
+        let request = Request::try_from(
+            b"PATCH http://localhost/home HTTP/1.1\r\n \
+                                     Expect: 100-continue\r\n \
+                                     Content-Length: 5000\r\n\r\nthis is a short body",
+        )
+        .unwrap_err();
+        assert_eq!(request, RequestError::InvalidRequest);
+
+        // Test for a request without a body and an optional header.
+        let request = Request::try_from(
+            b"GET http://localhost/ HTTP/1.0\r\n \
+                                     Accept-Encoding: gzip\r\n\r\n",
+        )
+        .unwrap();
+        assert_eq!(request.uri(), &Uri::new("http://localhost/"));
+        assert_eq!(request.http_version(), Version::Http10);
+        assert_eq!(request.method(), Method::Get);
+        assert_eq!(request.headers.chunked(), false);
+        assert_eq!(request.headers.expect(), false);
+        assert_eq!(request.headers.content_length(), 0);
+        assert!(request.body.is_none());
+    }
+}

--- a/micro_http/src/response.rs
+++ b/micro_http/src/response.rs
@@ -1,0 +1,232 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::{Error as WriteError, Write};
+
+use ascii::{COLON, CR, LF, SP};
+use common::{Body, Version};
+use headers::{Header, MediaType};
+
+/// Wrapper over a response status code.
+///
+/// The status code is defined as specified in the
+/// [RFC](https://tools.ietf.org/html/rfc7231#section-6).
+#[allow(dead_code)]
+#[derive(Clone, Copy, PartialEq)]
+pub enum StatusCode {
+    /// 100, Continue
+    Continue,
+    /// 200, OK
+    OK,
+    /// 204, No Content
+    NoContent,
+    /// 400, Bad Request
+    BadRequest,
+    /// 404, Not Found
+    NotFound,
+    /// 500, Internal Server Error
+    InternalServerError,
+    /// 501, Not Implemented
+    NotImplemented,
+}
+
+impl StatusCode {
+    fn raw(self) -> &'static [u8; 3] {
+        match self {
+            StatusCode::Continue => b"100",
+            StatusCode::OK => b"200",
+            StatusCode::NoContent => b"204",
+            StatusCode::BadRequest => b"400",
+            StatusCode::NotFound => b"404",
+            StatusCode::InternalServerError => b"500",
+            StatusCode::NotImplemented => b"501",
+        }
+    }
+}
+
+struct StatusLine {
+    http_version: Version,
+    status_code: StatusCode,
+}
+
+impl StatusLine {
+    fn new(http_version: Version, status_code: StatusCode) -> Self {
+        StatusLine {
+            http_version,
+            status_code,
+        }
+    }
+
+    fn write_all<T: Write>(&self, mut buf: T) -> Result<(), WriteError> {
+        buf.write_all(self.http_version.raw())?;
+        buf.write_all(&[SP])?;
+        buf.write_all(self.status_code.raw())?;
+        buf.write_all(&[SP, CR, LF])?;
+
+        Ok(())
+    }
+}
+
+/// Wrapper over the list of headers associated with a HTTP Response.
+/// When creating a ResponseHeaders object, the content type is initialized to `text/plain`.
+/// The content type can be updated with a call to `set_content_type`.
+#[derive(Default)]
+pub struct ResponseHeaders {
+    content_length: i32,
+    content_type: MediaType,
+}
+
+impl ResponseHeaders {
+    /// Writes the headers to `buf` using the HTTP specification.
+    pub fn write_all<T: Write>(&self, buf: &mut T) -> Result<(), WriteError> {
+        buf.write_all(b"Server: Firecracker API")?;
+        buf.write_all(&[CR, LF])?;
+        buf.write_all(b"Connection: keep-alive")?;
+        buf.write_all(&[CR, LF])?;
+
+        buf.write_all(Header::ContentType.raw())?;
+        buf.write_all(&[COLON, SP])?;
+        buf.write_all(self.content_type.as_str().as_bytes())?;
+        buf.write_all(&[CR, LF])?;
+
+        if self.content_length != 0 {
+            buf.write_all(Header::ContentLength.raw())?;
+            buf.write_all(&[COLON, SP])?;
+            buf.write_all(self.content_length.to_string().as_bytes())?;
+            buf.write_all(&[CR, LF])?;
+        }
+
+        buf.write_all(&[CR, LF])
+    }
+
+    // Sets the content length to be written in the HTTP response.
+    fn set_content_length(&mut self, content_length: i32) {
+        self.content_length = content_length;
+    }
+
+    /// Sets the content type to be written in the HTTP response.
+    #[allow(unused)]
+    pub fn set_content_type(&mut self, content_type: MediaType) {
+        self.content_type = content_type;
+    }
+}
+
+/// Wrapper over an HTTP Response.
+///
+/// The Response is created using a `Version` and a `StatusCode`. When creating a Response object,
+/// the body is initialized to `None`. The body can be updated with a call to `set_body`.
+pub struct Response {
+    status_line: StatusLine,
+    headers: ResponseHeaders,
+    body: Option<Body>,
+}
+
+impl Response {
+    /// Creates a new HTTP `Response` with an empty body.
+    pub fn new(http_version: Version, status_code: StatusCode) -> Response {
+        Response {
+            status_line: StatusLine::new(http_version, status_code),
+            headers: ResponseHeaders::default(),
+            body: None,
+        }
+    }
+
+    /// Updates the body of the `Response`.
+    ///
+    /// This function has side effects because it also updates the headers:
+    /// - `ContentLength`: this is set to the length of the specified body.
+    /// - `MediaType`: this is set to "text/plain".
+    pub fn set_body(&mut self, body: Body) {
+        self.headers.set_content_length(body.len() as i32);
+        self.body = Some(body);
+    }
+
+    fn write_body<T: Write>(&self, mut buf: T) -> Result<(), WriteError> {
+        if let Some(ref body) = self.body {
+            buf.write_all(body.raw())?;
+        }
+        Ok(())
+    }
+
+    /// Writes the content of the `Response` to the specified `buf`.
+    ///
+    /// # Errors
+    /// Returns an error when the buffer is not large enough.
+    pub fn write_all<T: Write>(&self, mut buf: &mut T) -> Result<(), WriteError> {
+        self.status_line.write_all(&mut buf)?;
+        self.headers.write_all(&mut buf)?;
+        self.write_body(&mut buf)?;
+
+        Ok(())
+    }
+
+    /// Returns the Status Code of the Response.
+    pub fn status(&self) -> StatusCode {
+        self.status_line.status_code
+    }
+
+    /// Returns the Body of the response. If the response does not have a body,
+    /// it returns None.
+    pub fn body(&self) -> Option<Body> {
+        self.body.clone()
+    }
+
+    /// Returns the HTTP Version of the response.
+    pub fn content_length(&self) -> i32 {
+        self.headers.content_length
+    }
+
+    /// Returns the HTTP Version of the response.
+    pub fn content_type(&self) -> MediaType {
+        self.headers.content_type
+    }
+
+    /// Returns the HTTP Version of the response.
+    pub fn http_version(&self) -> Version {
+        self.status_line.http_version
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_response() {
+        let mut response = Response::new(Version::Http10, StatusCode::OK);
+        let body = "This is a test";
+        response.set_body(Body::new(body));
+
+        assert!(response.status() == StatusCode::OK);
+        assert_eq!(response.body().unwrap(), Body::new(body));
+        assert_eq!(response.http_version(), Version::Http10);
+        assert_eq!(response.content_length(), 14);
+        assert_eq!(response.content_type(), MediaType::PlainText);
+
+        let expected_response: &'static [u8] = b"HTTP/1.0 200 \r\n\
+            Server: Firecracker API\r\n\
+            Connection: keep-alive\r\n\
+            Content-Type: text/plain\r\n\
+            Content-Length: 14\r\n\r\n\
+            This is a test";
+
+        let mut response_buf: [u8; 126] = [0; 126];
+        assert!(response.write_all(&mut response_buf.as_mut()).is_ok());
+        assert!(response_buf.as_ref() == expected_response);
+
+        // Test write failed.
+        let mut response_buf: [u8; 1] = [0; 1];
+        assert!(response.write_all(&mut response_buf.as_mut()).is_err());
+    }
+
+    #[test]
+    fn test_status_code() {
+        assert_eq!(StatusCode::Continue.raw(), b"100");
+        assert_eq!(StatusCode::OK.raw(), b"200");
+        assert_eq!(StatusCode::NoContent.raw(), b"204");
+        assert_eq!(StatusCode::BadRequest.raw(), b"400");
+        assert_eq!(StatusCode::NotFound.raw(), b"404");
+        assert_eq!(StatusCode::InternalServerError.raw(), b"500");
+        assert_eq!(StatusCode::NotImplemented.raw(), b"501");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ extern crate vmm_sys_util;
 #[macro_use(crate_version, crate_authors)]
 extern crate clap;
 
-use clap::{App, Arg};
+use clap::{App, Arg, ArgGroup};
 use libc::EFD_NONBLOCK;
 use log::LevelFilter;
 use std::process;
@@ -67,11 +67,14 @@ fn main() {
         .version(crate_version!())
         .author(crate_authors!())
         .about("Launch a cloud-hypervisor VMM.")
+        .group(ArgGroup::with_name("vm-config").multiple(true))
+        .group(ArgGroup::with_name("vmm-config").multiple(true))
         .arg(
             Arg::with_name("cpus")
                 .long("cpus")
                 .help("Number of virtual CPUs")
-                .default_value(config::DEFAULT_VCPUS),
+                .default_value(config::DEFAULT_VCPUS)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("memory")
@@ -80,26 +83,30 @@ fn main() {
                     "Memory parameters \"size=<guest_memory_size>,\
                      file=<backing_file_path>\"",
                 )
-                .default_value(config::DEFAULT_MEMORY),
+                .default_value(config::DEFAULT_MEMORY)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("kernel")
                 .long("kernel")
                 .help("Path to kernel image (vmlinux)")
-                .takes_value(true),
+                .takes_value(true)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("cmdline")
                 .long("cmdline")
                 .help("Kernel command line")
-                .takes_value(true),
+                .takes_value(true)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("disk")
                 .long("disk")
                 .help("Path to VM disk image")
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("net")
@@ -109,13 +116,15 @@ fn main() {
                      ip=<ip_addr>,mask=<net_mask>,mac=<mac_addr>\"",
                 )
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("rng")
                 .long("rng")
                 .help("Path to entropy source")
-                .default_value(config::DEFAULT_RNG_SOURCE),
+                .default_value(config::DEFAULT_RNG_SOURCE)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("fs")
@@ -127,7 +136,8 @@ fn main() {
                      cache_size=<DAX cache size: default 8Gib>\"",
                 )
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("pmem")
@@ -137,26 +147,30 @@ fn main() {
                      size=<persistent_memory_size>\"",
                 )
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("serial")
                 .long("serial")
                 .help("Control serial port: off|null|tty|file=/path/to/a/file")
-                .default_value("null"),
+                .default_value("null")
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("console")
                 .long("console")
                 .help("Control (virtio) console: off|null|tty|file=/path/to/a/file")
-                .default_value("tty"),
+                .default_value("tty")
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("device")
                 .long("device")
                 .help("Direct device assignment parameter")
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("vhost-user-net")
@@ -167,7 +181,8 @@ fn main() {
                      queue_size=<size_of_each_queue>\"",
                 )
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("vsock")
@@ -177,7 +192,8 @@ fn main() {
                      sock=<socket_path>\"",
                 )
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("vhost-user-blk")
@@ -195,14 +211,16 @@ fn main() {
             Arg::with_name("v")
                 .short("v")
                 .multiple(true)
-                .help("Sets the level of debugging output"),
+                .help("Sets the level of debugging output")
+                .group("vmm-config"),
         )
         .arg(
             Arg::with_name("log-file")
                 .long("log-file")
                 .help("Log file. Standard error is used if not specified")
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vmm-config"),
         )
         .get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,9 @@ fn main() {
         }
     }
 
+    let default_vcpus = format! {"{}", config::DEFAULT_VCPUS};
+    let default_memory = &format! {"size={}M", config::DEFAULT_MEMORY_MB};
+
     let cmd_arguments = App::new("cloud-hypervisor")
         .version(crate_version!())
         .author(crate_authors!())
@@ -89,7 +92,7 @@ fn main() {
             Arg::with_name("cpus")
                 .long("cpus")
                 .help("Number of virtual CPUs")
-                .default_value(config::DEFAULT_VCPUS)
+                .default_value(&default_vcpus)
                 .group("vm-config"),
         )
         .arg(
@@ -99,7 +102,7 @@ fn main() {
                     "Memory parameters \"size=<guest_memory_size>,\
                      file=<backing_file_path>\"",
                 )
-                .default_value(config::DEFAULT_MEMORY)
+                .default_value(&default_memory)
                 .group("vm-config"),
         )
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,8 +338,13 @@ fn main() {
     let (api_request_sender, api_request_receiver) = channel();
     let api_evt = EventFd::new(EFD_NONBLOCK).expect("Cannot create API EventFd");
 
-    let vmm_thread = match vmm::start_vmm_thread(api_evt.try_clone().unwrap(), api_request_receiver)
-    {
+    let http_sender = api_request_sender.clone();
+    let vmm_thread = match vmm::start_vmm_thread(
+        api_socket_path,
+        api_evt.try_clone().unwrap(),
+        http_sender,
+        api_request_receiver,
+    ) {
         Ok(t) => t,
         Err(e) => {
             println!("Failed spawning the VMM thread {:?}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -358,13 +358,13 @@ fn main() {
     if cmd_arguments.is_present("vm-config") && vm_config.valid() {
         // Create and start the VM based off the VM config we just built.
         let sender = api_request_sender.clone();
-        vmm::vm_create(
+        vmm::api::vm_create(
             api_evt.try_clone().unwrap(),
             api_request_sender,
             Arc::new(vm_config),
         )
         .expect("Could not create the VM");
-        vmm::vm_start(api_evt.try_clone().unwrap(), sender).expect("Could not start the VM");
+        vmm::api::vm_start(api_evt.try_clone().unwrap(), sender).expect("Could not start the VM");
     }
 
     match vmm_thread.join() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,7 +356,7 @@ fn main() {
     };
 
     if cmd_arguments.is_present("vm-config") && vm_config.valid() {
-        // Create and start the VM based off the VM config we just built.
+        // Create and boot the VM based off the VM config we just built.
         let sender = api_request_sender.clone();
         vmm::api::vm_create(
             api_evt.try_clone().unwrap(),
@@ -364,7 +364,7 @@ fn main() {
             Arc::new(vm_config),
         )
         .expect("Could not create the VM");
-        vmm::api::vm_start(api_evt.try_clone().unwrap(), sender).expect("Could not start the VM");
+        vmm::api::vm_boot(api_evt.try_clone().unwrap(), sender).expect("Could not boot the VM");
     }
 
     match vmm_thread.join() {

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -18,8 +18,10 @@ devices = { path = "../devices" }
 epoll = "4.1.0"
 kvm-bindings = "0.1.1"
 kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master" }
+lazy_static = "1.4.0"
 libc = "0.2.62"
 log = "0.4.8"
+micro_http = { path = "../micro_http" }
 net_util = { path = "../net_util" }
 pci = {path = "../pci", optional = true}
 qcow = { path = "../qcow" }
@@ -28,6 +30,7 @@ vm-virtio = { path = "../vm-virtio" }
 vm-allocator = { path = "../vm-allocator" }
 vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
 signal-hook = "0.1.10"
+threadpool = "1.0"
 
 [dependencies.linux-loader]
 git = "https://github.com/rust-vmm/linux-loader"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -25,6 +25,9 @@ micro_http = { path = "../micro_http" }
 net_util = { path = "../net_util" }
 pci = {path = "../pci", optional = true}
 qcow = { path = "../qcow" }
+serde = {version = ">=1.0.27", features = ["rc"] }
+serde_derive = ">=1.0.27"
+serde_json = ">=1.0.9"
 vfio = { path = "../vfio", optional = true }
 vm-virtio = { path = "../vm-virtio" }
 vm-allocator = { path = "../vm-allocator" }

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -4,9 +4,9 @@
 //
 
 extern crate threadpool;
-extern crate vmm_sys_util;
 
-use crate::api::ApiRequest;
+use crate::api::http_endpoint::{VmActionHandler, VmCreate};
+use crate::api::{ApiRequest, VmAction};
 use crate::{Error, Result};
 use micro_http::{HttpConnection, Request, Response, StatusCode, Version};
 use std::collections::HashMap;
@@ -50,9 +50,14 @@ macro_rules! endpoint {
 lazy_static! {
     /// HTTP_ROUTES contain all the cloud-hypervisor HTTP routes.
     pub static ref HTTP_ROUTES: HttpRoutes = {
-        let r = HttpRoutes {
+        let mut r = HttpRoutes {
             routes: HashMap::new(),
         };
+
+        r.routes.insert(endpoint!("/vm.create"), Box::new(VmCreate {}));
+        r.routes.insert(endpoint!("/vm.boot"), Box::new(VmActionHandler::new(VmAction::Boot)));
+        r.routes.insert(endpoint!("/vm.shutdown"), Box::new(VmActionHandler::new(VmAction::Shutdown)));
+        r.routes.insert(endpoint!("/vm.reboot"), Box::new(VmActionHandler::new(VmAction::Reboot)));
 
         r
     };

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -56,6 +56,7 @@ lazy_static! {
 
         r.routes.insert(endpoint!("/vm.create"), Box::new(VmCreate {}));
         r.routes.insert(endpoint!("/vm.boot"), Box::new(VmActionHandler::new(VmAction::Boot)));
+        r.routes.insert(endpoint!("/vm.delete"), Box::new(VmActionHandler::new(VmAction::Delete)));
         r.routes.insert(endpoint!("/vm.info"), Box::new(VmInfo {}));
         r.routes.insert(endpoint!("/vm.shutdown"), Box::new(VmActionHandler::new(VmAction::Shutdown)));
         r.routes.insert(endpoint!("/vm.reboot"), Box::new(VmActionHandler::new(VmAction::Reboot)));

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -82,7 +82,7 @@ fn http_serve<T: Read + Write>(
     while let Some(request) = http_connection.pop_parsed_request() {
         let sender = api_sender.clone();
         let path = request.uri().get_abs_path().to_string();
-        let response = match HTTP_ROUTES.routes.get(&path) {
+        let mut response = match HTTP_ROUTES.routes.get(&path) {
             Some(route) => match api_notifier.try_clone() {
                 Ok(notifier) => route.handle_request(&request, notifier, sender),
                 Err(_) => Response::new(Version::Http11, StatusCode::InternalServerError),
@@ -90,6 +90,7 @@ fn http_serve<T: Read + Write>(
             None => Response::new(Version::Http11, StatusCode::NotFound),
         };
 
+        response.set_server("Cloud Hypervisor API");
         http_connection.enqueue_response(response);
     }
 }

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -5,7 +5,7 @@
 
 extern crate threadpool;
 
-use crate::api::http_endpoint::{VmActionHandler, VmCreate};
+use crate::api::http_endpoint::{VmActionHandler, VmCreate, VmInfo};
 use crate::api::{ApiRequest, VmAction};
 use crate::{Error, Result};
 use micro_http::{HttpConnection, Request, Response, StatusCode, Version};
@@ -56,6 +56,7 @@ lazy_static! {
 
         r.routes.insert(endpoint!("/vm.create"), Box::new(VmCreate {}));
         r.routes.insert(endpoint!("/vm.boot"), Box::new(VmActionHandler::new(VmAction::Boot)));
+        r.routes.insert(endpoint!("/vm.info"), Box::new(VmInfo {}));
         r.routes.insert(endpoint!("/vm.shutdown"), Box::new(VmActionHandler::new(VmAction::Shutdown)));
         r.routes.insert(endpoint!("/vm.reboot"), Box::new(VmActionHandler::new(VmAction::Reboot)));
 

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -1,0 +1,127 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+extern crate threadpool;
+extern crate vmm_sys_util;
+
+use crate::api::ApiRequest;
+use crate::{Error, Result};
+use micro_http::{HttpConnection, Request, Response, StatusCode, Version};
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::os::unix::net::UnixListener;
+use std::sync::mpsc::Sender;
+use std::thread;
+use threadpool::ThreadPool;
+use vmm_sys_util::eventfd::EventFd;
+
+const HTTP_ROOT: &str = "/api/v1";
+const NUM_THREADS: usize = 4;
+
+/// An HTTP endpoint handler interface
+pub trait EndpointHandler: Sync + Send {
+    /// Handles an HTTP request.
+    /// After parsing the request, the handler could decide to send an
+    /// associated API request down to the VMM API server to e.g. create
+    /// or start a VM. The request will block waiting for an answer from the
+    /// API server and translate that into an HTTP response.
+    fn handle_request(
+        &self,
+        req: &Request,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+    ) -> Response;
+}
+
+/// An HTTP routes structure.
+pub struct HttpRoutes {
+    /// routes is a hash table mapping endpoint URIs to their endpoint handlers.
+    pub routes: HashMap<String, Box<dyn EndpointHandler + Sync + Send>>,
+}
+
+macro_rules! endpoint {
+    ($path:expr) => {
+        format!("{}{}", HTTP_ROOT, $path)
+    };
+}
+
+lazy_static! {
+    /// HTTP_ROUTES contain all the cloud-hypervisor HTTP routes.
+    pub static ref HTTP_ROUTES: HttpRoutes = {
+        let r = HttpRoutes {
+            routes: HashMap::new(),
+        };
+
+        r
+    };
+}
+
+fn http_serve<T: Read + Write>(
+    http_connection: &mut HttpConnection<T>,
+    api_notifier: EventFd,
+    api_sender: Sender<ApiRequest>,
+) {
+    if http_connection.try_read().is_err() {
+        http_connection.enqueue_response(Response::new(
+            Version::Http11,
+            StatusCode::InternalServerError,
+        ));
+
+        return;
+    }
+
+    while let Some(request) = http_connection.pop_parsed_request() {
+        let sender = api_sender.clone();
+        let path = request.uri().get_abs_path().to_string();
+        let response = match HTTP_ROUTES.routes.get(&path) {
+            Some(route) => match api_notifier.try_clone() {
+                Ok(notifier) => route.handle_request(&request, notifier, sender),
+                Err(_) => Response::new(Version::Http11, StatusCode::InternalServerError),
+            },
+            None => Response::new(Version::Http11, StatusCode::NotFound),
+        };
+
+        http_connection.enqueue_response(response);
+    }
+}
+
+pub fn start_http_thread(
+    path: &str,
+    api_notifier: EventFd,
+    api_sender: Sender<ApiRequest>,
+) -> Result<thread::JoinHandle<Result<()>>> {
+    let listener = UnixListener::bind(path).map_err(Error::Bind)?;
+    let pool = ThreadPool::new(NUM_THREADS);
+
+    thread::Builder::new()
+        .name("http-server".to_string())
+        .spawn(move || {
+            for stream in listener.incoming() {
+                match stream {
+                    Ok(s) => {
+                        let sender = api_sender.clone();
+                        let notifier = api_notifier.try_clone().map_err(Error::EventFdClone)?;
+
+                        pool.execute(move || {
+                            let mut http_connection = HttpConnection::new(s);
+
+                            http_serve(&mut http_connection, notifier, sender);
+
+                            // It's ok to panic from a threadpool managed thread,
+                            // it won't make parent threads crash.
+                            http_connection.try_write().unwrap();
+                        });
+                    }
+
+                    Err(_) => continue,
+                }
+            }
+
+            pool.join();
+
+            Ok(())
+        })
+        .map_err(Error::HttpThreadSpawn)
+}

--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -1,0 +1,126 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::api::http::EndpointHandler;
+use crate::api::VmConfig;
+use crate::api::{vm_boot, vm_create, vm_reboot, vm_shutdown, ApiRequest, VmAction};
+use crate::{Error, Result};
+use micro_http::{Body, Method, Request, Response, StatusCode, Version};
+use serde_json::Error as SerdeError;
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
+use vmm_sys_util::eventfd::EventFd;
+
+/// Errors associated with VMM management
+#[derive(Debug)]
+pub enum HttpError {
+    /// API request receive error
+    SerdeJsonDeserialize(SerdeError),
+
+    /// Could not create a VM
+    VmCreate(Error),
+
+    /// Could not boot a VM
+    VmBoot(Error),
+
+    /// Could not shut a VM down
+    VmShutdown(Error),
+
+    /// Could not reboot a VM
+    VmReboot(Error),
+
+    /// Could not act on a VM
+    VmAction(Error),
+}
+
+fn error_response(error: HttpError, status: StatusCode) -> Response {
+    let mut response = Response::new(Version::Http11, status);
+    response.set_body(Body::new(format!("{:?}", error)));
+
+    response
+}
+
+// /api/v1/vm.create handler
+pub struct VmCreate {}
+
+impl EndpointHandler for VmCreate {
+    fn handle_request(
+        &self,
+        req: &Request,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+    ) -> Response {
+        match req.method() {
+            Method::Put => {
+                match &req.body {
+                    Some(body) => {
+                        // Deserialize into a VmConfig
+                        let vm_config: VmConfig = match serde_json::from_slice(body.raw())
+                            .map_err(HttpError::SerdeJsonDeserialize)
+                        {
+                            Ok(config) => config,
+                            Err(e) => return error_response(e, StatusCode::BadRequest),
+                        };
+
+                        // Call vm_create()
+                        match vm_create(api_notifier, api_sender, Arc::new(vm_config))
+                            .map_err(HttpError::VmCreate)
+                        {
+                            Ok(_) => Response::new(Version::Http11, StatusCode::OK),
+                            Err(e) => error_response(e, StatusCode::InternalServerError),
+                        }
+                    }
+
+                    None => Response::new(Version::Http11, StatusCode::BadRequest),
+                }
+            }
+
+            _ => Response::new(Version::Http11, StatusCode::BadRequest),
+        }
+    }
+}
+
+// Common handler for boot, shutdown and reboot
+pub struct VmActionHandler {
+    action_fn: VmActionFn,
+}
+
+type VmActionFn = Box<dyn Fn(EventFd, Sender<ApiRequest>) -> Result<()> + Send + Sync>;
+
+impl VmActionHandler {
+    pub fn new(action: VmAction) -> Self {
+        let action_fn = Box::new(match action {
+            VmAction::Boot => vm_boot,
+            VmAction::Shutdown => vm_shutdown,
+            VmAction::Reboot => vm_reboot,
+        });
+
+        VmActionHandler { action_fn }
+    }
+}
+
+impl EndpointHandler for VmActionHandler {
+    fn handle_request(
+        &self,
+        req: &Request,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+    ) -> Response {
+        match req.method() {
+            Method::Put => {
+                match (self.action_fn)(api_notifier, api_sender).map_err(|e| match e {
+                    Error::ApiVmBoot(_) => HttpError::VmBoot(e),
+                    Error::ApiVmShutdown(_) => HttpError::VmShutdown(e),
+                    Error::ApiVmReboot(_) => HttpError::VmReboot(e),
+                    _ => HttpError::VmAction(e),
+                }) {
+                    Ok(_) => Response::new(Version::Http11, StatusCode::OK),
+                    Err(e) => error_response(e, StatusCode::InternalServerError),
+                }
+            }
+            _ => Response::new(Version::Http11, StatusCode::BadRequest),
+        }
+    }
+}

--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -5,8 +5,8 @@
 
 use crate::api::http::EndpointHandler;
 use crate::api::{
-    vm_boot, vm_create, vm_info, vm_reboot, vm_shutdown, ApiError, ApiRequest, ApiResult, VmAction,
-    VmConfig,
+    vm_boot, vm_create, vm_delete, vm_info, vm_reboot, vm_shutdown, ApiError, ApiRequest,
+    ApiResult, VmAction, VmConfig,
 };
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 use serde_json::Error as SerdeError;
@@ -97,6 +97,7 @@ impl VmActionHandler {
     pub fn new(action: VmAction) -> Self {
         let action_fn = Box::new(match action {
             VmAction::Boot => vm_boot,
+            VmAction::Delete => vm_delete,
             VmAction::Shutdown => vm_shutdown,
             VmAction::Reboot => vm_reboot,
         });

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -48,8 +48,8 @@ pub enum ApiError {
     /// The VM could not be created.
     VmCreate(VmError),
 
-    /// The VM could not start.
-    VmStart(VmError),
+    /// The VM could not boot.
+    VmBoot(VmError),
 }
 
 pub enum ApiResponsePayload {
@@ -68,10 +68,10 @@ pub enum ApiRequest {
     /// error back.
     VmCreate(Arc<VmConfig>, Sender<ApiResponse>),
 
-    /// Start the previously created virtual machine.
+    /// Boot the previously created virtual machine.
     /// If the VM was not previously created, the VMM API server will send a
-    /// VmStart error back.
-    VmStart(Sender<ApiResponse>),
+    /// VmBoot error back.
+    VmBoot(Sender<ApiResponse>),
 }
 
 pub fn vm_create(
@@ -95,19 +95,19 @@ pub fn vm_create(
     Ok(())
 }
 
-pub fn vm_start(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> Result<()> {
+pub fn vm_boot(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> Result<()> {
     let (response_sender, response_receiver) = channel();
 
-    // Send the VM start request.
+    // Send the VM boot request.
     api_sender
-        .send(ApiRequest::VmStart(response_sender))
+        .send(ApiRequest::VmBoot(response_sender))
         .map_err(Error::ApiRequestSend)?;
     api_evt.write(1).map_err(Error::EventFdWrite)?;
 
     response_receiver
         .recv()
         .map_err(Error::ApiResponseRecv)?
-        .map_err(Error::ApiVmStart)?;
+        .map_err(Error::ApiVmBoot)?;
 
     Ok(())
 }

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -58,6 +58,12 @@ pub enum ApiError {
     /// The VM config is missing.
     VmMissingConfig,
 
+    /// The VM is not booted.
+    VmNotBooted,
+
+    /// The VM is not created.
+    VmNotCreated,
+
     /// The VM could not shutdown.
     VmShutdown(VmError),
 

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -34,6 +34,7 @@ extern crate vmm_sys_util;
 pub use self::http::start_http_thread;
 
 pub mod http;
+pub mod http_endpoint;
 
 use crate::config::VmConfig;
 use crate::vm::Error as VmError;

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -28,6 +28,12 @@
 //!    response channel Receiver.
 //! 5. The thread handles the response and forwards potential errors.
 
+extern crate micro_http;
+
+pub use self::http::start_http_thread;
+
+pub mod http;
+
 use crate::config::VmConfig;
 use crate::vm::Error;
 use std::sync::mpsc::Sender;

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -52,6 +52,12 @@ pub enum ApiError {
     /// The VM could not boot.
     VmBoot(VmError),
 
+    /// The VM is already created.
+    VmAlreadyCreated,
+
+    /// The VM config is missing.
+    VmMissingConfig,
+
     /// The VM could not shutdown.
     VmShutdown(VmError),
 

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1,0 +1,348 @@
+openapi: 3.0.1
+info:
+  title: Cloud Hypervisor API
+  description: Local HTTP based API for managing and inspecting a cloud-hypervisor virtual machine.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 0.3.0
+
+servers:
+- url: http://localhost/api/v1
+
+paths:
+
+  /vmm.info:
+    get:
+      summary: Returns general information about the cloud-hypervisor Virtual Machine Monitor (VMM).
+      responses:
+        200:
+          description: The VMM information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VmmInfo'
+
+  /vm.info:
+    get:
+      summary: Returns general information about the cloud-hypervisor Virtual Machine (VM) instance.
+      responses:
+        200:
+          description: The VM information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VmInfo'
+
+  /vm.create:
+    put:
+      summary: Create the cloud-hypervisor Virtual Machine (VM) instance. The instance is not booted, only created.
+      operationId: createVM
+      requestBody:
+        description: The VM configuration
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VmConfig'
+        required: true
+      responses:
+        201:
+          description: The VM instance was successfully created.
+          content: {}
+
+  /vm.delete:
+    put:
+      summary: Delete the cloud-hypervisor Virtual Machine (VM) instance.
+      operationId: deleteVM
+      responses:
+        201:
+          description: The VM instance was successfully deleted.
+          content: {}
+
+  /vm.boot:
+    put:
+      summary: Boot the previously created VM instance.
+      operationId: bootVM
+      responses:
+        201:
+          description: The VM instance successfully booted.
+          content: {}
+        404:
+          description: The VM instance could not boot because it is not created yet
+          content: {}
+
+  /vm.shutdown:
+    put:
+      summary: Shut the VM instance down.
+      operationId: shutdownVM
+      responses:
+        201:
+          description: The VM instance successfully shut down.
+          content: {}
+        404:
+          description: The VM instance could not shut down because is not created.
+          content: {}
+        405:
+          description: The VM instance could not shut down because it is not started.
+          content: {}
+
+  /vm.reboot:
+    put:
+      summary: Reboot the VM instance.
+      operationId: rebootVM
+      responses:
+        201:
+          description: The VM instance successfully rebooted.
+          content: {}
+        404:
+          description: The VM instance could not reboot because it is not created.
+          content: {}
+        405:
+          description: The VM instance could not reboot because it is not booted.
+          content: {}
+
+components:
+  schemas:
+
+    VmmInfo:
+      required:
+      - version
+      type: object
+      properties:
+        version:
+          type: string
+      description: Virtual Machine Monitor information
+
+    VmInfo:
+      required:
+      - config
+      - state
+      type: object
+      properties:
+        version:
+          type: '#/components/schemas/VmConfig'
+        state:
+          type: string
+          enum: [Created, Booted, Shutdown]
+      description: Virtual Machine information
+
+    VmConfig:
+      required:
+      - kernel
+      - cmdline
+      type: object
+      properties:
+        cpus:
+          $ref: '#/components/schemas/CpuConfig'
+        memory:
+          $ref: '#/components/schemas/MemoryConfig'
+        kernel:
+          $ref: '#/components/schemas/KernelConfig'
+        cmdline:
+          $ref: '#/components/schemas/CmdLineConfig'
+        disks:
+          type: array
+          items:
+            $ref: '#/components/schemas/DiskConfig'
+        net:
+          type: array
+          items:
+            $ref: '#/components/schemas/NetConfig'
+        rng:
+          $ref: '#/components/schemas/RngConfig'
+        fs:
+          type: array
+          items:
+            $ref: '#/components/schemas/FsConfig'
+        pmem:
+          type: array
+          items:
+            $ref: '#/components/schemas/PmemConfig'
+        serial:
+          $ref: '#/components/schemas/ConsoleConfig'
+        console:
+          $ref: '#/components/schemas/ConsoleConfig'
+        devices:
+          type: array
+          items:
+            $ref: '#/components/schemas/DeviceConfig'
+        vhost_user_net:
+          type: array
+          items:
+            $ref: '#/components/schemas/VhostUserNetConfig'
+        vhost_user_blk:
+          type: array
+          items:
+            $ref: '#/components/schemas/VhostUserBlkConfig'
+        vsock:
+          $ref: '#/components/schemas/VsockConfig'
+      description: Virtual machine configuration
+
+    CpuConfig:
+      required:
+      - cpu_count
+      type: object
+      properties:
+        cpu_count:
+          minimum: 1
+          default: 1
+          type: integer
+
+    MemoryConfig:
+      required:
+      - size
+      type: object
+      properties:
+        size:
+          type: integer
+          default: 512 MB
+        file:
+          type: string
+
+    KernelConfig:
+      required:
+      - path
+      type: object
+      properties:
+        path:
+          type: string
+
+    CmdLineConfig:
+      required:
+      - args
+      type: object
+      properties:
+        args:
+          type: string
+
+    DiskConfig:
+      required:
+      - path
+      type: object
+      properties:
+        path:
+          type: string
+
+    NetConfig:
+      required:
+      - ip
+      - mask
+      - mac
+      type: object
+      properties:
+        tap:
+          type: string
+        ip:
+          type: string
+        mask:
+          type: string
+        mac:
+          type: string
+
+    RngConfig:
+      required:
+      - src
+      type: object
+      properties:
+        src:
+          type: string
+          default: "/dev/urandom"
+
+    FsConfig:
+      required:
+      - tag
+      - sock
+      - num_queues
+      - queue_size
+      type: object
+      properties:
+        tag:
+          type: string
+        sock:
+          type: string
+        num_queues:
+          type: integer
+        queue_size:
+          type: integer
+        cache_size:
+          type: integer
+
+    PmemConfig:
+      required:
+      - file
+      - size
+      type: object
+      properties:
+        file:
+          type: string
+        size:
+          type: integer
+
+    ConsoleConfig:
+      required:
+      - mode
+      type: object
+      properties:
+        file:
+          type: string
+        mode:
+          type: string
+          enum: [Off, Tty, File, Null]
+
+    DeviceConfig:
+      required:
+      - path
+      type: object
+      properties:
+        path:
+          type: string
+
+    VhostUserConfig:
+      required:
+      - sock
+      - num_queues
+      - queue_size
+      type: object
+      properties:
+        sock:
+          type: string
+        num_queues:
+          type: integer
+        queue:size:
+          type: integer
+
+    VhostUserNetConfig:
+      required:
+      - mac
+      - vu_cfg
+      type: object
+      properties:
+        mac:
+          type: string
+        vu_cfg:
+          $ref: '#/components/schemas/VhostUserConfig'
+
+    VhostUserBlkConfig:
+      required:
+      - wce
+      - vu_cfg
+      type: object
+      properties:
+        wce:
+          type: boolean
+        vu_cfg:
+          $ref: '#/components/schemas/VhostUserConfig'
+
+    VsockConfig:
+      required:
+      - cid
+      - sock
+      type: object
+      properties:
+        cid:
+          type: integer
+          minimum: 3
+          description: Guest Vsock CID
+        sock:
+          type: string
+          description: Path to UNIX domain socket, used to proxy vsock connections.

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -12,7 +12,6 @@ use std::net::AddrParseError;
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::result;
-use vm_virtio::vhost_user::VhostUserConfig;
 
 pub const DEFAULT_VCPUS: &str = "1";
 pub const DEFAULT_MEMORY: &str = "size=512M";
@@ -460,9 +459,16 @@ impl DeviceConfig {
 }
 
 #[derive(Clone, Debug)]
+pub struct VuConfig {
+    pub sock: String,
+    pub num_queues: usize,
+    pub queue_size: u16,
+}
+
+#[derive(Clone, Debug)]
 pub struct VhostUserNetConfig {
     pub mac: MacAddr,
-    pub vu_cfg: VhostUserConfig,
+    pub vu_cfg: VuConfig,
 }
 
 impl VhostUserNetConfig {
@@ -508,7 +514,7 @@ impl VhostUserNetConfig {
                 .map_err(Error::ParseVuQueueSizeParam)?;
         }
 
-        let vu_cfg = VhostUserConfig {
+        let vu_cfg = VuConfig {
             sock: sock.to_string(),
             num_queues,
             queue_size,
@@ -554,7 +560,7 @@ impl VsockConfig {
 #[derive(Clone, Debug)]
 pub struct VhostUserBlkConfig {
     pub wce: bool,
-    pub vu_cfg: VhostUserConfig,
+    pub vu_cfg: VuConfig,
 }
 
 impl VhostUserBlkConfig {
@@ -597,7 +603,7 @@ impl VhostUserBlkConfig {
             wce = wce_str.parse().map_err(Error::ParseVuBlkWceParam)?;
         }
 
-        let vu_cfg = VhostUserConfig {
+        let vu_cfg = VuConfig {
             sock: sock.to_string(),
             num_queues,
             queue_size,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -5,7 +5,6 @@
 
 extern crate vm_virtio;
 
-use linux_loader::cmdline::Cmdline;
 use net_util::MacAddr;
 use std::convert::From;
 use std::net::AddrParseError;
@@ -180,16 +179,14 @@ pub struct KernelConfig {
 
 #[derive(Clone)]
 pub struct CmdlineConfig {
-    pub args: Cmdline,
+    pub args: String,
 }
 
 impl CmdlineConfig {
     pub fn parse(cmdline: Option<&str>) -> Result<Self> {
-        let cmdline_str = cmdline
+        let args = cmdline
             .map(std::string::ToString::to_string)
             .unwrap_or_else(String::new);
-        let mut args = Cmdline::new(arch::CMDLINE_MAX_SIZE);
-        args.insert_str(cmdline_str).unwrap();
 
         Ok(CmdlineConfig { args })
     }

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -43,6 +43,7 @@ use vm_memory::GuestAddress;
 use vm_memory::{Address, GuestMemoryMmap, GuestUsize};
 #[cfg(feature = "pci_support")]
 use vm_virtio::transport::VirtioPciDevice;
+use vm_virtio::vhost_user::VhostUserConfig;
 use vm_virtio::{VirtioSharedMemory, VirtioSharedMemoryList};
 use vmm_sys_util::eventfd::EventFd;
 
@@ -801,11 +802,14 @@ impl DeviceManager {
         // Add vhost-user-net if required
         if let Some(vhost_user_net_list_cfg) = &vm_info.vm_cfg.vhost_user_net {
             for vhost_user_net_cfg in vhost_user_net_list_cfg.iter() {
-                let vhost_user_net_device = vm_virtio::vhost_user::Net::new(
-                    vhost_user_net_cfg.mac,
-                    vhost_user_net_cfg.vu_cfg.clone(),
-                )
-                .map_err(DeviceManagerError::CreateVhostUserNet)?;
+                let vu_cfg = VhostUserConfig {
+                    sock: vhost_user_net_cfg.vu_cfg.sock.clone(),
+                    num_queues: vhost_user_net_cfg.vu_cfg.num_queues,
+                    queue_size: vhost_user_net_cfg.vu_cfg.queue_size,
+                };
+                let vhost_user_net_device =
+                    vm_virtio::vhost_user::Net::new(vhost_user_net_cfg.mac, vu_cfg)
+                        .map_err(DeviceManagerError::CreateVhostUserNet)?;
 
                 devices.push(Box::new(vhost_user_net_device) as Box<dyn vm_virtio::VirtioDevice>);
             }
@@ -821,11 +825,14 @@ impl DeviceManager {
         // Add vhost-user-blk if required
         if let Some(vhost_user_blk_list_cfg) = &vm_info.vm_cfg.vhost_user_blk {
             for vhost_user_blk_cfg in vhost_user_blk_list_cfg.iter() {
-                let vhost_user_blk_device = vm_virtio::vhost_user::Blk::new(
-                    vhost_user_blk_cfg.wce,
-                    vhost_user_blk_cfg.vu_cfg.clone(),
-                )
-                .map_err(DeviceManagerError::CreateVhostUserBlk)?;
+                let vu_cfg = VhostUserConfig {
+                    sock: vhost_user_blk_cfg.vu_cfg.sock.clone(),
+                    num_queues: vhost_user_blk_cfg.vu_cfg.num_queues,
+                    queue_size: vhost_user_blk_cfg.vu_cfg.queue_size,
+                };
+                let vhost_user_blk_device =
+                    vm_virtio::vhost_user::Blk::new(vhost_user_blk_cfg.wce, vu_cfg)
+                        .map_err(DeviceManagerError::CreateVhostUserBlk)?;
 
                 devices.push(Box::new(vhost_user_blk_device) as Box<dyn vm_virtio::VirtioDevice>);
             }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -4,6 +4,9 @@
 //
 
 #[macro_use]
+extern crate lazy_static;
+
+#[macro_use]
 extern crate log;
 extern crate vmm_sys_util;
 
@@ -47,6 +50,9 @@ pub enum Error {
     /// Cannot start a VM from the API
     ApiVmStart(ApiError),
 
+    /// Cannot bind to the UNIX domain socket path
+    Bind(io::Error),
+
     /// Cannot clone EventFd.
     EventFdClone(io::Error),
 
@@ -61,6 +67,9 @@ pub enum Error {
 
     /// Cannot create epoll context.
     Epoll(io::Error),
+
+    /// Cannot create HTTP thread
+    HttpThreadSpawn(io::Error),
 
     /// Cannot handle the VM STDIN stream
     Stdin(VmError),

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -8,6 +8,10 @@ extern crate lazy_static;
 
 #[macro_use]
 extern crate log;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
 extern crate vmm_sys_util;
 
 use crate::api::{ApiError, ApiRequest, ApiResponse, ApiResponsePayload};

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -394,10 +394,10 @@ impl Vmm {
                                     sender.send(response).map_err(Error::ApiResponseSend)?;
                                 }
                                 ApiRequest::VmDelete(sender) => {
-                                    let response = match self.vm_delete() {
-                                        Ok(_) => Ok(ApiResponsePayload::Empty),
-                                        Err(e) => Err(ApiError::VmDelete(e)),
-                                    };
+                                    let response = self
+                                        .vm_delete()
+                                        .map_err(ApiError::VmDelete)
+                                        .map(|_| ApiResponsePayload::Empty);
 
                                     sender.send(response).map_err(Error::ApiResponseSend)?;
                                 }
@@ -410,34 +410,34 @@ impl Vmm {
                                         continue;
                                     }
 
-                                    let response = match self.vm_boot() {
-                                        Ok(_) => Ok(ApiResponsePayload::Empty),
-                                        Err(e) => Err(ApiError::VmBoot(e)),
-                                    };
+                                    let response = self
+                                        .vm_boot()
+                                        .map_err(ApiError::VmBoot)
+                                        .map(|_| ApiResponsePayload::Empty);
 
                                     sender.send(response).map_err(Error::ApiResponseSend)?;
                                 }
                                 ApiRequest::VmShutdown(sender) => {
-                                    let response = match self.vm_shutdown() {
-                                        Ok(_) => Ok(ApiResponsePayload::Empty),
-                                        Err(e) => Err(ApiError::VmShutdown(e)),
-                                    };
+                                    let response = self
+                                        .vm_shutdown()
+                                        .map_err(ApiError::VmShutdown)
+                                        .map(|_| ApiResponsePayload::Empty);
 
                                     sender.send(response).map_err(Error::ApiResponseSend)?;
                                 }
                                 ApiRequest::VmReboot(sender) => {
-                                    let response = match self.vm_reboot() {
-                                        Ok(_) => Ok(ApiResponsePayload::Empty),
-                                        Err(e) => Err(ApiError::VmReboot(e)),
-                                    };
+                                    let response = self
+                                        .vm_reboot()
+                                        .map_err(ApiError::VmReboot)
+                                        .map(|_| ApiResponsePayload::Empty);
 
                                     sender.send(response).map_err(Error::ApiResponseSend)?;
                                 }
                                 ApiRequest::VmInfo(sender) => {
-                                    let response = match self.vm_info() {
-                                        Ok(info) => Ok(ApiResponsePayload::VmInfo(info)),
-                                        Err(e) => Err(ApiError::VmInfo(e)),
-                                    };
+                                    let response = self
+                                        .vm_info()
+                                        .map_err(ApiError::VmInfo)
+                                        .map(ApiResponsePayload::VmInfo);
 
                                     sender.send(response).map_err(Error::ApiResponseSend)?;
                                 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -753,7 +753,7 @@ impl Vm {
         }
     }
 
-    pub fn stop(&mut self) -> Result<()> {
+    pub fn shutdown(&mut self) -> Result<()> {
         if self.on_tty {
             // Don't forget to set the terminal in canonical mode
             // before to exit.
@@ -798,7 +798,7 @@ impl Vm {
         }
     }
 
-    pub fn start(&mut self) -> Result<()> {
+    pub fn boot(&mut self) -> Result<()> {
         let entry_addr = self.load_kernel()?;
         let vcpu_count = u8::from(&self.config.cpus);
         let vcpu_thread_barrier = Arc::new(Barrier::new((vcpu_count + 1) as usize));

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -463,7 +463,8 @@ fn get_host_cpu_phys_bits() -> u8 {
 impl Vm {
     pub fn new(config: Arc<VmConfig>, exit_evt: EventFd, reset_evt: EventFd) -> Result<Self> {
         let kvm = Kvm::new().map_err(Error::KvmNew)?;
-        let kernel = File::open(&config.kernel.path).map_err(Error::KernelFile)?;
+        let kernel =
+            File::open(&config.kernel.as_ref().unwrap().path).map_err(Error::KernelFile)?;
         let fd = kvm.create_vm().map_err(Error::VmCreate)?;
         let fd = Arc::new(fd);
         let creation_ts = std::time::Instant::now();

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -213,6 +213,9 @@ pub enum Error {
     /// VM is not created
     VmNotCreated,
 
+    /// VM is not bootted
+    VmNotBooted,
+
     /// Cannot clone EventFd.
     EventFdClone(io::Error),
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -209,6 +209,12 @@ pub enum Error {
 
     /// Failed to create a new KVM instance
     KvmNew(io::Error),
+
+    /// VM is not created
+    VmNotCreated,
+
+    /// Cannot clone EventFd.
+    EventFdClone(io::Error),
 }
 pub type Result<T> = result::Result<T, Error>;
 


### PR DESCRIPTION
Cloud Hypervisor API is a RPC-style HTTP based API, using JSON for its payload.
The API is described at `vmm/src/api/swagger/`

The HTTP requests are handled by a `micro_http` HTTP server thread. Each request is routed to its specific handler, which will translate the HTTP request into an IPC one. Each handler is given an `mpsc` Sender for sending the IPC commands and listening for the reply back.

The HTTP handlers are responsible for handling HTTP requests and unconditionally returning an HTTP response back.
The HTTP server is responsible for collecting incoming requests, routing them to the appropriate endpoint handler and sending the handler response back to the caller.

Fixes: #244 

TODO

* [x]  Improve VMM state machine: e.g. we should not create a VM when one is already running, we should not start a VM when it's not created
* [x] VM create, delete, boot, shutdown and reboot support
* [x] VM information endpoint support
* [x] Integration tests for the HTTP API
