### PR TITLE
Clean-up all feature based build warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ before_script:
   - rustup component add rustfmt
 
 script:
-  - cargo build --release
-  - cargo build --release --no-default-features
+  - cargo rustc -- -D warnings
+  - cargo rustc --no-default-features --features "pci"  -- -D warnings
+  - cargo rustc --no-default-features --features "pci,acpi"  -- -D warnings
+  - cargo rustc --no-default-features --features "mmio"  -- -D warnings
   - cargo test
   - cargo clippy --all-targets --all-features -- -D warnings
   - find . -name "*.rs" | xargs rustfmt --check

--- a/vm-virtio/src/transport/mmio.rs
+++ b/vm-virtio/src/transport/mmio.rs
@@ -10,8 +10,8 @@ use libc::EFD_NONBLOCK;
 
 use crate::{
     Queue, VirtioDevice, VirtioInterrupt, VirtioInterruptType, DEVICE_ACKNOWLEDGE, DEVICE_DRIVER,
-    DEVICE_DRIVER_OK, DEVICE_FAILED, DEVICE_FEATURES_OK, INTERRUPT_STATUS_CONFIG_CHANGED,
-    INTERRUPT_STATUS_USED_RING,
+    DEVICE_DRIVER_OK, DEVICE_FAILED, DEVICE_FEATURES_OK, DEVICE_INIT,
+    INTERRUPT_STATUS_CONFIG_CHANGED, INTERRUPT_STATUS_USED_RING,
 };
 use devices::{BusDevice, Interrupt};
 use vm_memory::{GuestAddress, GuestMemoryMmap};
@@ -75,8 +75,7 @@ impl MmioDevice {
             queue_select: 0,
             interrupt_status: Arc::new(AtomicUsize::new(0)),
             interrupt_cb: None,
-
-            driver_status: 0,
+            driver_status: DEVICE_INIT,
             config_generation: 0,
             queues,
             queue_evts,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -299,7 +299,7 @@ impl DeviceManager {
         msi_capable: bool,
         userspace_ioapic: bool,
         mut mem_slots: u32,
-        exit_evt: &EventFd,
+        _exit_evt: &EventFd,
         reset_evt: &EventFd,
     ) -> DeviceManagerResult<Self> {
         let mut io_bus = devices::Bus::new();
@@ -362,7 +362,7 @@ impl DeviceManager {
 
         #[cfg(feature = "acpi")]
         let acpi_device = Arc::new(Mutex::new(devices::AcpiShutdownDevice::new(
-            exit_evt.try_clone().map_err(DeviceManagerError::EventFd)?,
+            _exit_evt.try_clone().map_err(DeviceManagerError::EventFd)?,
             reset_evt.try_clone().map_err(DeviceManagerError::EventFd)?,
         )));
 


### PR DESCRIPTION
With the addition of some conditionally built features some build warnings have crept in. Add build testing (with warnings treated as errors) for all supported feature configurations and fix the issues shown up.