### PR TITLE
arch: acpi: Correct starting length of MCFG table

### DIFF
--- a/arch/src/x86_64/acpi.rs
+++ b/arch/src/x86_64/acpi.rs
@@ -276,7 +276,10 @@ pub fn create_acpi_tables(
     tables.push(madt_offset.0);
 
     // MCFG
-    let mut mcfg = SDT::new(*b"MCFG", 60, 1, *b"CLOUDH", *b"CHMCFG  ", 1);
+    let mut mcfg = SDT::new(*b"MCFG", 36, 1, *b"CLOUDH", *b"CHMCFG  ", 1);
+
+    // MCFG reserved 8 bytes
+    mcfg.append(0u64);
 
     // 32-bit PCI enhanced configuration mechanism
     mcfg.append(PCIRangeEntry {


### PR DESCRIPTION
The starting length of the MCFG table was too long resulting in the
kernel trying to get extra MCFG entries from the table that weren't
there resulting in the following error message from the kernel:

PCI: no memory for MCFG entries

The MCFG table also has an 8 bytes of padding at the start before the
table begins.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>