### PR TITLE
Initial support for the API server socket logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "credibility 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ssh2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 clap = "2.33.0"
 lazy_static = "1.4.0"
+libc = "0.2.60"
 log = { version = "0.4.8", features = ["std"] }
 vmm = { path = "vmm" }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,6 +291,19 @@ fn main() {
         }
     };
 
+    let api_socket_path = cmd_arguments.value_of("api-socket");
+
+    let vmm_config = config::VmmConfig::parse(config::VmmParams {
+        // These .unwrap() cannot fail as there is a default value defined
+        api_socket_path: api_socket_path.unwrap(),
+        log_level,
+        log_file: cmd_arguments.value_of("log-file"),
+    })
+    .map_err(|e| {
+        println!("Failed parsing parameters {:?}", e);
+        process::exit(1);
+    });
+
     println!(
         "Cloud Hypervisor Guest\n\tvCPUs: {}\n\tMemory: {} MB\
          \n\tKernel: {:?}\n\tKernel cmdline: {}\n\tDisk(s): {:?}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ extern crate vmm;
 #[macro_use(crate_version, crate_authors)]
 extern crate clap;
 
-use clap::{App, Arg};
+use clap::{App, Arg, ArgGroup};
 use log::LevelFilter;
 use std::process;
 use std::sync::Mutex;
@@ -63,11 +63,14 @@ fn main() {
         .version(crate_version!())
         .author(crate_authors!())
         .about("Launch a cloud-hypervisor VMM.")
+        .group(ArgGroup::with_name("vm-config").multiple(true))
+        .group(ArgGroup::with_name("vmm-config").multiple(true))
         .arg(
             Arg::with_name("cpus")
                 .long("cpus")
                 .help("Number of virtual CPUs")
-                .default_value(config::DEFAULT_VCPUS),
+                .default_value(config::DEFAULT_VCPUS)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("memory")
@@ -76,26 +79,30 @@ fn main() {
                     "Memory parameters \"size=<guest_memory_size>,\
                      file=<backing_file_path>\"",
                 )
-                .default_value(config::DEFAULT_MEMORY),
+                .default_value(config::DEFAULT_MEMORY)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("kernel")
                 .long("kernel")
                 .help("Path to kernel image (vmlinux)")
-                .takes_value(true),
+                .takes_value(true)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("cmdline")
                 .long("cmdline")
                 .help("Kernel command line")
-                .takes_value(true),
+                .takes_value(true)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("disk")
                 .long("disk")
                 .help("Path to VM disk image")
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("net")
@@ -105,13 +112,15 @@ fn main() {
                      ip=<ip_addr>,mask=<net_mask>,mac=<mac_addr>\"",
                 )
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("rng")
                 .long("rng")
                 .help("Path to entropy source")
-                .default_value(config::DEFAULT_RNG_SOURCE),
+                .default_value(config::DEFAULT_RNG_SOURCE)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("fs")
@@ -123,7 +132,8 @@ fn main() {
                      cache_size=<DAX cache size: default 8Gib>\"",
                 )
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("pmem")
@@ -133,26 +143,30 @@ fn main() {
                      size=<persistent_memory_size>\"",
                 )
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("serial")
                 .long("serial")
                 .help("Control serial port: off|null|tty|file=/path/to/a/file")
-                .default_value("null"),
+                .default_value("null")
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("console")
                 .long("console")
                 .help("Control (virtio) console: off|null|tty|file=/path/to/a/file")
-                .default_value("tty"),
+                .default_value("tty")
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("device")
                 .long("device")
                 .help("Direct device assignment parameter")
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("vhost-user-net")
@@ -163,7 +177,8 @@ fn main() {
                      queue_size=<size_of_each_queue>\"",
                 )
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("vsock")
@@ -173,20 +188,23 @@ fn main() {
                      sock=<socket_path>\"",
                 )
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vm-config"),
         )
         .arg(
             Arg::with_name("v")
                 .short("v")
                 .multiple(true)
-                .help("Sets the level of debugging output"),
+                .help("Sets the level of debugging output")
+                .group("vmm-config"),
         )
         .arg(
             Arg::with_name("log-file")
                 .long("log-file")
                 .help("Log file. Standard error is used if not specified")
                 .takes_value(true)
-                .min_values(1),
+                .min_values(1)
+                .group("vmm-config"),
         )
         .get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,6 +268,7 @@ fn main() {
     .expect("Expected to be able to setup logger");
 
     let vm_config = match config::VmConfig::parse(config::VmParams {
+        user_defined: cmd_arguments.is_present("vm-config"),
         cpus,
         memory,
         kernel,

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,10 @@ impl log::Log for Logger {
 }
 
 fn main() {
+    let uid = unsafe { libc::getuid() };
+    let pid = unsafe { libc::getpid() };
+    let api_server_path = format! {"/run/user/{}/cloud-hypervisor.{}", uid, pid};
+
     let cmd_arguments = App::new("cloud-hypervisor")
         .version(crate_version!())
         .author(crate_authors!())
@@ -204,6 +208,15 @@ fn main() {
                 .help("Log file. Standard error is used if not specified")
                 .takes_value(true)
                 .min_values(1)
+                .group("vmm-config"),
+        )
+        .arg(
+            Arg::with_name("api-socket")
+                .long("api-socket")
+                .help("HTTP API socket path (UNIX domain socket).")
+                .takes_value(true)
+                .min_values(1)
+                .default_value(&api_server_path)
                 .group("vmm-config"),
         )
         .get_matches();

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,9 +227,7 @@ fn main() {
     let rng = cmd_arguments.value_of("rng").unwrap();
     let serial = cmd_arguments.value_of("serial").unwrap();
 
-    let kernel = cmd_arguments
-        .value_of("kernel")
-        .expect("Missing argument: kernel");
+    let kernel = cmd_arguments.value_of("kernel");
     let cmdline = cmd_arguments.value_of("cmdline");
 
     let disks: Option<Vec<&str>> = cmd_arguments.values_of("disk").map(|x| x.collect());
@@ -309,7 +307,7 @@ fn main() {
          \n\tKernel: {:?}\n\tKernel cmdline: {}\n\tDisk(s): {:?}",
         u8::from(&vm_config.cpus),
         vm_config.memory.size >> 20,
-        vm_config.kernel.path,
+        vm_config.kernel,
         vm_config.cmdline.args.as_str(),
         vm_config.disks,
     );

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -79,6 +79,7 @@ pub enum Error<'a> {
 pub type Result<'a, T> = result::Result<T, Error<'a>>;
 
 pub struct VmParams<'a> {
+    pub user_defined: bool,
     pub cpus: &'a str,
     pub memory: &'a str,
     pub kernel: &'a str,
@@ -551,6 +552,7 @@ impl<'a> VsockConfig<'a> {
 }
 
 pub struct VmConfig<'a> {
+    pub user_defined: bool,
     pub cpus: CpusConfig,
     pub memory: MemoryConfig<'a>,
     pub kernel: KernelConfig<'a>,
@@ -639,6 +641,7 @@ impl<'a> VmConfig<'a> {
         }
 
         Ok(VmConfig {
+            user_defined: vm_params.user_defined,
             cpus: CpusConfig::parse(vm_params.cpus)?,
             memory: MemoryConfig::parse(vm_params.memory)?,
             kernel: KernelConfig::parse(vm_params.kernel)?,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -6,6 +6,7 @@
 extern crate vm_virtio;
 
 use linux_loader::cmdline::Cmdline;
+use log::LevelFilter;
 use net_util::MacAddr;
 use std::convert::From;
 use std::net::AddrParseError;
@@ -657,5 +658,43 @@ impl<'a> VmConfig<'a> {
             vhost_user_net,
             vsock,
         })
+    }
+}
+
+/// VMM specific parameters.
+pub struct VmmParams<'a> {
+    /// The VMM HTTP API server socket path.
+    pub api_socket_path: &'a str,
+
+    /// The VMM debugging output level
+    pub log_level: LevelFilter,
+
+    /// Optional VMM log file
+    pub log_file: Option<&'a str>,
+}
+
+/// HTTP API server configuration for the VMM
+pub struct ApiServerConfig<'a> {
+    /// Unix domain socket path.
+    pub socket_path: &'a str,
+}
+
+impl<'a> ApiServerConfig<'a> {
+    pub fn parse(socket_path: &'a str) -> Result<Self> {
+        Ok(ApiServerConfig { socket_path })
+    }
+}
+
+/// VMM specific configuration.
+pub struct VmmConfig<'a> {
+    /// The VMM HTTP API server configuration.
+    pub api_server: ApiServerConfig<'a>,
+}
+
+impl<'a> VmmConfig<'a> {
+    pub fn parse(vmm_params: VmmParams<'a>) -> Result<Self> {
+        let api_server = ApiServerConfig::parse(vmm_params.api_socket_path)?;
+
+        Ok(VmmConfig { api_server })
     }
 }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -9,7 +9,7 @@ extern crate log;
 
 use kvm_ioctls::*;
 use std::fmt::{self, Display};
-use std::result;
+use std::{result, thread};
 
 pub mod config;
 pub mod device_manager;
@@ -21,6 +21,9 @@ use self::vm::{ExitBehaviour, Vm};
 /// Errors associated with VM management
 #[derive(Debug)]
 pub enum Error {
+    /// Cannot start API server socket
+    ApiServerStart,
+
     /// Cannot create a new VM.
     VmNew(vm::Error),
 
@@ -37,6 +40,7 @@ impl Display for Error {
         use self::Error::*;
 
         match self {
+            ApiServerStart => write!(f, "Can not start the API server"),
             VmNew(e) => write!(f, "Can not create a new virtual machine: {:?}", e),
             VmStart(e) => write!(f, "Can not start a new virtual machine: {:?}", e),
             LoadKernel(e) => write!(f, "Can not load a guest kernel: {:?}", e),
@@ -55,18 +59,32 @@ impl Vmm {
     }
 
     pub fn run(&self, vmm_config: VmmConfig, vm_config: VmConfig) -> Result<()> {
-        loop {
-            let mut vm = Vm::new(&self.kvm, &vm_config).map_err(Error::VmNew)?;
+        let socket_path = vmm_config.api_server.socket_path.to_string();
 
-            let entry = vm.load_kernel().map_err(Error::LoadKernel)?;
+        // First we spawn the API server
+        let api_thread = thread::spawn(move || {
+            panic!("API server at {} UNSUPPORTED", &socket_path);
+        });
 
-            if vm.start(entry).map_err(Error::VmStart)? == ExitBehaviour::Shutdown {
+        // If we have a valid VM configuration, we need to verify that it
+        // has been explicitly set by the user.
+        if vm_config.user_defined && vm_config.valid() {
+            loop {
+                let mut vm = Vm::new(&self.kvm, &vm_config).map_err(Error::VmNew)?;
+
+                let entry = vm.load_kernel().map_err(Error::LoadKernel)?;
+
+                if vm.start(entry).map_err(Error::VmStart)? == ExitBehaviour::Shutdown {
+                    break;
+                }
+
+                #[cfg(not(feature = "acpi"))]
                 break;
             }
-
-            #[cfg(not(feature = "acpi"))]
-            break;
         }
+
+        api_thread.join().map_err(|_| Error::ApiServerStart)?;
+
         Ok(())
     }
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -534,7 +534,8 @@ fn get_host_cpu_phys_bits() -> u8 {
 
 impl<'a> Vm<'a> {
     pub fn new(kvm: &Kvm, config: &'a VmConfig<'a>) -> Result<Self> {
-        let kernel = File::open(&config.kernel.path).map_err(Error::KernelFile)?;
+        let kernel =
+            File::open(&config.kernel.as_ref().unwrap().path).map_err(Error::KernelFile)?;
         let fd = kvm.create_vm().map_err(Error::VmCreate)?;
         let fd = Arc::new(fd);
         let creation_ts = std::time::Instant::now();


### PR DESCRIPTION
The API server potentially brings a couple of new usage models, on top of the current, all cli based one:

1. The user relies exclusively on the API server to configure and start the VM. This is the `cloud-hypervisor --api-socket` model. Here we're not trying to start any VM, but only the API server.

2. Through the CLI, the user provides a set of VM configuration knobs together with the `api-socket` one. Here the user is trying to start a VM and asks for an API server to asynchronously control it (hotplug, shutdown, etc). This is the `cloud-hypervisor --kernel /my/kernel --cpus 4 --api-socket` model. Both the VM and the API server are started.

This PR tries to add support for both models to cloud-hypervisor.

**NOTE** This PR does not start the API server itself, this will be done through PR #273. This PR only brings the UX logic to support the above mentioned models, the VMM will panic when only given the `--api-socket` option.