### PR TITLE
Convert all VmConfig fields to owned data types

### DIFF
--- a/vm-virtio/src/vhost_user/blk.rs
+++ b/vm-virtio/src/vhost_user/blk.rs
@@ -46,10 +46,10 @@ pub struct Blk {
     interrupt_cb: Option<Arc<VirtioInterrupt>>,
 }
 
-impl<'a> Blk {
+impl Blk {
     /// Create a new vhost-user-blk device
-    pub fn new(wce: bool, vu_cfg: VhostUserConfig<'a>) -> Result<Blk> {
-        let mut vhost_user_blk = Master::connect(vu_cfg.sock, vu_cfg.num_queues as u64)
+    pub fn new(wce: bool, vu_cfg: VhostUserConfig) -> Result<Blk> {
+        let mut vhost_user_blk = Master::connect(&vu_cfg.sock, vu_cfg.num_queues as u64)
             .map_err(Error::VhostUserCreateMaster)?;
 
         // Filling device and vring features VMM supports.

--- a/vm-virtio/src/vhost_user/net.rs
+++ b/vm-virtio/src/vhost_user/net.rs
@@ -38,10 +38,10 @@ pub struct Net {
     queue_sizes: Vec<u16>,
 }
 
-impl<'a> Net {
+impl Net {
     /// Create a new vhost-user-net device
-    pub fn new(mac_addr: MacAddr, vu_cfg: VhostUserConfig<'a>) -> Result<Net> {
-        let mut vhost_user_net = Master::connect(vu_cfg.sock, vu_cfg.num_queues as u64)
+    pub fn new(mac_addr: MacAddr, vu_cfg: VhostUserConfig) -> Result<Net> {
+        let mut vhost_user_net = Master::connect(&vu_cfg.sock, vu_cfg.num_queues as u64)
             .map_err(Error::VhostUserCreateMaster)?;
 
         let kill_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::CreateKillEventFd)?;

--- a/vm-virtio/src/vhost_user/vu_common_ctrl.rs
+++ b/vm-virtio/src/vhost_user/vu_common_ctrl.rs
@@ -14,9 +14,9 @@ use super::{Error, Result};
 use vhost_rs::vhost_user::{Master, VhostUserMaster};
 use vhost_rs::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
 
-#[derive(Debug, Copy, Clone)]
-pub struct VhostUserConfig<'a> {
-    pub sock: &'a str,
+#[derive(Debug, Clone)]
+pub struct VhostUserConfig {
+    pub sock: String,
     pub num_queues: usize,
     pub queue_size: u16,
 }

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -116,6 +116,7 @@ fn parse_size(size: &str) -> Result<u64> {
     Ok(res << shift)
 }
 
+#[derive(Clone, Debug)]
 pub struct CpusConfig(pub u8);
 
 impl CpusConfig {
@@ -132,6 +133,7 @@ impl From<&CpusConfig> for u8 {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct MemoryConfig {
     pub size: u64,
     pub file: Option<PathBuf>,
@@ -172,6 +174,7 @@ impl MemoryConfig {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct KernelConfig {
     pub path: PathBuf,
 }
@@ -184,6 +187,7 @@ impl KernelConfig {
     }
 }
 
+#[derive(Clone)]
 pub struct CmdlineConfig {
     pub args: Cmdline,
     pub offset: GuestAddress,
@@ -204,7 +208,7 @@ impl CmdlineConfig {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DiskConfig {
     pub path: PathBuf,
 }
@@ -217,6 +221,7 @@ impl DiskConfig {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct NetConfig {
     pub tap: Option<String>,
     pub ip: Ipv4Addr,
@@ -268,6 +273,7 @@ impl NetConfig {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct RngConfig {
     pub src: PathBuf,
 }
@@ -280,7 +286,7 @@ impl RngConfig {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct FsConfig {
     pub tag: String,
     pub sock: PathBuf,
@@ -368,6 +374,7 @@ impl FsConfig {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct PmemConfig {
     pub file: PathBuf,
     pub size: u64,
@@ -400,7 +407,7 @@ impl PmemConfig {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Clone, PartialEq)]
 pub enum ConsoleOutputMode {
     Off,
     Tty,
@@ -417,6 +424,7 @@ impl ConsoleOutputMode {
     }
 }
 
+#[derive(Clone)]
 pub struct ConsoleConfig {
     pub file: Option<PathBuf>,
     pub mode: ConsoleOutputMode,
@@ -450,7 +458,7 @@ impl ConsoleConfig {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DeviceConfig {
     pub path: PathBuf,
 }
@@ -463,6 +471,7 @@ impl DeviceConfig {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct VhostUserNetConfig {
     pub mac: MacAddr,
     pub vu_cfg: VhostUserConfig,
@@ -521,6 +530,7 @@ impl VhostUserNetConfig {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct VsockConfig {
     pub cid: u64,
     pub sock: PathBuf,
@@ -553,6 +563,7 @@ impl VsockConfig {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct VhostUserBlkConfig {
     pub wce: bool,
     pub vu_cfg: VhostUserConfig,
@@ -608,6 +619,7 @@ impl VhostUserBlkConfig {
     }
 }
 
+#[derive(Clone)]
 pub struct VmConfig {
     pub cpus: CpusConfig,
     pub memory: MemoryConfig,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -268,14 +268,14 @@ impl NetConfig {
     }
 }
 
-pub struct RngConfig<'a> {
-    pub src: &'a Path,
+pub struct RngConfig {
+    pub src: PathBuf,
 }
 
-impl<'a> RngConfig<'a> {
-    pub fn parse(rng: &'a str) -> Result<Self> {
+impl RngConfig {
+    pub fn parse(rng: &str) -> Result<Self> {
         Ok(RngConfig {
-            src: Path::new(rng),
+            src: PathBuf::from(rng),
         })
     }
 }
@@ -615,7 +615,7 @@ pub struct VmConfig<'a> {
     pub cmdline: CmdlineConfig,
     pub disks: Option<Vec<DiskConfig>>,
     pub net: Option<Vec<NetConfig>>,
-    pub rng: RngConfig<'a>,
+    pub rng: RngConfig,
     pub fs: Option<Vec<FsConfig<'a>>>,
     pub pmem: Option<Vec<PmemConfig<'a>>>,
     pub serial: ConsoleConfig<'a>,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -281,16 +281,16 @@ impl RngConfig {
 }
 
 #[derive(Debug)]
-pub struct FsConfig<'a> {
-    pub tag: &'a str,
-    pub sock: &'a Path,
+pub struct FsConfig {
+    pub tag: String,
+    pub sock: PathBuf,
     pub num_queues: usize,
     pub queue_size: u16,
     pub cache_size: Option<u64>,
 }
 
-impl<'a> FsConfig<'a> {
-    pub fn parse(fs: &'a str) -> Result<Self> {
+impl FsConfig {
+    pub fn parse(fs: &str) -> Result<Self> {
         // Split the parameters based on the comma delimiter
         let params_list: Vec<&str> = fs.split(',').collect();
 
@@ -359,8 +359,8 @@ impl<'a> FsConfig<'a> {
         }
 
         Ok(FsConfig {
-            tag,
-            sock: Path::new(sock),
+            tag: tag.to_string(),
+            sock: PathBuf::from(sock),
             num_queues,
             queue_size,
             cache_size,
@@ -616,7 +616,7 @@ pub struct VmConfig<'a> {
     pub disks: Option<Vec<DiskConfig>>,
     pub net: Option<Vec<NetConfig>>,
     pub rng: RngConfig,
-    pub fs: Option<Vec<FsConfig<'a>>>,
+    pub fs: Option<Vec<FsConfig>>,
     pub pmem: Option<Vec<PmemConfig<'a>>>,
     pub serial: ConsoleConfig<'a>,
     pub console: ConsoleConfig<'a>,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -10,7 +10,7 @@ use net_util::MacAddr;
 use std::convert::From;
 use std::net::AddrParseError;
 use std::net::Ipv4Addr;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::result;
 use vm_memory::GuestAddress;
 use vm_virtio::vhost_user::VhostUserConfig;
@@ -521,13 +521,13 @@ impl VhostUserNetConfig {
     }
 }
 
-pub struct VsockConfig<'a> {
+pub struct VsockConfig {
     pub cid: u64,
-    pub sock: &'a Path,
+    pub sock: PathBuf,
 }
 
-impl<'a> VsockConfig<'a> {
-    pub fn parse(vsock: &'a str) -> Result<Self> {
+impl VsockConfig {
+    pub fn parse(vsock: &str) -> Result<Self> {
         // Split the parameters based on the comma delimiter
         let params_list: Vec<&str> = vsock.split(',').collect();
 
@@ -548,7 +548,7 @@ impl<'a> VsockConfig<'a> {
 
         Ok(VsockConfig {
             cid: cid_str.parse::<u64>().map_err(Error::ParseVsockCidParam)?,
-            sock: Path::new(sock_str),
+            sock: PathBuf::from(sock_str),
         })
     }
 }
@@ -608,7 +608,7 @@ impl VhostUserBlkConfig {
     }
 }
 
-pub struct VmConfig<'a> {
+pub struct VmConfig {
     pub cpus: CpusConfig,
     pub memory: MemoryConfig,
     pub kernel: KernelConfig,
@@ -623,11 +623,11 @@ pub struct VmConfig<'a> {
     pub devices: Option<Vec<DeviceConfig>>,
     pub vhost_user_net: Option<Vec<VhostUserNetConfig>>,
     pub vhost_user_blk: Option<Vec<VhostUserBlkConfig>>,
-    pub vsock: Option<Vec<VsockConfig<'a>>>,
+    pub vsock: Option<Vec<VsockConfig>>,
 }
 
-impl<'a> VmConfig<'a> {
-    pub fn parse(vm_params: VmParams<'a>) -> Result<Self> {
+impl VmConfig {
+    pub fn parse(vm_params: VmParams) -> Result<Self> {
         let mut disks: Option<Vec<DiskConfig>> = None;
         if let Some(disk_list) = &vm_params.disks {
             let mut disk_config_list = Vec::new();

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -451,14 +451,14 @@ impl ConsoleConfig {
 }
 
 #[derive(Debug)]
-pub struct DeviceConfig<'a> {
-    pub path: &'a Path,
+pub struct DeviceConfig {
+    pub path: PathBuf,
 }
 
-impl<'a> DeviceConfig<'a> {
-    pub fn parse(device: &'a str) -> Result<Self> {
+impl DeviceConfig {
+    pub fn parse(device: &str) -> Result<Self> {
         Ok(DeviceConfig {
-            path: Path::new(device),
+            path: PathBuf::from(device),
         })
     }
 }
@@ -620,7 +620,7 @@ pub struct VmConfig<'a> {
     pub pmem: Option<Vec<PmemConfig>>,
     pub serial: ConsoleConfig,
     pub console: ConsoleConfig,
-    pub devices: Option<Vec<DeviceConfig<'a>>>,
+    pub devices: Option<Vec<DeviceConfig>>,
     pub vhost_user_net: Option<Vec<VhostUserNetConfig<'a>>>,
     pub vhost_user_blk: Option<Vec<VhostUserBlkConfig<'a>>>,
     pub vsock: Option<Vec<VsockConfig<'a>>>,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -205,14 +205,14 @@ impl CmdlineConfig {
 }
 
 #[derive(Debug)]
-pub struct DiskConfig<'a> {
-    pub path: &'a Path,
+pub struct DiskConfig {
+    pub path: PathBuf,
 }
 
-impl<'a> DiskConfig<'a> {
-    pub fn parse(disk: &'a str) -> Result<Self> {
+impl DiskConfig {
+    pub fn parse(disk: &str) -> Result<Self> {
         Ok(DiskConfig {
-            path: Path::new(disk),
+            path: PathBuf::from(disk),
         })
     }
 }
@@ -613,7 +613,7 @@ pub struct VmConfig<'a> {
     pub memory: MemoryConfig,
     pub kernel: KernelConfig,
     pub cmdline: CmdlineConfig,
-    pub disks: Option<Vec<DiskConfig<'a>>>,
+    pub disks: Option<Vec<DiskConfig>>,
     pub net: Option<Vec<NetConfig<'a>>>,
     pub rng: RngConfig<'a>,
     pub fs: Option<Vec<FsConfig<'a>>>,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -10,7 +10,7 @@ use net_util::MacAddr;
 use std::convert::From;
 use std::net::AddrParseError;
 use std::net::Ipv4Addr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::result;
 use vm_memory::GuestAddress;
 use vm_virtio::vhost_user::VhostUserConfig;
@@ -132,13 +132,13 @@ impl From<&CpusConfig> for u8 {
     }
 }
 
-pub struct MemoryConfig<'a> {
+pub struct MemoryConfig {
     pub size: u64,
-    pub file: Option<&'a Path>,
+    pub file: Option<PathBuf>,
 }
 
-impl<'a> MemoryConfig<'a> {
-    pub fn parse(memory: &'a str) -> Result<Self> {
+impl MemoryConfig {
+    pub fn parse(memory: &str) -> Result<Self> {
         // Split the parameters based on the comma delimiter
         let params_list: Vec<&str> = memory.split(',').collect();
 
@@ -160,7 +160,7 @@ impl<'a> MemoryConfig<'a> {
                 return Err(Error::ParseMemoryFileParam);
             }
 
-            Some(Path::new(file_str))
+            Some(PathBuf::from(file_str))
         } else {
             None
         };
@@ -610,7 +610,7 @@ impl<'a> VhostUserBlkConfig<'a> {
 
 pub struct VmConfig<'a> {
     pub cpus: CpusConfig,
-    pub memory: MemoryConfig<'a>,
+    pub memory: MemoryConfig,
     pub kernel: KernelConfig<'a>,
     pub cmdline: CmdlineConfig,
     pub disks: Option<Vec<DiskConfig<'a>>>,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -368,13 +368,13 @@ impl FsConfig {
     }
 }
 
-pub struct PmemConfig<'a> {
-    pub file: &'a Path,
+pub struct PmemConfig {
+    pub file: PathBuf,
     pub size: u64,
 }
 
-impl<'a> PmemConfig<'a> {
-    pub fn parse(pmem: &'a str) -> Result<Self> {
+impl PmemConfig {
+    pub fn parse(pmem: &str) -> Result<Self> {
         // Split the parameters based on the comma delimiter
         let params_list: Vec<&str> = pmem.split(',').collect();
 
@@ -394,7 +394,7 @@ impl<'a> PmemConfig<'a> {
         }
 
         Ok(PmemConfig {
-            file: Path::new(file_str),
+            file: PathBuf::from(file_str),
             size: parse_size(size_str)?,
         })
     }
@@ -617,7 +617,7 @@ pub struct VmConfig<'a> {
     pub net: Option<Vec<NetConfig>>,
     pub rng: RngConfig,
     pub fs: Option<Vec<FsConfig>>,
-    pub pmem: Option<Vec<PmemConfig<'a>>>,
+    pub pmem: Option<Vec<PmemConfig>>,
     pub serial: ConsoleConfig<'a>,
     pub console: ConsoleConfig<'a>,
     pub devices: Option<Vec<DeviceConfig<'a>>>,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -217,15 +217,15 @@ impl DiskConfig {
     }
 }
 
-pub struct NetConfig<'a> {
-    pub tap: Option<&'a str>,
+pub struct NetConfig {
+    pub tap: Option<String>,
     pub ip: Ipv4Addr,
     pub mask: Ipv4Addr,
     pub mac: MacAddr,
 }
 
-impl<'a> NetConfig<'a> {
-    pub fn parse(net: &'a str) -> Result<Self> {
+impl NetConfig {
+    pub fn parse(net: &str) -> Result<Self> {
         // Split the parameters based on the comma delimiter
         let params_list: Vec<&str> = net.split(',').collect();
 
@@ -246,13 +246,13 @@ impl<'a> NetConfig<'a> {
             }
         }
 
-        let mut tap: Option<&str> = None;
+        let mut tap: Option<String> = None;
         let mut ip: Ipv4Addr = Ipv4Addr::new(192, 168, 249, 1);
         let mut mask: Ipv4Addr = Ipv4Addr::new(255, 255, 255, 0);;
         let mut mac: MacAddr = MacAddr::local_random();
 
         if !tap_str.is_empty() {
-            tap = Some(tap_str);
+            tap = Some(tap_str.to_string());
         }
         if !ip_str.is_empty() {
             ip = ip_str.parse().map_err(Error::ParseNetIpParam)?;
@@ -614,7 +614,7 @@ pub struct VmConfig<'a> {
     pub kernel: KernelConfig,
     pub cmdline: CmdlineConfig,
     pub disks: Option<Vec<DiskConfig>>,
-    pub net: Option<Vec<NetConfig<'a>>>,
+    pub net: Option<Vec<NetConfig>>,
     pub rng: RngConfig<'a>,
     pub fs: Option<Vec<FsConfig<'a>>>,
     pub pmem: Option<Vec<PmemConfig<'a>>>,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -172,14 +172,14 @@ impl MemoryConfig {
     }
 }
 
-pub struct KernelConfig<'a> {
-    pub path: &'a Path,
+pub struct KernelConfig {
+    pub path: PathBuf,
 }
 
-impl<'a> KernelConfig<'a> {
-    pub fn parse(kernel: &'a str) -> Result<Self> {
+impl KernelConfig {
+    pub fn parse(kernel: &str) -> Result<Self> {
         Ok(KernelConfig {
-            path: Path::new(kernel),
+            path: PathBuf::from(kernel),
         })
     }
 }
@@ -611,7 +611,7 @@ impl<'a> VhostUserBlkConfig<'a> {
 pub struct VmConfig<'a> {
     pub cpus: CpusConfig,
     pub memory: MemoryConfig,
-    pub kernel: KernelConfig<'a>,
+    pub kernel: KernelConfig,
     pub cmdline: CmdlineConfig,
     pub disks: Option<Vec<DiskConfig<'a>>>,
     pub net: Option<Vec<NetConfig<'a>>>,

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -463,13 +463,13 @@ impl DeviceConfig {
     }
 }
 
-pub struct VhostUserNetConfig<'a> {
+pub struct VhostUserNetConfig {
     pub mac: MacAddr,
-    pub vu_cfg: VhostUserConfig<'a>,
+    pub vu_cfg: VhostUserConfig,
 }
 
-impl<'a> VhostUserNetConfig<'a> {
-    pub fn parse(vhost_user_net: &'a str) -> Result<Self> {
+impl VhostUserNetConfig {
+    pub fn parse(vhost_user_net: &str) -> Result<Self> {
         // Split the parameters based on the comma delimiter
         let params_list: Vec<&str> = vhost_user_net.split(',').collect();
 
@@ -512,7 +512,7 @@ impl<'a> VhostUserNetConfig<'a> {
         }
 
         let vu_cfg = VhostUserConfig {
-            sock,
+            sock: sock.to_string(),
             num_queues,
             queue_size,
         };
@@ -553,13 +553,13 @@ impl<'a> VsockConfig<'a> {
     }
 }
 
-pub struct VhostUserBlkConfig<'a> {
+pub struct VhostUserBlkConfig {
     pub wce: bool,
-    pub vu_cfg: VhostUserConfig<'a>,
+    pub vu_cfg: VhostUserConfig,
 }
 
-impl<'a> VhostUserBlkConfig<'a> {
-    pub fn parse(vhost_user_blk: &'a str) -> Result<Self> {
+impl VhostUserBlkConfig {
+    pub fn parse(vhost_user_blk: &str) -> Result<Self> {
         // Split the parameters based on the comma delimiter
         let params_list: Vec<&str> = vhost_user_blk.split(',').collect();
 
@@ -599,7 +599,7 @@ impl<'a> VhostUserBlkConfig<'a> {
         }
 
         let vu_cfg = VhostUserConfig {
-            sock,
+            sock: sock.to_string(),
             num_queues,
             queue_size,
         };
@@ -621,8 +621,8 @@ pub struct VmConfig<'a> {
     pub serial: ConsoleConfig,
     pub console: ConsoleConfig,
     pub devices: Option<Vec<DeviceConfig>>,
-    pub vhost_user_net: Option<Vec<VhostUserNetConfig<'a>>>,
-    pub vhost_user_blk: Option<Vec<VhostUserBlkConfig<'a>>>,
+    pub vhost_user_net: Option<Vec<VhostUserNetConfig>>,
+    pub vhost_user_blk: Option<Vec<VhostUserBlkConfig>>,
     pub vsock: Option<Vec<VsockConfig<'a>>>,
 }
 

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -417,13 +417,13 @@ impl ConsoleOutputMode {
     }
 }
 
-pub struct ConsoleConfig<'a> {
-    pub file: Option<&'a Path>,
+pub struct ConsoleConfig {
+    pub file: Option<PathBuf>,
     pub mode: ConsoleOutputMode,
 }
 
-impl<'a> ConsoleConfig<'a> {
-    pub fn parse(param: &'a str) -> Result<Self> {
+impl ConsoleConfig {
+    pub fn parse(param: &str) -> Result<Self> {
         if param == "off" {
             Ok(Self {
                 mode: ConsoleOutputMode::Off,
@@ -437,7 +437,7 @@ impl<'a> ConsoleConfig<'a> {
         } else if param.starts_with("file=") {
             Ok(Self {
                 mode: ConsoleOutputMode::File,
-                file: Some(Path::new(&param[5..])),
+                file: Some(PathBuf::from(&param[5..])),
             })
         } else if param.starts_with("null") {
             Ok(Self {
@@ -618,8 +618,8 @@ pub struct VmConfig<'a> {
     pub rng: RngConfig,
     pub fs: Option<Vec<FsConfig>>,
     pub pmem: Option<Vec<PmemConfig>>,
-    pub serial: ConsoleConfig<'a>,
-    pub console: ConsoleConfig<'a>,
+    pub serial: ConsoleConfig,
+    pub console: ConsoleConfig,
     pub devices: Option<Vec<DeviceConfig<'a>>>,
     pub vhost_user_net: Option<Vec<VhostUserNetConfig<'a>>>,
     pub vhost_user_blk: Option<Vec<VhostUserBlkConfig<'a>>>,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -676,7 +676,7 @@ impl DeviceManager {
 
                     let virtio_fs_device = vm_virtio::vhost_user::Fs::new(
                         fs_sock,
-                        fs_cfg.tag,
+                        &fs_cfg.tag,
                         fs_cfg.num_queues,
                         fs_cfg.queue_size,
                         cache,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -719,7 +719,7 @@ impl DeviceManager {
                     .read(true)
                     .write(true)
                     .custom_flags(custom_flags)
-                    .open(pmem_cfg.file)
+                    .open(&pmem_cfg.file)
                     .map_err(DeviceManagerError::PmemFileOpen)?;
 
                 if set_len {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -857,7 +857,7 @@ impl DeviceManager {
 
             for device_cfg in device_list_cfg.iter() {
                 let vfio_device =
-                    VfioDevice::new(device_cfg.path, device_fd.clone(), vm_info.memory.clone())
+                    VfioDevice::new(&device_cfg.path, device_fd.clone(), vm_info.memory.clone())
                         .map_err(DeviceManagerError::VfioCreate)?;
 
                 let mut vfio_pci_device = VfioPciDevice::new(vm_info.vm_fd, allocator, vfio_device)

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -576,7 +576,7 @@ impl DeviceManager {
         // Add virtio-net if required
         if let Some(net_list_cfg) = &vm_info.vm_cfg.net {
             for net_cfg in net_list_cfg.iter() {
-                let virtio_net_device = if let Some(tap_if_name) = net_cfg.tap {
+                let virtio_net_device = if let Some(ref tap_if_name) = net_cfg.tap {
                     let tap = Tap::open_named(tap_if_name).map_err(DeviceManagerError::OpenTap)?;
                     vm_virtio::Net::new_with_tap(tap, Some(&net_cfg.mac))
                         .map_err(DeviceManagerError::CreateVirtioNet)?

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -540,7 +540,7 @@ impl DeviceManager {
                 let raw_img: File = OpenOptions::new()
                     .read(true)
                     .write(true)
-                    .open(disk_cfg.path)
+                    .open(&disk_cfg.path)
                     .map_err(DeviceManagerError::Disk)?;
 
                 let image_type = qcow::detect_image_type(&raw_img)
@@ -548,17 +548,15 @@ impl DeviceManager {
                 let block = match image_type {
                     ImageType::Raw => {
                         let raw_img = vm_virtio::RawFile::new(raw_img);
-                        let dev =
-                            vm_virtio::Block::new(raw_img, disk_cfg.path.to_path_buf(), false)
-                                .map_err(DeviceManagerError::CreateVirtioBlock)?;
+                        let dev = vm_virtio::Block::new(raw_img, disk_cfg.path.clone(), false)
+                            .map_err(DeviceManagerError::CreateVirtioBlock)?;
                         Box::new(dev) as Box<dyn vm_virtio::VirtioDevice>
                     }
                     ImageType::Qcow2 => {
                         let qcow_img = QcowFile::from(raw_img)
                             .map_err(DeviceManagerError::QcowDeviceCreate)?;
-                        let dev =
-                            vm_virtio::Block::new(qcow_img, disk_cfg.path.to_path_buf(), false)
-                                .map_err(DeviceManagerError::CreateVirtioBlock)?;
+                        let dev = vm_virtio::Block::new(qcow_img, disk_cfg.path.clone(), false)
+                            .map_err(DeviceManagerError::CreateVirtioBlock)?;
                         Box::new(dev) as Box<dyn vm_virtio::VirtioDevice>
                     }
                 };

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -325,7 +325,7 @@ impl DeviceManager {
 
         let serial_writer: Option<Box<dyn io::Write + Send>> = match vm_info.vm_cfg.serial.mode {
             ConsoleOutputMode::File => Some(Box::new(
-                File::create(vm_info.vm_cfg.serial.file.unwrap())
+                File::create(vm_info.vm_cfg.serial.file.as_ref().unwrap())
                     .map_err(DeviceManagerError::SerialOutputFileOpen)?,
             )),
             ConsoleOutputMode::Tty => Some(Box::new(stdout())),
@@ -386,7 +386,7 @@ impl DeviceManager {
 
         let console_writer: Option<Box<dyn io::Write + Send>> = match vm_info.vm_cfg.console.mode {
             ConsoleOutputMode::File => Some(Box::new(
-                File::create(vm_info.vm_cfg.console.file.unwrap())
+                File::create(vm_info.vm_cfg.console.file.as_ref().unwrap())
                     .map_err(DeviceManagerError::ConsoleOutputFileOpen)?,
             )),
             ConsoleOutputMode::Tty => Some(Box::new(stdout())),

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -773,7 +773,7 @@ impl DeviceManager {
             for vhost_user_net_cfg in vhost_user_net_list_cfg.iter() {
                 let vhost_user_net_device = vm_virtio::vhost_user::Net::new(
                     vhost_user_net_cfg.mac,
-                    vhost_user_net_cfg.vu_cfg,
+                    vhost_user_net_cfg.vu_cfg.clone(),
                 )
                 .map_err(DeviceManagerError::CreateVhostUserNet)?;
 
@@ -793,7 +793,7 @@ impl DeviceManager {
             for vhost_user_blk_cfg in vhost_user_blk_list_cfg.iter() {
                 let vhost_user_blk_device = vm_virtio::vhost_user::Blk::new(
                     vhost_user_blk_cfg.wce,
-                    vhost_user_blk_cfg.vu_cfg,
+                    vhost_user_blk_cfg.vu_cfg.clone(),
                 )
                 .map_err(DeviceManagerError::CreateVhostUserBlk)?;
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -564,7 +564,7 @@ impl<'a> Vm<'a> {
         }
 
         let guest_memory = match config.memory.file {
-            Some(file) => {
+            Some(ref file) => {
                 let mut mem_regions = Vec::<(GuestAddress, usize, Option<FileOffset>)>::new();
                 for region in ram_regions.iter() {
                     if file.is_file() {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -426,7 +426,7 @@ impl Vcpu {
 pub struct VmInfo<'a> {
     pub memory: &'a Arc<RwLock<GuestMemoryMmap>>,
     pub vm_fd: &'a Arc<VmFd>,
-    pub vm_cfg: &'a VmConfig<'a>,
+    pub vm_cfg: &'a VmConfig,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -507,7 +507,7 @@ pub struct Vm<'a> {
     threads: Vec<thread::JoinHandle<()>>,
     devices: DeviceManager,
     cpuid: CpuId,
-    config: &'a VmConfig<'a>,
+    config: &'a VmConfig,
     epoll: EpollContext,
     on_tty: bool,
     creation_ts: std::time::Instant,
@@ -533,7 +533,7 @@ fn get_host_cpu_phys_bits() -> u8 {
 }
 
 impl<'a> Vm<'a> {
-    pub fn new(kvm: &Kvm, config: &'a VmConfig<'a>) -> Result<Self> {
+    pub fn new(kvm: &Kvm, config: &'a VmConfig) -> Result<Self> {
         let kernel = File::open(&config.kernel.path).map_err(Error::KernelFile)?;
         let fd = kvm.create_vm().map_err(Error::VmCreate)?;
         let fd = Arc::new(fd);


### PR DESCRIPTION
This is needed for the API server implementation #244 since the `VmConfig` structure is going to be moved between threads.

Fixes #298