### PR TITLE
Simplify the VM starting flow

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -285,7 +285,7 @@ fn main() {
         vm_config.disks,
     );
 
-    if let Err(e) = vmm::boot_kernel(vm_config) {
+    if let Err(e) = vmm::start_vm_loop(vm_config) {
         println!("Guest boot failed: {}", e);
         process::exit(1);
     }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -26,9 +26,6 @@ pub enum Error {
 
     /// Cannot start a VM.
     VmStart(vm::Error),
-
-    /// Cannot load a kernel.
-    LoadKernel(vm::Error),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -39,7 +36,6 @@ impl Display for Error {
         match self {
             VmNew(e) => write!(f, "Can not create a new virtual machine: {:?}", e),
             VmStart(e) => write!(f, "Can not start a new virtual machine: {:?}", e),
-            LoadKernel(e) => write!(f, "Can not load a guest kernel: {:?}", e),
         }
     }
 }
@@ -60,9 +56,7 @@ pub fn boot_kernel(config: VmConfig) -> Result<()> {
         let vmm = Vmm::new()?;
         let mut vm = Vm::new(&vmm.kvm, &config).map_err(Error::VmNew)?;
 
-        let entry = vm.load_kernel().map_err(Error::LoadKernel)?;
-
-        if vm.start(entry).map_err(Error::VmStart)? == ExitBehaviour::Shutdown {
+        if vm.start().map_err(Error::VmStart)? == ExitBehaviour::Shutdown {
             break;
         }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-extern crate kvm_ioctls;
 #[macro_use]
 extern crate log;
 
-use kvm_ioctls::*;
 use std::fmt::{self, Display};
 use std::result;
 
@@ -40,21 +38,9 @@ impl Display for Error {
     }
 }
 
-struct Vmm {
-    kvm: Kvm,
-}
-
-impl Vmm {
-    fn new() -> Result<Self> {
-        let kvm = Kvm::new().expect("new KVM instance creation failed");
-        Ok(Vmm { kvm })
-    }
-}
-
-pub fn boot_kernel(config: VmConfig) -> Result<()> {
+pub fn start_vm_loop(config: VmConfig) -> Result<()> {
     loop {
-        let vmm = Vmm::new()?;
-        let mut vm = Vm::new(&vmm.kvm, &config).map_err(Error::VmNew)?;
+        let mut vm = Vm::new(&config).map_err(Error::VmNew)?;
 
         if vm.start().map_err(Error::VmStart)? == ExitBehaviour::Shutdown {
             break;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -211,6 +211,9 @@ pub enum Error {
 
     /// Failed to join on vCPU threads
     ThreadCleanup,
+
+    /// Failed to create a new KVM instance
+    KvmNew(io::Error),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -533,7 +536,8 @@ fn get_host_cpu_phys_bits() -> u8 {
 }
 
 impl<'a> Vm<'a> {
-    pub fn new(kvm: &Kvm, config: &'a VmConfig) -> Result<Self> {
+    pub fn new(config: &'a VmConfig) -> Result<Self> {
+        let kvm = Kvm::new().map_err(Error::KvmNew)?;
         let kernel = File::open(&config.kernel.path).map_err(Error::KernelFile)?;
         let fd = kvm.create_vm().map_err(Error::VmCreate)?;
         let fd = Arc::new(fd);

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -766,7 +766,7 @@ impl<'a> Vm<'a> {
         })
     }
 
-    pub fn load_kernel(&mut self) -> Result<GuestAddress> {
+    fn load_kernel(&mut self) -> Result<GuestAddress> {
         let mut cmdline = self.config.cmdline.args.clone();
         for entry in self.devices.cmdline_additions() {
             cmdline.insert_str(entry).map_err(|_| Error::CmdLine)?;
@@ -956,10 +956,9 @@ impl<'a> Vm<'a> {
         }
     }
 
-    pub fn start(&mut self, entry_addr: GuestAddress) -> Result<ExitBehaviour> {
+    pub fn start(&mut self) -> Result<ExitBehaviour> {
+        let entry_addr = self.load_kernel()?;
         let vcpu_count = u8::from(&self.config.cpus);
-
-        //        let vcpus: Vec<thread::JoinHandle<()>> = Vec::with_capacity(vcpu_count as usize);
         let vcpu_thread_barrier = Arc::new(Barrier::new((vcpu_count + 1) as usize));
 
         for cpu_id in 0..vcpu_count {


### PR DESCRIPTION
And get rid of the VMM structure.
We're currently in a weird place where we have a VMM dedicated structure, but it's only a placeholder. We can simply get rid of it and remove one abstraction layer.