### PR TITLE
Add a VMM control loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,10 +173,12 @@ dependencies = [
  "credibility 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ssh2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm 0.1.0",
+ "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2018"
 [dependencies]
 clap = "2.33.0"
 lazy_static = "1.4.0"
+libc = "0.2.62"
 log = { version = "0.4.8", features = ["std"] }
 vmm = { path = "vmm" }
+vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
 
 [dev-dependencies]
 ssh2 = "0.4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ extern crate clap;
 use clap::{App, Arg};
 use log::LevelFilter;
 use std::process;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use vmm::config;
 
 struct Logger {
@@ -285,7 +285,7 @@ fn main() {
         vm_config.disks,
     );
 
-    if let Err(e) = vmm::start_vm_loop(vm_config) {
+    if let Err(e) = vmm::start_vm_loop(Arc::new(vm_config)) {
         println!("Guest boot failed: {}", e);
         process::exit(1);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,7 +286,7 @@ fn main() {
     );
 
     if let Err(e) = vmm::start_vm_loop(Arc::new(vm_config)) {
-        println!("Guest boot failed: {}", e);
+        println!("Guest boot failed: {:?}", e);
         process::exit(1);
     }
 }

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -1,0 +1,66 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! The internal VMM API for Cloud Hypervisor.
+//!
+//! This API is a synchronous, [mpsc](https://doc.rust-lang.org/std/sync/mpsc/)
+//! based IPC for sending commands to the VMM thread, from other
+//! Cloud Hypervisor threads. The IPC follows a command-response protocol, i.e.
+//! each command will receive a response back.
+//!
+//! The main Cloud Hypervisor thread creates an API event file descriptor
+//! to notify the VMM thread about pending API commands, together with an
+//! API mpsc channel. The former is the IPC control plane, the latter is the
+//! IPC data plane.
+//! In order to use the IPC, a Cloud Hypervisor thread needs to have a clone
+//! of both the API event file descriptor and the channel Sender. Then it must
+//! go through the following steps:
+//!
+//! 1. The thread creates an mpsc channel for receiving the command response.
+//! 2. The thread sends an ApiRequest to the Sender endpoint. The ApiRequest
+//!    contains the response channel Sender, for the VMM API server to be able
+//!    to send the response back.
+//! 3. The thread writes to the API event file descriptor to notify the VMM
+//!    API server about a pending command.
+//! 4. The thread reads the response back from the VMM API server, from the
+//!    response channel Receiver.
+//! 5. The thread handles the response and forwards potential errors.
+
+use crate::config::VmConfig;
+use crate::vm::Error;
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
+
+/// API errors are sent back from the VMM API server through the ApiResponse.
+#[derive(Debug)]
+pub enum ApiError {
+    /// The VM could not be created.
+    VmCreate(Error),
+
+    /// The VM could not start.
+    VmStart(Error),
+}
+
+pub enum ApiResponsePayload {
+    /// No data is sent on the channel.
+    Empty,
+}
+
+/// This is the response sent by the VMM API server through the mpsc channel.
+pub type ApiResponse = std::result::Result<ApiResponsePayload, ApiError>;
+
+#[allow(clippy::large_enum_variant)]
+pub enum ApiRequest {
+    /// Create the virtual machine. This request payload is a VM configuration
+    /// (VmConfig).
+    /// If the VMM API server could not create the VM, it will send a VmCreate
+    /// error back.
+    VmCreate(Arc<VmConfig>, Sender<ApiResponse>),
+
+    /// Start the previously created virtual machine.
+    /// If the VM was not previously created, the VMM API server will send a
+    /// VmStart error back.
+    VmStart(Sender<ApiResponse>),
+}

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -25,6 +25,9 @@ pub enum Error {
 
     /// Cannot start a VM.
     VmStart(vm::Error),
+
+    /// Cannot stop a VM.
+    VmStop(vm::Error),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -35,6 +38,7 @@ impl Display for Error {
         match self {
             VmNew(e) => write!(f, "Can not create a new virtual machine: {:?}", e),
             VmStart(e) => write!(f, "Can not start a new virtual machine: {:?}", e),
+            VmStop(e) => write!(f, "Can not stop a virtual machine: {:?}", e),
         }
     }
 }
@@ -44,8 +48,11 @@ pub fn start_vm_loop(config: Arc<VmConfig>) -> Result<()> {
         let mut vm = Vm::new(config.clone()).map_err(Error::VmNew)?;
 
         if vm.start().map_err(Error::VmStart)? == ExitBehaviour::Shutdown {
+            vm.stop().map_err(Error::VmStop)?;
             break;
         }
+
+        vm.stop().map_err(Error::VmStop)?;
 
         #[cfg(not(feature = "acpi"))]
         break;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -14,6 +14,7 @@ use std::result;
 use std::sync::Arc;
 use vmm_sys_util::eventfd::EventFd;
 
+pub mod api;
 pub mod config;
 pub mod device_manager;
 pub mod vm;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -8,6 +8,7 @@ extern crate log;
 
 use std::fmt::{self, Display};
 use std::result;
+use std::sync::Arc;
 
 pub mod config;
 pub mod device_manager;
@@ -38,9 +39,9 @@ impl Display for Error {
     }
 }
 
-pub fn start_vm_loop(config: VmConfig) -> Result<()> {
+pub fn start_vm_loop(config: Arc<VmConfig>) -> Result<()> {
     loop {
-        let mut vm = Vm::new(&config).map_err(Error::VmNew)?;
+        let mut vm = Vm::new(config.clone()).map_err(Error::VmNew)?;
 
         if vm.start().map_err(Error::VmStart)? == ExitBehaviour::Shutdown {
             break;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -5,10 +5,14 @@
 
 #[macro_use]
 extern crate log;
+extern crate vmm_sys_util;
 
+use libc::EFD_NONBLOCK;
 use std::fmt::{self, Display};
+use std::io;
 use std::result;
 use std::sync::Arc;
+use vmm_sys_util::eventfd::EventFd;
 
 pub mod config;
 pub mod device_manager;
@@ -20,6 +24,9 @@ use self::vm::{ExitBehaviour, Vm};
 /// Errors associated with VM management
 #[derive(Debug)]
 pub enum Error {
+    /// Cannot create EventFd.
+    EventFd(io::Error),
+
     /// Cannot create a new VM.
     VmNew(vm::Error),
 
@@ -36,6 +43,7 @@ impl Display for Error {
         use self::Error::*;
 
         match self {
+            EventFd(e) => write!(f, "Can not create EventFd: {:?}", e),
             VmNew(e) => write!(f, "Can not create a new virtual machine: {:?}", e),
             VmStart(e) => write!(f, "Can not start a new virtual machine: {:?}", e),
             VmStop(e) => write!(f, "Can not stop a virtual machine: {:?}", e),
@@ -44,8 +52,16 @@ impl Display for Error {
 }
 
 pub fn start_vm_loop(config: Arc<VmConfig>) -> Result<()> {
+    let exit_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?;
+    let reset_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?;
+
     loop {
-        let mut vm = Vm::new(config.clone()).map_err(Error::VmNew)?;
+        let mut vm = Vm::new(
+            config.clone(),
+            exit_evt.try_clone().unwrap(),
+            reset_evt.try_clone().unwrap(),
+        )
+        .map_err(Error::VmNew)?;
 
         if vm.start().map_err(Error::VmStart)? == ExitBehaviour::Shutdown {
             vm.stop().map_err(Error::VmStop)?;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -7,12 +7,14 @@
 extern crate log;
 extern crate vmm_sys_util;
 
+use crate::api::{ApiError, ApiRequest, ApiResponse, ApiResponsePayload};
+use crate::vm::{Error as VmError, ExitBehaviour, Vm};
 use libc::EFD_NONBLOCK;
-use std::fmt::{self, Display};
 use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::result;
+use std::sync::mpsc::{channel, Receiver, RecvError, SendError, Sender};
 use std::sync::Arc;
+use std::{result, thread};
 use vmm_sys_util::eventfd::EventFd;
 
 pub mod api;
@@ -21,37 +23,58 @@ pub mod device_manager;
 pub mod vm;
 
 use self::config::VmConfig;
-use self::vm::{ExitBehaviour, Vm};
+//use self::vm::{ExitBehaviour, Vm};
 
-/// Errors associated with VM management
+/// Errors associated with VMM management
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Error {
+    /// API request receive error
+    ApiRequestRecv(RecvError),
+
+    /// API response receive error
+    ApiResponseRecv(RecvError),
+
+    /// API request send error
+    ApiRequestSend(SendError<ApiRequest>),
+
+    /// API response send error
+    ApiResponseSend(SendError<ApiResponse>),
+
+    /// Cannot create a VM from the API
+    ApiVmCreate(ApiError),
+
+    /// Cannot start a VM from the API
+    ApiVmStart(ApiError),
+
+    /// Cannot clone EventFd.
+    EventFdClone(io::Error),
+
     /// Cannot create EventFd.
-    EventFd(io::Error),
+    EventFdCreate(io::Error),
 
-    /// Cannot create a new VM.
-    VmNew(vm::Error),
+    /// Cannot read from EventFd.
+    EventFdRead(io::Error),
 
-    /// Cannot start a VM.
-    VmStart(vm::Error),
+    /// Cannot write to EventFd.
+    EventFdWrite(io::Error),
 
-    /// Cannot stop a VM.
-    VmStop(vm::Error),
+    /// Cannot create epoll context.
+    Epoll(io::Error),
+
+    /// Cannot handle the VM STDIN stream
+    Stdin(VmError),
+
+    /// Cannot create a VM
+    VmCreate(VmError),
+
+    /// Cannot start a VM
+    VmStart(VmError),
+
+    /// Cannot stop a VM
+    VmStop(VmError),
 }
 pub type Result<T> = result::Result<T, Error>;
-
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-
-        match self {
-            EventFd(e) => write!(f, "Can not create EventFd: {:?}", e),
-            VmNew(e) => write!(f, "Can not create a new virtual machine: {:?}", e),
-            VmStart(e) => write!(f, "Can not start a new virtual machine: {:?}", e),
-            VmStop(e) => write!(f, "Can not stop a virtual machine: {:?}", e),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum EpollDispatch {
@@ -121,9 +144,142 @@ impl AsRawFd for EpollContext {
     }
 }
 
+pub struct Vmm {
+    epoll: EpollContext,
+    exit_evt: EventFd,
+    reset_evt: EventFd,
+    api_evt: EventFd,
+    vm: Option<Vm>,
+}
+
+impl Vmm {
+    fn new(api_evt: EventFd) -> Result<Self> {
+        let mut epoll = EpollContext::new().map_err(Error::Epoll)?;
+        let exit_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?;
+        let reset_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?;
+
+        if unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0 {
+            epoll.add_stdin().map_err(Error::Epoll)?;
+        }
+
+        epoll
+            .add_event(&exit_evt, EpollDispatch::Exit)
+            .map_err(Error::Epoll)?;
+
+        epoll
+            .add_event(&reset_evt, EpollDispatch::Reset)
+            .map_err(Error::Epoll)?;
+
+        epoll
+            .add_event(&api_evt, EpollDispatch::Api)
+            .map_err(Error::Epoll)?;
+
+        Ok(Vmm {
+            epoll,
+            exit_evt,
+            reset_evt,
+            api_evt,
+            vm: None,
+        })
+    }
+
+    fn control_loop(&mut self, api_receiver: Arc<Receiver<ApiRequest>>) -> Result<ExitBehaviour> {
+        const EPOLL_EVENTS_LEN: usize = 100;
+
+        let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
+        let epoll_fd = self.epoll.as_raw_fd();
+
+        let exit_behaviour;
+
+        'outer: loop {
+            let num_events = match epoll::wait(epoll_fd, -1, &mut events[..]) {
+                Ok(res) => res,
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::Interrupted {
+                        // It's well defined from the epoll_wait() syscall
+                        // documentation that the epoll loop can be interrupted
+                        // before any of the requested events occurred or the
+                        // timeout expired. In both those cases, epoll_wait()
+                        // returns an error of type EINTR, but this should not
+                        // be considered as a regular error. Instead it is more
+                        // appropriate to retry, by calling into epoll_wait().
+                        continue;
+                    }
+                    return Err(Error::Epoll(e));
+                }
+            };
+
+            for event in events.iter().take(num_events) {
+                let dispatch_idx = event.data as usize;
+
+                if let Some(dispatch_type) = self.epoll.dispatch_table[dispatch_idx] {
+                    match dispatch_type {
+                        EpollDispatch::Exit => {
+                            // Consume the event.
+                            self.exit_evt.read().map_err(Error::EventFdRead)?;
+                            exit_behaviour = ExitBehaviour::Shutdown;
+
+                            break 'outer;
+                        }
+                        EpollDispatch::Reset => {
+                            // Consume the event.
+                            self.reset_evt.read().map_err(Error::EventFdRead)?;
+                            exit_behaviour = ExitBehaviour::Reset;
+
+                            break 'outer;
+                        }
+                        EpollDispatch::Stdin => {
+                            if let Some(ref vm) = self.vm {
+                                vm.handle_stdin().map_err(Error::Stdin)?;
+                            }
+                        }
+                        EpollDispatch::Api => {
+                            // Consume the event.
+                            self.api_evt.read().map_err(Error::EventFdRead)?;
+
+                            // Read from the API receiver channel
+                            let api_request = api_receiver.recv().map_err(Error::ApiRequestRecv)?;
+
+                            match api_request {
+                                ApiRequest::VmCreate(config, sender) => {
+                                    let exit_evt =
+                                        self.exit_evt.try_clone().map_err(Error::EventFdClone)?;
+                                    let reset_evt =
+                                        self.reset_evt.try_clone().map_err(Error::EventFdClone)?;
+                                    let response = match Vm::new(config, exit_evt, reset_evt) {
+                                        Ok(vm) => {
+                                            self.vm = Some(vm);
+                                            Ok(ApiResponsePayload::Empty)
+                                        }
+                                        Err(e) => Err(ApiError::VmCreate(e)),
+                                    };
+
+                                    sender.send(response).map_err(Error::ApiResponseSend)?;
+                                }
+                                ApiRequest::VmStart(sender) => {
+                                    if let Some(ref mut vm) = self.vm {
+                                        let response = match vm.start() {
+                                            Ok(_) => Ok(ApiResponsePayload::Empty),
+                                            Err(e) => Err(ApiError::VmStart(e)),
+                                        };
+
+                                        sender.send(response).map_err(Error::ApiResponseSend)?;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(exit_behaviour)
+    }
+}
+
 pub fn start_vm_loop(config: Arc<VmConfig>) -> Result<()> {
-    let exit_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?;
-    let reset_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?;
+    let exit_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?;
+    let reset_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?;
 
     loop {
         let mut vm = Vm::new(
@@ -131,14 +287,14 @@ pub fn start_vm_loop(config: Arc<VmConfig>) -> Result<()> {
             exit_evt.try_clone().unwrap(),
             reset_evt.try_clone().unwrap(),
         )
-        .map_err(Error::VmNew)?;
+        .expect("Could not create VM");
 
-        if vm.start().map_err(Error::VmStart)? == ExitBehaviour::Shutdown {
-            vm.stop().map_err(Error::VmStop)?;
+        if vm.start().expect("Could not start VM") == ExitBehaviour::Shutdown {
+            vm.stop().expect("Could not stop VM");
             break;
         }
 
-        vm.stop().map_err(Error::VmStop)?;
+        vm.stop().expect("Could not stop VM");
 
         #[cfg(not(feature = "acpi"))]
         break;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -10,6 +10,7 @@ extern crate vmm_sys_util;
 use libc::EFD_NONBLOCK;
 use std::fmt::{self, Display};
 use std::io;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::result;
 use std::sync::Arc;
 use vmm_sys_util::eventfd::EventFd;
@@ -49,6 +50,74 @@ impl Display for Error {
             VmStart(e) => write!(f, "Can not start a new virtual machine: {:?}", e),
             VmStop(e) => write!(f, "Can not stop a virtual machine: {:?}", e),
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum EpollDispatch {
+    Exit,
+    Reset,
+    Stdin,
+    Api,
+}
+
+pub struct EpollContext {
+    raw_fd: RawFd,
+    dispatch_table: Vec<Option<EpollDispatch>>,
+}
+
+impl EpollContext {
+    pub fn new() -> result::Result<EpollContext, io::Error> {
+        let raw_fd = epoll::create(true)?;
+
+        // Initial capacity needs to be large enough to hold:
+        // * 1 exit event
+        // * 1 reset event
+        // * 1 stdin event
+        // * 1 API event
+        let mut dispatch_table = Vec::with_capacity(5);
+        dispatch_table.push(None);
+
+        Ok(EpollContext {
+            raw_fd,
+            dispatch_table,
+        })
+    }
+
+    pub fn add_stdin(&mut self) -> result::Result<(), io::Error> {
+        let dispatch_index = self.dispatch_table.len() as u64;
+        epoll::ctl(
+            self.raw_fd,
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            libc::STDIN_FILENO,
+            epoll::Event::new(epoll::Events::EPOLLIN, dispatch_index),
+        )?;
+
+        self.dispatch_table.push(Some(EpollDispatch::Stdin));
+
+        Ok(())
+    }
+
+    fn add_event<T>(&mut self, fd: &T, token: EpollDispatch) -> result::Result<(), io::Error>
+    where
+        T: AsRawFd,
+    {
+        let dispatch_index = self.dispatch_table.len() as u64;
+        epoll::ctl(
+            self.raw_fd,
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            fd.as_raw_fd(),
+            epoll::Event::new(epoll::Events::EPOLLIN, dispatch_index),
+        )?;
+        self.dispatch_table.push(Some(token));
+
+        Ok(())
+    }
+}
+
+impl AsRawFd for EpollContext {
+    fn as_raw_fd(&self) -> RawFd {
+        self.raw_fd
     }
 }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -383,29 +383,3 @@ impl Vmm {
         Ok(exit_behaviour)
     }
 }
-
-pub fn start_vm_loop(config: Arc<VmConfig>) -> Result<()> {
-    let exit_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?;
-    let reset_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?;
-
-    loop {
-        let mut vm = Vm::new(
-            config.clone(),
-            exit_evt.try_clone().unwrap(),
-            reset_evt.try_clone().unwrap(),
-        )
-        .expect("Could not create VM");
-
-        if vm.start().expect("Could not start VM") == ExitBehaviour::Shutdown {
-            vm.stop().expect("Could not stop VM");
-            break;
-        }
-
-        vm.stop().expect("Could not stop VM");
-
-        #[cfg(not(feature = "acpi"))]
-        break;
-    }
-
-    Ok(())
-}

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -851,13 +851,6 @@ impl Vm {
         let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
         let epoll_fd = self.epoll.as_raw_fd();
 
-        if self.devices.console().input_enabled() && self.on_tty {
-            io::stdin()
-                .lock()
-                .set_raw_mode()
-                .map_err(Error::SetTerminalRaw)?;
-        }
-
         let exit_behaviour;
 
         'outer: loop {
@@ -1044,7 +1037,15 @@ impl Vm {
                 }
                 Err(e) => error!("Signal not found {}", e),
             }
+
+            if self.on_tty {
+                io::stdin()
+                    .lock()
+                    .set_raw_mode()
+                    .map_err(Error::SetTerminalRaw)?;
+            }
         }
+
         self.control_loop()
     }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1061,6 +1061,11 @@ impl Vm {
 
         Ok(())
     }
+
+    /// Gets a thread-safe reference counted pointer to the VM configuration.
+    pub fn get_config(&self) -> Arc<VmConfig> {
+        Arc::clone(&self.config)
+    }
 }
 
 #[allow(unused)]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -503,14 +503,14 @@ pub enum ExitBehaviour {
     Reset = 2,
 }
 
-pub struct Vm<'a> {
+pub struct Vm {
     fd: Arc<VmFd>,
     kernel: File,
     memory: Arc<RwLock<GuestMemoryMmap>>,
     threads: Vec<thread::JoinHandle<()>>,
     devices: DeviceManager,
     cpuid: CpuId,
-    config: &'a VmConfig,
+    config: Arc<VmConfig>,
     epoll: EpollContext,
     on_tty: bool,
     creation_ts: std::time::Instant,
@@ -535,8 +535,8 @@ fn get_host_cpu_phys_bits() -> u8 {
     }
 }
 
-impl<'a> Vm<'a> {
-    pub fn new(config: &'a VmConfig) -> Result<Self> {
+impl Vm {
+    pub fn new(config: Arc<VmConfig>) -> Result<Self> {
         let kvm = Kvm::new().map_err(Error::KvmNew)?;
         let kernel = File::open(&config.kernel.path).map_err(Error::KernelFile)?;
         let fd = kvm.create_vm().map_err(Error::VmCreate)?;
@@ -717,7 +717,7 @@ impl<'a> Vm<'a> {
         let vm_info = VmInfo {
             memory: &guest_memory,
             vm_fd: &fd,
-            vm_cfg: config,
+            vm_cfg: &config,
         };
 
         let exit_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -909,6 +909,10 @@ impl Vm {
             }
         }
 
+        Ok(exit_behaviour)
+    }
+
+    pub fn stop(&mut self) -> Result<()> {
         if self.on_tty {
             // Don't forget to set the terminal in canonical mode
             // before to exit.
@@ -941,7 +945,7 @@ impl Vm {
             thread.join().map_err(|_| Error::ThreadCleanup)?
         }
 
-        Ok(exit_behaviour)
+        Ok(())
     }
 
     fn os_signal_handler(signals: Signals, console_input_clone: Arc<Console>) {


### PR DESCRIPTION
And decouple the main VMM control logic from the VM itself. This is needed for properly supporting the HTTP external API.

Fixes #303 