### PR TITLE
README: Update Slack invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ etc, are all equal and welcome means of contribution. See the [CONTRIBUTING](CON
 
 ## Join us
 
-Get an [invite to our Slack channel](https://join.slack.com/t/cloud-hypervisor/shared_invite/enQtNjY3MTE3MDkwNDQ4LTc0YzlmYzQxZDkxNDVhYzZjZjA5MTkxMGY3NTI3YzMzYTFkM2IyY2E0YTIxMzkyYTEwYzdlMzBhMWYxYzVmNDI)
+Get an [invite to our Slack channel](https://join.slack.com/t/cloud-hypervisor/shared_invite/enQtNjY3MTE3MDkwNDQ4LWQ1MTA1ZDVmODkwMWQ1MTRhYzk4ZGNlN2UwNTI3ZmFlODU0OTcwOWZjMTkwZDExYWE3YjFmNzgzY2FmNDAyMjI)
 and [join us on Slack](https://cloud-hypervisor.slack.com/).
 
 # 6. Security


### PR DESCRIPTION
The current one is no longer valid.
The new one does not expire.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>