### PR TITLE
arch, vmm: Start documenting major regions of RAM and reserved memory

### DIFF
--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -21,7 +21,6 @@ extern crate linux_loader;
 extern crate vm_memory;
 
 use std::result;
-use vm_memory::GuestAddress;
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -53,9 +52,6 @@ pub enum RegionType {
     Reserved,
 }
 
-// 1MB.  We don't put anything above here except the kernel itself.
-pub const HIMEM_START: GuestAddress = GuestAddress(0x100000);
-
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64;
 
@@ -70,6 +66,5 @@ pub mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
-    arch_memory_regions, configure_system, get_32bit_gap_start as get_reserved_mem_addr,
-    layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START,
+    arch_memory_regions, configure_system, layout, layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START,
 };

--- a/arch/src/x86_64/acpi.rs
+++ b/arch/src/x86_64/acpi.rs
@@ -10,6 +10,8 @@ use vm_memory::{GuestAddress, GuestMemoryMmap};
 
 use vm_memory::{Address, ByteValued, Bytes};
 
+use super::layout;
+
 #[repr(packed)]
 struct LocalAPIC {
     pub r#type: u8,
@@ -209,7 +211,7 @@ pub fn create_acpi_tables(
     end_of_device_area: GuestAddress,
 ) -> GuestAddress {
     // RSDP is at the EBDA
-    let rsdp_offset = super::EBDA_START;
+    let rsdp_offset = layout::RSDP_POINTER;
     let mut tables: Vec<u64> = Vec::new();
 
     // DSDT
@@ -296,7 +298,7 @@ pub fn create_acpi_tables(
 
     // 32-bit PCI enhanced configuration mechanism
     mcfg.append(PCIRangeEntry {
-        base_address: super::MEM_32BIT_DEVICES_GAP_SIZE,
+        base_address: layout::MEM_32BIT_DEVICES_START.0,
         segment: 0,
         start: 0,
         end: 0xff,

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -5,9 +5,25 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
-use vm_memory::GuestAddress;
+use vm_memory::{GuestAddress, GuestUsize};
 
-/// Magic addresses externally used to lay out x86_64 VMs.
+/*
+
+Memory layout documentation and constants
+~~~~~~ ~~~~~~ ~~~~~~~~~~~~~ ~~~ ~~~~~~~~~
+
+Constants are in order and grouped by range. Take care to update all references
+when making changes and keep them in order.
+
+*/
+
+// ** Low RAM (start: 0, length: 640KiB) **
+pub const LOW_RAM_START: GuestAddress = GuestAddress(0x0);
+
+// == Fixed addresses within the "Low RAM" range: ==
+
+/// The 'zero page', a.k.a linux kernel bootparams.
+pub const ZERO_PAGE_START: GuestAddress = GuestAddress(0x7000);
 
 /// Initial stack for the boot CPU.
 pub const BOOT_STACK_START: GuestAddress = GuestAddress(0x8000);
@@ -18,8 +34,37 @@ pub const CMDLINE_START: GuestAddress = GuestAddress(0x20000);
 /// Kernel command line start address maximum size.
 pub const CMDLINE_MAX_SIZE: usize = 0x10000;
 
-/// Address for the TSS setup.
-pub const KVM_TSS_ADDRESS: GuestAddress = GuestAddress(0xfffbd000);
+// == End of "Low RAM" range. ==
 
-/// The 'zero page', a.k.a linux kernel bootparams.
-pub const ZERO_PAGE_START: GuestAddress = GuestAddress(0x7000);
+// ** EBDA reserved area (start: 640KiB, length: 384KiB) **
+pub const EBDA_START: GuestAddress = GuestAddress(0xa0000);
+
+// == Fixed constants within the "EBDA" range ==
+
+// ACPI RSDP table
+pub const RSDP_POINTER: GuestAddress = EBDA_START;
+
+// == End of "EBDA" range ==
+
+// ** High RAM (start: 1MiB, length: 3071MiB) **
+pub const HIGH_RAM_START: GuestAddress = GuestAddress(0x100000);
+
+// == No fixed addresses in the "High RAM" range ==
+
+// ** 32-bit reserved area (start: 3GiB, length: 1GiB) **
+pub const MEM_32BIT_RESERVED_START: GuestAddress = GuestAddress(0xc000_0000);
+pub const MEM_32BIT_RESERVED_SIZE: GuestUsize = (1024 << 20);
+
+// == Fixed constants within the "32-bit reserved" range ==
+
+// Sub range: 32-bit PCI devices (start: 3GiB, length: 768Mib)
+pub const MEM_32BIT_DEVICES_START: GuestAddress = MEM_32BIT_RESERVED_START;
+pub const MEM_32BIT_DEVICES_SIZE: GuestUsize = (768 << 20);
+
+/// Address for the TSS setup.
+pub const KVM_TSS_ADDRESS: GuestAddress = GuestAddress(0xfffb_d000);
+
+// == End of "32-bit reserved" range. ==
+
+// ** 64-bit RAM start (start: 4GiB, length: varies) **
+pub const RAM_64BIT_START: GuestAddress = GuestAddress(0x1_0000_0000);

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -687,7 +687,7 @@ impl Vm {
             mem.deref(),
             None,
             &mut self.kernel,
-            Some(arch::HIMEM_START),
+            Some(arch::layout::HIGH_RAM_START),
         ) {
             Ok(entry_addr) => entry_addr,
             Err(linux_loader::loader::Error::InvalidElfMagicNumber) => {
@@ -695,7 +695,7 @@ impl Vm {
                     mem.deref(),
                     None,
                     &mut self.kernel,
-                    Some(arch::HIMEM_START),
+                    Some(arch::layout::HIGH_RAM_START),
                 )
                 .map_err(Error::KernelLoad)?
             }


### PR DESCRIPTION
Using the existing layout module start documenting the major regions of
RAM and those areas that are reserved. Some of the constants have also
been renamed to be more consistent and some functions that returned
constant variables have been replaced.

Future commits will move more constants into this file to make it the
canonical source of information about the memory layout.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>