### PR TITLE
Enable PCI MMCONFIG

### DIFF
--- a/arch/src/x86_64/acpi.rs
+++ b/arch/src/x86_64/acpi.rs
@@ -163,7 +163,7 @@ pub fn create_dsdt_table(
     pci_dsdt_data[200..208].copy_from_slice(&(start_of_device_area.0).to_le_bytes());
     pci_dsdt_data[208..216].copy_from_slice(&end_of_device_area.0.to_le_bytes());
     pci_dsdt_data[224..232].copy_from_slice(
-        &(end_of_device_area.unchecked_offset_from(start_of_device_area)).to_le_bytes(),
+        &(end_of_device_area.unchecked_offset_from(start_of_device_area) + 1).to_le_bytes(),
     );
 
     /*

--- a/arch/src/x86_64/acpi.rs
+++ b/arch/src/x86_64/acpi.rs
@@ -151,6 +151,14 @@ pub fn create_dsdt_table(
         0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x79, 0x00,
     ];
 
+    // Patch Range Minimum/Range Maximum/Length for the the 64-bit device area
+    pci_dsdt_data[170..174].copy_from_slice(&layout::MEM_32BIT_DEVICES_START.0.to_le_bytes()[0..4]);
+    pci_dsdt_data[174..178].copy_from_slice(
+        &(layout::MEM_32BIT_DEVICES_START.0 + layout::MEM_32BIT_DEVICES_SIZE - 1).to_le_bytes()
+            [0..4],
+    );
+    pci_dsdt_data[182..186].copy_from_slice(&layout::MEM_32BIT_DEVICES_SIZE.to_le_bytes()[0..4]);
+
     // Patch the Range Minimum/Range Maximum/Length for the the 64-bit device area
     pci_dsdt_data[200..208].copy_from_slice(&(start_of_device_area.0).to_le_bytes());
     pci_dsdt_data[208..216].copy_from_slice(&end_of_device_area.0.to_le_bytes());

--- a/arch/src/x86_64/acpi.rs
+++ b/arch/src/x86_64/acpi.rs
@@ -306,7 +306,7 @@ pub fn create_acpi_tables(
 
     // 32-bit PCI enhanced configuration mechanism
     mcfg.append(PCIRangeEntry {
-        base_address: layout::MEM_32BIT_DEVICES_START.0,
+        base_address: layout::PCI_MMCONFIG_START.0,
         segment: 0,
         start: 0,
         end: 0xff,

--- a/arch/src/x86_64/layout.rs
+++ b/arch/src/x86_64/layout.rs
@@ -69,9 +69,14 @@ pub const MEM_32BIT_RESERVED_SIZE: GuestUsize = (1024 << 20);
 
 // == Fixed constants within the "32-bit reserved" range ==
 
-// Sub range: 32-bit PCI devices (start: 3GiB, length: 768Mib)
+// Sub range: 32-bit PCI devices (start: 3GiB, length: 640Mib)
 pub const MEM_32BIT_DEVICES_START: GuestAddress = MEM_32BIT_RESERVED_START;
-pub const MEM_32BIT_DEVICES_SIZE: GuestUsize = (768 << 20);
+pub const MEM_32BIT_DEVICES_SIZE: GuestUsize = (640 << 20);
+
+// PCI MMCONFIG space (start: after the device space, length: 256MiB)
+pub const PCI_MMCONFIG_START: GuestAddress =
+    GuestAddress(MEM_32BIT_DEVICES_START.0 + MEM_32BIT_DEVICES_SIZE);
+pub const PCI_MMCONFIG_SIZE: GuestUsize = (256 << 20);
 
 // IOAPIC
 pub const IOAPIC_START: GuestAddress = GuestAddress(0xfec0_0000);

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -22,6 +22,7 @@ use vm_memory::{
 };
 
 const E820_RAM: u32 = 1;
+const E820_RESERVED: u32 = 2;
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
 // trait (in this case `DataInit`) where:
@@ -161,6 +162,13 @@ pub fn configure_system(
             )?;
         }
     }
+
+    add_e820_entry(
+        &mut params.0,
+        layout::PCI_MMCONFIG_START.0,
+        layout::PCI_MMCONFIG_SIZE,
+        E820_RESERVED,
+    )?;
 
     #[cfg(feature = "acpi")]
     {

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -16,7 +16,7 @@ mod device;
 mod msi;
 mod msix;
 
-pub use self::bus::{PciConfigIo, PciConfigMmio, PciRoot, PciRootError};
+pub use self::bus::{PciBus, PciConfigIo, PciConfigMmio, PciRoot, PciRootError};
 pub use self::configuration::{
     PciBarConfiguration, PciBarPrefetchable, PciBarRegionType, PciCapability, PciCapabilityID,
     PciClassCode, PciConfiguration, PciHeaderType, PciMassStorageSubclass,


### PR DESCRIPTION
Add support for PCI MMCONFIG so that the extended configuration space can be used. The ACPI and E820 tables need to be updated to reference the region of memory. The region also has strict placement requirements (< 4GiB and not in device space).

The PCI data structures also required refactoring to support both port IO and MMIO access.

Fixes: #221 