### PR TITLE
ci: Do not look for vubridge to decide if qemu must be built

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -80,7 +80,7 @@ fi
 VIRTIOFSD="$WORKLOADS_DIR/virtiofsd"
 VUBD="$WORKLOADS_DIR/vubd"
 QEMU_DIR="qemu_build"
-if [ ! -f "$VIRTIOFSD" ] || [ ! -f "$VUBRIDGE" ] || [ ! -f "$VUBD" ]; then
+if [ ! -f "$VIRTIOFSD" ] || [ ! -f "$VUBD" ]; then
     pushd $WORKLOADS_DIR
     git clone --depth 1 "https://github.com/sboeuf/qemu.git" -b "virtio-fs" $QEMU_DIR
     pushd $QEMU_DIR


### PR DESCRIPTION
We no longer build vubridge, so we end up cloning qemu and building
virtiofs and the block backend all the time.

Fixes: #312

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>