### PR TITLE
vmm: Unreference the VM when shutting down

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -252,7 +252,7 @@ impl Vmm {
     }
 
     fn vm_shutdown(&mut self) -> result::Result<(), VmError> {
-        if let Some(ref mut vm) = self.vm {
+        if let Some(ref mut vm) = self.vm.take() {
             vm.shutdown()
         } else {
             Err(VmError::VmNotBooted)
@@ -312,13 +312,10 @@ impl Vmm {
             return Ok(());
         }
 
-        self.vm_config = None;
+        // First we try to shut the current VM down.
+        self.vm_shutdown()?;
 
-        // First we shut the current VM down if necessary.
-        if let Some(ref mut vm) = self.vm {
-            vm.shutdown()?;
-            self.vm = None;
-        }
+        self.vm_config = None;
 
         Ok(())
     }


### PR DESCRIPTION
This way, we are forced to re-create the VM object when moving from
shutdown to boot.

Fixes: #321

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>