### PR TITLE
Cargo: Move to crates.io vmm-sys-util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
  "vmm 0.1.0",
- "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
+ "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -232,7 +232,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
+ "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -412,7 +412,7 @@ source = "git+https://github.com/firecracker-microvm/firecracker#2b94334a6a2a5f7
 name = "net_gen"
 version = "0.1.0"
 dependencies = [
- "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
+ "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -426,7 +426,7 @@ dependencies = [
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
+ "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -466,7 +466,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-allocator 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
+ "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -585,7 +585,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "remain 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
+ "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1001,15 +1001,12 @@ dependencies = [
  "vfio-bindings 0.0.1",
  "vm-allocator 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
+ "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "vfio-bindings"
 version = "0.0.1"
-dependencies = [
- "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
-]
 
 [[package]]
 name = "vhost_rs"
@@ -1019,7 +1016,7 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
+ "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1031,7 +1028,7 @@ dependencies = [
  "vhost_rs 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
- "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
+ "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1074,7 +1071,7 @@ dependencies = [
  "virtio-bindings 0.1.0 (git+https://github.com/rust-vmm/virtio-bindings)",
  "vm-allocator 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
- "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
+ "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1104,13 +1101,13 @@ dependencies = [
  "vm-allocator 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
- "vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)",
+ "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vmm-sys-util#27e7ff14d60de7ab22dbfbd46464798fa0714294"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1269,7 +1266,7 @@ dependencies = [
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum virtio-bindings 0.1.0 (git+https://github.com/rust-vmm/virtio-bindings)" = "<none>"
 "checksum vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)" = "<none>"
-"checksum vmm-sys-util 0.1.0 (git+https://github.com/rust-vmm/vmm-sys-util)" = "<none>"
+"checksum vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "46996f56aeae31fbc0532ae57a944e00089302f03b18c10c76eebfd9249f4a6c"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ vhost_user_backend = { path = "vhost_user_backend"}
 virtio-bindings = { git = "https://github.com/rust-vmm/virtio-bindings", version = "0.1", features = ["virtio-v5_0_0"]}
 vmm = { path = "vmm" }
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
-vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
+vmm-sys-util = "0.1.1"
 vm-virtio = { path = "vm-virtio" }
 
 [dev-dependencies]

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -11,7 +11,7 @@ kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master"
 libc = "0.2.60"
 log = "0.4.8"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
-vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
+vmm-sys-util = "0.1.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/net_gen/Cargo.toml
+++ b/net_gen/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 
 [dependencies]
-vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
+vmm-sys-util = "0.1.1"

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -7,9 +7,9 @@ authors = ["The Chromium OS Authors"]
 libc = "0.2.60"
 rand = "0.7.0"
 serde = "1.0.98"
+vmm-sys-util = "0.1.1"
 
 net_gen = { path = "../net_gen" }
-vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
 
 [dev-dependencies]
 lazy_static = "1.3.0"

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -13,4 +13,4 @@ kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master"
 libc = "0.2.60"
 log = "0.4.8"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
-vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
+vmm-sys-util = "0.1.1"

--- a/qcow/Cargo.toml
+++ b/qcow/Cargo.toml
@@ -13,7 +13,7 @@ byteorder = "1.3.2"
 libc = "0.2.60"
 log = "0.4.8"
 remain = "0.1.3"
-vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
+vmm-sys-util = "0.1.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/vfio-bindings/Cargo.toml
+++ b/vfio-bindings/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.0.1"
 authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 
-[dependencies]
-vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
-
 [features]
 default = ["v5_0_0"]
 v5_0_0 = []

--- a/vfio/Cargo.toml
+++ b/vfio/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4.8"
 pci = { path = "../pci" }
 vfio-bindings = { path = "../vfio-bindings" }
 vm-allocator = { path = "../vm-allocator" }
-vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
+vmm-sys-util = "0.1.1"
 
 [dependencies.vm-memory]
 git = "https://github.com/rust-vmm/vm-memory"

--- a/vhost_rs/Cargo.toml
+++ b/vhost_rs/Cargo.toml
@@ -15,7 +15,7 @@ vhost-user-slave = []
 [dependencies]
 bitflags = "1.1.0"
 libc = "0.2.60"
-vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
+vmm-sys-util = "0.1.1"
 
 [dependencies.vm-memory]
 git = "https://github.com/rust-vmm/vm-memory"

--- a/vhost_user_backend/Cargo.toml
+++ b/vhost_user_backend/Cargo.toml
@@ -14,7 +14,7 @@ epoll = "4.1.0"
 libc = "0.2.60"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" } 
 vm-virtio = { path = "../vm-virtio" }
-vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
+vmm-sys-util = "0.1.1"
 
 [dependencies.vhost_rs]
 path = "../vhost_rs"

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -21,7 +21,7 @@ pci = { path = "../pci", optional = true }
 tempfile = "3.1.0"
 virtio-bindings = { git = "https://github.com/rust-vmm/virtio-bindings", version = "0.1", features = ["virtio-v5_0_0"]}
 vm-allocator = { path = "../vm-allocator" }
-vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
+vmm-sys-util = "0.1.1"
 
 [dependencies.vhost_rs]
 path = "../vhost_rs"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = ">=1.0.9"
 vfio = { path = "../vfio", optional = true }
 vm-virtio = { path = "../vm-virtio" }
 vm-allocator = { path = "../vm-allocator" }
-vmm-sys-util = { git = "https://github.com/rust-vmm/vmm-sys-util" }
+vmm-sys-util = "0.1.1"
 signal-hook = "0.1.10"
 threadpool = "1.0"
 


### PR DESCRIPTION
Use the newly published 0.1.1 version.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>