### PR TITLE
VMM thread simplification

### DIFF
--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -5,7 +5,7 @@
 
 extern crate threadpool;
 
-use crate::api::http_endpoint::{VmActionHandler, VmCreate, VmInfo};
+use crate::api::http_endpoint::{VmActionHandler, VmCreate, VmInfo, VmmShutdown};
 use crate::api::{ApiRequest, VmAction};
 use crate::{Error, Result};
 use micro_http::{HttpConnection, Request, Response, StatusCode, Version};
@@ -60,6 +60,7 @@ lazy_static! {
         r.routes.insert(endpoint!("/vm.info"), Box::new(VmInfo {}));
         r.routes.insert(endpoint!("/vm.shutdown"), Box::new(VmActionHandler::new(VmAction::Shutdown)));
         r.routes.insert(endpoint!("/vm.reboot"), Box::new(VmActionHandler::new(VmAction::Reboot)));
+        r.routes.insert(endpoint!("/vmm.shutdown"), Box::new(VmmShutdown {}));
 
         r
     };

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -23,6 +23,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/VmmInfo'
 
+  /vmm.shutdown:
+    put:
+      summary: Shuts the cloud-hypervisor VMM.
+      operationId: shutdownVMM
+      responses:
+        201:
+          description: The VMM successfully shutdown.
+          content: {}
+
   /vm.info:
     get:
       summary: Returns general information about the cloud-hypervisor Virtual Machine (VM) instance.

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -436,12 +436,6 @@ pub struct VmInfo<'a> {
     pub vm_cfg: &'a VmConfig,
 }
 
-#[derive(PartialEq)]
-pub enum ExitBehaviour {
-    Shutdown = 1,
-    Reset = 2,
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum VmState {
     Created,


### PR DESCRIPTION
We can simplify the VMM thread and its control loop by handling the Exit and Reset events directly from the control loop itself, and avoid passing an exit behaviour up to the VMM thread.

By handling everything from the control loop, we can also easily add a `vmm.shutdown` endpoint to kill the VMM itself from the HTTP API interface.