### PR TITLE
Support VFIO nested with virtio-iommu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,7 @@ dependencies = [
  "vhost_rs 0.1.0",
  "virtio-bindings 0.1.0 (git+https://github.com/rust-vmm/virtio-bindings)",
  "vm-allocator 0.1.0",
+ "vm-device 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "vhost_rs 0.1.0",
  "vhost_user_backend 0.1.0",
  "virtio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-device 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vm-virtio 0.1.0",
  "vmm 0.1.0",
@@ -1021,6 +1022,10 @@ dependencies = [
  "libc 0.2.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
 ]
+
+[[package]]
+name = "vm-device"
+version = "0.1.0"
 
 [[package]]
 name = "vm-memory"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,7 @@ dependencies = [
  "pci 0.1.0",
  "vfio-bindings 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-allocator 0.1.0",
+ "vm-device 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
  "vmm-sys-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ net_util = { path = "net_util" }
 vhost_user_backend = { path = "vhost_user_backend"}
 virtio-bindings = "0.1.0"
 vmm = { path = "vmm" }
+vm-device = { path = "vm-device" }
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
 vmm-sys-util = "0.1.1"
 vm-virtio = { path = "vm-virtio" }

--- a/docs/vfio.md
+++ b/docs/vfio.md
@@ -72,7 +72,7 @@ takes the device's sysfs path as an argument. In our example it is
     --cmdline "console=ttyS0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda3" \
     --cpus 4 \
     --memory size=512M \
-    --device /sys/bus/pci/devices/0000:01:00.0/
+    --device path=/sys/bus/pci/devices/0000:01:00.0/
 ```
 
 The guest kernel will then detect the card reader on its PCI bus and provided

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,10 @@ fn main() {
             Arg::with_name("device")
                 .long("device")
                 .help("Direct device assignment parameter")
+                .help(
+                    "Direct device assignment parameters \
+                     \"path=<device_path>,iommu=on|off\"",
+                )
                 .takes_value(true)
                 .min_values(1)
                 .group("vm-config"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2904,7 +2904,7 @@ mod tests {
                     .ssh_command("ls /sys/kernel/iommu_groups/0/devices")
                     .unwrap()
                     .trim(),
-                "0000:00:03.0"
+                "0000:00:02.0"
             );
 
             // Verify the second disk is located under IOMMU group 1.
@@ -2914,7 +2914,7 @@ mod tests {
                     .ssh_command("ls /sys/kernel/iommu_groups/1/devices")
                     .unwrap()
                     .trim(),
-                "0000:00:04.0"
+                "0000:00:03.0"
             );
 
             // Verify the network card is located under IOMMU group 2.
@@ -2924,7 +2924,7 @@ mod tests {
                     .ssh_command("ls /sys/kernel/iommu_groups/2/devices")
                     .unwrap()
                     .trim(),
-                "0000:00:05.0"
+                "0000:00:04.0"
             );
 
             guest.ssh_command("sudo shutdown -h now")?;

--- a/test_data/cloud-init/clear/openstack/latest/user_data
+++ b/test_data/cloud-init/clear/openstack/latest/user_data
@@ -48,7 +48,7 @@ write_files:
         #!/bin/bash
 
         mount -t virtio_fs virtiofs /mnt -o rootmode=040000,user_id=0,group_id=0,dax
-        bash -c "echo 0000:00:06.0 > /sys/bus/pci/devices/0000\:00\:06.0/driver/unbind"
+        bash -c "echo 0000:00:05.0 > /sys/bus/pci/devices/0000\:00\:05.0/driver/unbind"
         bash -c "echo 1af4 1041 > /sys/bus/pci/drivers/vfio-pci/new_id"
 
-        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda2 VFIOTAG" --disk path=/mnt/clear-cloudguest.img path=/mnt/cloudinit.img --cpus 1 --memory size=512M --rng --device path=/sys/bus/pci/devices/0000:00:06.0/
+        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda2 VFIOTAG" --disk path=/mnt/clear-cloudguest.img path=/mnt/cloudinit.img --cpus 1 --memory size=512M --rng --device path=/sys/bus/pci/devices/0000:00:05.0/

--- a/test_data/cloud-init/clear/openstack/latest/user_data
+++ b/test_data/cloud-init/clear/openstack/latest/user_data
@@ -51,4 +51,4 @@ write_files:
         bash -c "echo 0000:00:06.0 > /sys/bus/pci/devices/0000\:00\:06.0/driver/unbind"
         bash -c "echo 1af4 1041 > /sys/bus/pci/drivers/vfio-pci/new_id"
 
-        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda2 VFIOTAG" --disk path=/mnt/clear-cloudguest.img path=/mnt/cloudinit.img --cpus 1 --memory size=512M --rng --device /sys/bus/pci/devices/0000:00:06.0/
+        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda2 VFIOTAG" --disk path=/mnt/clear-cloudguest.img path=/mnt/cloudinit.img --cpus 1 --memory size=512M --rng --device path=/sys/bus/pci/devices/0000:00:06.0/

--- a/vfio/Cargo.toml
+++ b/vfio/Cargo.toml
@@ -13,6 +13,7 @@ log = "0.4.8"
 pci = { path = "../pci" }
 vfio-bindings = "0.1.0"
 vm-allocator = { path = "../vm-allocator" }
+vm-device = { path = "../vm-device" }
 vmm-sys-util = "0.1.1"
 
 [dependencies.vm-memory]

--- a/vfio/src/lib.rs
+++ b/vfio/src/lib.rs
@@ -14,6 +14,7 @@ extern crate log;
 extern crate pci;
 extern crate vfio_bindings;
 extern crate vm_allocator;
+extern crate vm_device;
 extern crate vm_memory;
 #[macro_use]
 extern crate vmm_sys_util;
@@ -24,7 +25,7 @@ mod vfio_pci;
 
 use std::mem::size_of;
 
-pub use vfio_device::{VfioDevice, VfioError};
+pub use vfio_device::{VfioContainer, VfioDevice, VfioDmaMapping, VfioError};
 pub use vfio_pci::{VfioPciDevice, VfioPciError};
 
 // Returns a `Vec<T>` with a size in bytes at least as large as `size_in_bytes`.

--- a/vfio/src/vfio_device.rs
+++ b/vfio/src/vfio_device.rs
@@ -14,11 +14,13 @@ use std::mem;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::prelude::FileExt;
 use std::path::{Path, PathBuf};
+use std::result;
 use std::sync::{Arc, RwLock};
 use std::u32;
 use vfio_bindings::bindings::vfio::*;
 use vfio_ioctls::*;
-use vm_memory::{Address, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+use vm_device::ExternalDmaMapping;
+use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::ioctl::*;
 
@@ -503,6 +505,68 @@ impl VfioDeviceInfo {
         }
 
         Ok(regions)
+    }
+}
+
+/// This structure implements the ExternalDmaMapping trait. It is meant to
+/// be used when the caller tries to provide a way to update the mappings
+/// associated with a specific VFIO container.
+pub struct VfioDmaMapping {
+    container: Arc<VfioContainer>,
+    memory: Arc<RwLock<GuestMemoryMmap>>,
+}
+
+impl VfioDmaMapping {
+    pub fn new(container: Arc<VfioContainer>, memory: Arc<RwLock<GuestMemoryMmap>>) -> Self {
+        VfioDmaMapping { container, memory }
+    }
+}
+
+impl ExternalDmaMapping for VfioDmaMapping {
+    fn map(&self, iova: u64, gpa: u64, size: u64) -> result::Result<(), io::Error> {
+        let user_addr = if let Some(addr) = self
+            .memory
+            .read()
+            .unwrap()
+            .get_host_address(GuestAddress(gpa))
+        {
+            addr as u64
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "failed to convert guest address 0x{:x} into \
+                     host user virtual address",
+                    gpa
+                ),
+            ));
+        };
+
+        self.container
+            .vfio_dma_map(iova, size, user_addr)
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!(
+                        "failed to map memory for VFIO container, \
+                         iova 0x{:x}, gpa 0x{:x}, size 0x{:x}: {:?}",
+                        iova, gpa, size, e
+                    ),
+                )
+            })
+    }
+
+    fn unmap(&self, iova: u64, size: u64) -> result::Result<(), io::Error> {
+        self.container.vfio_dma_unmap(iova, size).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "failed to unmap memory for VFIO container, \
+                     iova 0x{:x}, size 0x{:x}: {:?}",
+                    iova, size, e
+                ),
+            )
+        })
     }
 }
 

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "vm-device"
+version = "0.1.0"
+authors = ["The Cloud Hypervisor Authors"]
+edition = "2018"
+
+[dependencies]

--- a/vm-device/src/lib.rs
+++ b/vm-device/src/lib.rs
@@ -1,0 +1,11 @@
+/// Trait meant for triggering the DMA mapping update related to an external
+/// device not managed fully through virtio. It is dedicated to virtio-iommu
+/// in order to trigger the map update anytime the mapping is updated from the
+/// guest.
+pub trait ExternalDmaMapping: Send + Sync {
+    /// Map a memory range
+    fn map(&self, iova: u64, gpa: u64, size: u64) -> std::result::Result<(), std::io::Error>;
+
+    /// Unmap a memory range
+    fn unmap(&self, iova: u64, size: u64) -> std::result::Result<(), std::io::Error>;
+}

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -21,6 +21,7 @@ pci = { path = "../pci", optional = true }
 tempfile = "3.1.0"
 virtio-bindings = { git = "https://github.com/rust-vmm/virtio-bindings", version = "0.1", features = ["virtio-v5_0_0"]}
 vm-allocator = { path = "../vm-allocator" }
+vm-device = { path = "../vm-device" }
 vmm-sys-util = "0.1.1"
 
 [dependencies.vhost_rs]

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -29,8 +29,8 @@ serde = {version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 vfio = { path = "../vfio", optional = true }
-vm-virtio = { path = "../vm-virtio" }
 vm-allocator = { path = "../vm-allocator" }
+vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.1.1"
 signal-hook = "0.1.10"
 threadpool = "1.0"

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -353,6 +353,9 @@ components:
       properties:
         path:
           type: string
+        iommu:
+          type: boolean
+          default: false
 
     VhostUserConfig:
       required:

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -999,9 +999,13 @@ impl DeviceManager {
                 // global device ID.
                 let device_id = pci.next_device_id() << 3;
 
-                let vfio_device =
-                    VfioDevice::new(&device_cfg.path, device_fd.clone(), vm_info.memory.clone())
-                        .map_err(DeviceManagerError::VfioCreate)?;
+                let vfio_device = VfioDevice::new(
+                    &device_cfg.path,
+                    device_fd.clone(),
+                    vm_info.memory.clone(),
+                    device_cfg.iommu,
+                )
+                .map_err(DeviceManagerError::VfioCreate)?;
 
                 if device_cfg.iommu {
                     if let Some(iommu) = iommu_device {

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1006,6 +1006,8 @@ impl DeviceManager {
                     VfioDevice::new(&device_cfg.path, device_fd.clone(), vm_info.memory.clone())
                         .map_err(DeviceManagerError::VfioCreate)?;
 
+                let _vfio_container = vfio_device.get_container();
+
                 let mut vfio_pci_device = VfioPciDevice::new(vm_info.vm_fd, allocator, vfio_device)
                     .map_err(DeviceManagerError::VfioPciCreate)?;
 


### PR DESCRIPTION
This PR intends to bring a new feature to cloud-hypervisor. By relying on the recently added virtual IOMMU device, a physical device being passed through a first layer of virtualization can now be passed to a second layer.

The idea is to place the physical device behind the virtual IOMMU as it gets attached to an IOMMU group from the L1 guest. And from this L1 guest, we can simply use VFIO to pass the device through a second layer of virtualization, which end up being managed by an L2 guest.