### PR TITLE
VM pause and resume support

### DIFF
--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -58,6 +58,7 @@ lazy_static! {
         r.routes.insert(endpoint!("/vm.boot"), Box::new(VmActionHandler::new(VmAction::Boot)));
         r.routes.insert(endpoint!("/vm.delete"), Box::new(VmActionHandler::new(VmAction::Delete)));
         r.routes.insert(endpoint!("/vm.info"), Box::new(VmInfo {}));
+        r.routes.insert(endpoint!("/vm.pause"), Box::new(VmActionHandler::new(VmAction::Pause)));
         r.routes.insert(endpoint!("/vm.shutdown"), Box::new(VmActionHandler::new(VmAction::Shutdown)));
         r.routes.insert(endpoint!("/vm.reboot"), Box::new(VmActionHandler::new(VmAction::Reboot)));
         r.routes.insert(endpoint!("/vmm.shutdown"), Box::new(VmmShutdown {}));

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -59,6 +59,7 @@ lazy_static! {
         r.routes.insert(endpoint!("/vm.delete"), Box::new(VmActionHandler::new(VmAction::Delete)));
         r.routes.insert(endpoint!("/vm.info"), Box::new(VmInfo {}));
         r.routes.insert(endpoint!("/vm.pause"), Box::new(VmActionHandler::new(VmAction::Pause)));
+        r.routes.insert(endpoint!("/vm.resume"), Box::new(VmActionHandler::new(VmAction::Resume)));
         r.routes.insert(endpoint!("/vm.shutdown"), Box::new(VmActionHandler::new(VmAction::Shutdown)));
         r.routes.insert(endpoint!("/vm.reboot"), Box::new(VmActionHandler::new(VmAction::Reboot)));
         r.routes.insert(endpoint!("/vmm.shutdown"), Box::new(VmmShutdown {}));

--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -5,8 +5,8 @@
 
 use crate::api::http::EndpointHandler;
 use crate::api::{
-    vm_boot, vm_create, vm_delete, vm_info, vm_reboot, vm_shutdown, vmm_shutdown, ApiError,
-    ApiRequest, ApiResult, VmAction, VmConfig,
+    vm_boot, vm_create, vm_delete, vm_info, vm_pause, vm_reboot, vm_shutdown, vmm_shutdown,
+    ApiError, ApiRequest, ApiResult, VmAction, VmConfig,
 };
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 use serde_json::Error as SerdeError;
@@ -28,6 +28,9 @@ pub enum HttpError {
 
     /// Could not get the VM information
     VmInfo(ApiError),
+
+    /// Could not pause the VM
+    VmPause(ApiError),
 
     /// Could not shut a VM down
     VmShutdown(ApiError),
@@ -103,6 +106,7 @@ impl VmActionHandler {
             VmAction::Delete => vm_delete,
             VmAction::Shutdown => vm_shutdown,
             VmAction::Reboot => vm_reboot,
+            VmAction::Pause => vm_pause,
         });
 
         VmActionHandler { action_fn }
@@ -122,6 +126,7 @@ impl EndpointHandler for VmActionHandler {
                     ApiError::VmBoot(_) => HttpError::VmBoot(e),
                     ApiError::VmShutdown(_) => HttpError::VmShutdown(e),
                     ApiError::VmReboot(_) => HttpError::VmReboot(e),
+                    ApiError::VmPause(_) => HttpError::VmPause(e),
                     _ => HttpError::VmAction(e),
                 }) {
                     Ok(_) => Response::new(Version::Http11, StatusCode::OK),

--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -5,8 +5,8 @@
 
 use crate::api::http::EndpointHandler;
 use crate::api::{
-    vm_boot, vm_create, vm_delete, vm_info, vm_pause, vm_reboot, vm_shutdown, vmm_shutdown,
-    ApiError, ApiRequest, ApiResult, VmAction, VmConfig,
+    vm_boot, vm_create, vm_delete, vm_info, vm_pause, vm_reboot, vm_resume, vm_shutdown,
+    vmm_shutdown, ApiError, ApiRequest, ApiResult, VmAction, VmConfig,
 };
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 use serde_json::Error as SerdeError;
@@ -31,6 +31,9 @@ pub enum HttpError {
 
     /// Could not pause the VM
     VmPause(ApiError),
+
+    /// Could not pause the VM
+    VmResume(ApiError),
 
     /// Could not shut a VM down
     VmShutdown(ApiError),
@@ -107,6 +110,7 @@ impl VmActionHandler {
             VmAction::Shutdown => vm_shutdown,
             VmAction::Reboot => vm_reboot,
             VmAction::Pause => vm_pause,
+            VmAction::Resume => vm_resume,
         });
 
         VmActionHandler { action_fn }
@@ -127,6 +131,7 @@ impl EndpointHandler for VmActionHandler {
                     ApiError::VmShutdown(_) => HttpError::VmShutdown(e),
                     ApiError::VmReboot(_) => HttpError::VmReboot(e),
                     ApiError::VmPause(_) => HttpError::VmPause(e),
+                    ApiError::VmResume(_) => HttpError::VmResume(e),
                     _ => HttpError::VmAction(e),
                 }) {
                     Ok(_) => Response::new(Version::Http11, StatusCode::OK),

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -76,6 +76,9 @@ pub enum ApiError {
     /// The VM config is missing.
     VmMissingConfig,
 
+    /// The VM could not be paused.
+    VmPause(VmError),
+
     /// The VM is not booted.
     VmNotBooted,
 
@@ -132,6 +135,9 @@ pub enum ApiRequest {
     /// Request the VM information.
     VmInfo(Sender<ApiResponse>),
 
+    /// Pause a VM.
+    VmPause(Sender<ApiResponse>),
+
     /// Shut the previously booted virtual machine down.
     /// If the VM was not previously booted or created, the VMM API server
     /// will send a VmShutdown error back.
@@ -181,6 +187,9 @@ pub enum VmAction {
 
     /// Reboot a VM
     Reboot,
+
+    /// Pause a VM
+    Pause,
 }
 
 fn vm_action(api_evt: EventFd, api_sender: Sender<ApiRequest>, action: VmAction) -> ApiResult<()> {
@@ -191,6 +200,7 @@ fn vm_action(api_evt: EventFd, api_sender: Sender<ApiRequest>, action: VmAction)
         VmAction::Delete => ApiRequest::VmDelete(response_sender),
         VmAction::Shutdown => ApiRequest::VmShutdown(response_sender),
         VmAction::Reboot => ApiRequest::VmReboot(response_sender),
+        VmAction::Pause => ApiRequest::VmPause(response_sender),
     };
 
     // Send the VM request.
@@ -216,6 +226,10 @@ pub fn vm_shutdown(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> ApiResul
 
 pub fn vm_reboot(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> ApiResult<()> {
     vm_action(api_evt, api_sender, VmAction::Reboot)
+}
+
+pub fn vm_pause(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> ApiResult<()> {
+    vm_action(api_evt, api_sender, VmAction::Pause)
 }
 
 pub fn vm_info(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> ApiResult<VmInfo> {

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -79,6 +79,9 @@ pub enum ApiError {
     /// The VM could not be paused.
     VmPause(VmError),
 
+    /// The VM could not resume.
+    VmResume(VmError),
+
     /// The VM is not booted.
     VmNotBooted,
 
@@ -138,6 +141,9 @@ pub enum ApiRequest {
     /// Pause a VM.
     VmPause(Sender<ApiResponse>),
 
+    /// Resume a VM.
+    VmResume(Sender<ApiResponse>),
+
     /// Shut the previously booted virtual machine down.
     /// If the VM was not previously booted or created, the VMM API server
     /// will send a VmShutdown error back.
@@ -190,6 +196,9 @@ pub enum VmAction {
 
     /// Pause a VM
     Pause,
+
+    /// Resume a VM
+    Resume,
 }
 
 fn vm_action(api_evt: EventFd, api_sender: Sender<ApiRequest>, action: VmAction) -> ApiResult<()> {
@@ -201,6 +210,7 @@ fn vm_action(api_evt: EventFd, api_sender: Sender<ApiRequest>, action: VmAction)
         VmAction::Shutdown => ApiRequest::VmShutdown(response_sender),
         VmAction::Reboot => ApiRequest::VmReboot(response_sender),
         VmAction::Pause => ApiRequest::VmPause(response_sender),
+        VmAction::Resume => ApiRequest::VmResume(response_sender),
     };
 
     // Send the VM request.
@@ -230,6 +240,10 @@ pub fn vm_reboot(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> ApiResult<
 
 pub fn vm_pause(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> ApiResult<()> {
     vm_action(api_evt, api_sender, VmAction::Pause)
+}
+
+pub fn vm_resume(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> ApiResult<()> {
+    vm_action(api_evt, api_sender, VmAction::Resume)
 }
 
 pub fn vm_info(api_evt: EventFd, api_sender: Sender<ApiRequest>) -> ApiResult<VmInfo> {

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -80,6 +80,21 @@ paths:
           description: The VM instance could not boot because it is not created yet
           content: {}
 
+  /vm.pause:
+    put:
+      summary: Pause a previously booted VM instance.
+      operationId: pauseVM
+      responses:
+        201:
+          description: The VM instance successfully paused.
+          content: {}
+        404:
+          description: The VM instance could not pause because it is not created yet
+          content: {}
+        405:
+          description: The VM instance could not pause because it is not booted.
+          content: {}
+
   /vm.shutdown:
     put:
       summary: Shut the VM instance down.

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -95,6 +95,21 @@ paths:
           description: The VM instance could not pause because it is not booted.
           content: {}
 
+  /vm.resume:
+    put:
+      summary: Resume a previously paused VM instance.
+      operationId: resumeVM
+      responses:
+        201:
+          description: The VM instance successfully paused.
+          content: {}
+        404:
+          description: The VM instance could not resume because it is not booted yet
+          content: {}
+        405:
+          description: The VM instance could not resume because it is not paused.
+          content: {}
+
   /vm.shutdown:
     put:
       summary: Shut the VM instance down.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -235,6 +235,14 @@ impl Vmm {
         }
     }
 
+    fn vm_resume(&mut self) -> result::Result<(), VmError> {
+        if let Some(ref mut vm) = self.vm {
+            vm.resume()
+        } else {
+            Err(VmError::VmNotBooted)
+        }
+    }
+
     fn vm_shutdown(&mut self) -> result::Result<(), VmError> {
         if let Some(ref mut vm) = self.vm.take() {
             vm.shutdown()
@@ -426,6 +434,14 @@ impl Vmm {
                                     let response = self
                                         .vm_pause()
                                         .map_err(ApiError::VmPause)
+                                        .map(|_| ApiResponsePayload::Empty);
+
+                                    sender.send(response).map_err(Error::ApiResponseSend)?;
+                                }
+                                ApiRequest::VmResume(sender) => {
+                                    let response = self
+                                        .vm_resume()
+                                        .map_err(ApiError::VmResume)
                                         .map(|_| ApiResponsePayload::Empty);
 
                                     sender.send(response).map_err(Error::ApiResponseSend)?;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -227,6 +227,14 @@ impl Vmm {
         }
     }
 
+    fn vm_pause(&mut self) -> result::Result<(), VmError> {
+        if let Some(ref mut vm) = self.vm {
+            vm.pause()
+        } else {
+            Err(VmError::VmNotBooted)
+        }
+    }
+
     fn vm_shutdown(&mut self) -> result::Result<(), VmError> {
         if let Some(ref mut vm) = self.vm.take() {
             vm.shutdown()
@@ -411,6 +419,14 @@ impl Vmm {
                                         .vm_info()
                                         .map_err(ApiError::VmInfo)
                                         .map(ApiResponsePayload::VmInfo);
+
+                                    sender.send(response).map_err(Error::ApiResponseSend)?;
+                                }
+                                ApiRequest::VmPause(sender) => {
+                                    let response = self
+                                        .vm_pause()
+                                        .map_err(ApiError::VmPause)
+                                        .map(|_| ApiResponsePayload::Empty);
 
                                     sender.send(response).map_err(Error::ApiResponseSend)?;
                                 }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -231,7 +231,7 @@ impl Vmm {
         if let Some(ref mut vm) = self.vm {
             vm.pause()
         } else {
-            Err(VmError::VmNotBooted)
+            Err(VmError::VmNotRunning)
         }
     }
 
@@ -239,7 +239,7 @@ impl Vmm {
         if let Some(ref mut vm) = self.vm {
             vm.resume()
         } else {
-            Err(VmError::VmNotBooted)
+            Err(VmError::VmNotRunning)
         }
     }
 
@@ -247,7 +247,7 @@ impl Vmm {
         if let Some(ref mut vm) = self.vm.take() {
             vm.shutdown()
         } else {
-            Err(VmError::VmNotBooted)
+            Err(VmError::VmNotRunning)
         }
     }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -213,8 +213,8 @@ pub enum Error {
     /// VM is not created
     VmNotCreated,
 
-    /// VM is not bootted
-    VmNotBooted,
+    /// VM is not running
+    VmNotRunning,
 
     /// Cannot clone EventFd.
     EventFdClone(io::Error),
@@ -439,7 +439,7 @@ pub struct VmInfo<'a> {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum VmState {
     Created,
-    Booted,
+    Running,
     Shutdown,
     Paused,
 }
@@ -843,9 +843,9 @@ impl Vm {
             vcpu_thread.thread().unpark();
         }
 
-        // And we're back to Booted state.
+        // And we're back to the Running state.
         let mut state = self.state.try_write().map_err(|_| Error::PoisonedState)?;
-        *state = VmState::Booted;
+        *state = VmState::Running;
 
         Ok(())
     }
@@ -965,7 +965,7 @@ impl Vm {
         }
 
         let mut state = self.state.try_write().map_err(|_| Error::PoisonedState)?;
-        *state = VmState::Booted;
+        *state = VmState::Running;
 
         Ok(())
     }


### PR DESCRIPTION
We implement a simple VM pause and resume support by parking vCPU threads when receiving a pause request from the HTTP API, and unparking them when receiving a resume request.

The PR also includes an integration test for the pause/resume cycle.