### PR TITLE
ci: Make sure VFIO test don't conflict with Azure private IP

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -134,10 +134,10 @@ if [ ! -d "$VFIO_DIR" ]; then
 fi
 
 # VFIO test network setup.
-# We reserve a different IP class for it: 172.16.0.0/24.
+# We reserve a different IP class for it: 172.17.0.0/24.
 sudo ip link add name vfio-br0 type bridge
 sudo ip link set vfio-br0 up
-sudo ip addr add 172.16.0.1/24 dev vfio-br0
+sudo ip addr add 172.17.0.1/24 dev vfio-br0
 
 sudo ip tuntap add vfio-tap0 mode tap
 sudo ip link set vfio-tap0 master vfio-br0

--- a/src/main.rs
+++ b/src/main.rs
@@ -2306,7 +2306,7 @@ mod tests {
     fn test_vfio() {
         test_block!(tb, "", {
             let mut clear = ClearDiskConfig::new();
-            let guest = Guest::new_from_ip_range(&mut clear, "172.16", 0);
+            let guest = Guest::new_from_ip_range(&mut clear, "172.17", 0);
 
             let mut workload_path = dirs::home_dir().unwrap();
             workload_path.push("workloads");


### PR DESCRIPTION
Azure virtual machines can have private IPs in the 172.16.x.x range,
causing some issues with the VFIO test. By using 172.17.x.x for this
test, we avoid IP conflicts.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>