### PR TITLE
ci: Allow enough time for L2 VM to boot

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2374,10 +2374,10 @@ mod tests {
                 .spawn()
                 .unwrap();
 
-            thread::sleep(std::time::Duration::new(20, 0));
+            thread::sleep(std::time::Duration::new(30, 0));
 
             guest.ssh_command_l1("sudo systemctl start vfio")?;
-            thread::sleep(std::time::Duration::new(30, 0));
+            thread::sleep(std::time::Duration::new(60, 0));
 
             // We booted our cloud hypervisor L2 guest with a "VFIOTAG" tag
             // added to its kernel command line.

--- a/test_data/cloud-init/clear/openstack/latest/user_data
+++ b/test_data/cloud-init/clear/openstack/latest/user_data
@@ -51,4 +51,4 @@ write_files:
         bash -c "echo 0000:00:06.0 > /sys/bus/pci/devices/0000\:00\:06.0/driver/unbind"
         bash -c "echo 1af4 1041 > /sys/bus/pci/drivers/vfio-pci/new_id"
 
-        /mnt/cloud-hypervisor --console off --serial tty --kernel /mnt/vmlinux --cmdline "console=ttyS0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda2 VFIOTAG" --disk path=/mnt/clear-cloudguest.img path=/mnt/cloudinit.img --cpus 1 --memory size=512M --rng --device /sys/bus/pci/devices/0000:00:06.0/
+        /mnt/cloud-hypervisor --kernel /mnt/vmlinux --cmdline "console=hvc0 reboot=k panic=1 nomodules i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd root=/dev/vda2 VFIOTAG" --disk path=/mnt/clear-cloudguest.img path=/mnt/cloudinit.img --cpus 1 --memory size=512M --rng --device /sys/bus/pci/devices/0000:00:06.0/


### PR DESCRIPTION
Because the L2 VM running in the VFIO integration test is actually
running as L3 (since the CI runs in a VM), it can take quite some
time for this VM to boot.

The way to solve this issue is to extend the sleep time before to try
communicating with the L2 VM, but also to speed up the boot time by
using virtio-console instead of serial. We suspect the use of serial,
implying PIO VM exits for each character on the serial port is quite
expensive compared to the paravirtualized console.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>