### PR TITLE
api: http: Fix openpi schema.

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -159,7 +159,7 @@ components:
       type: object
       properties:
         version:
-          type: '#/components/schemas/VmConfig'
+          type: string
         state:
           type: string
           enum: [Created, Booted, Shutdown]
@@ -341,7 +341,7 @@ components:
           type: string
         mode:
           type: string
-          enum: [Off, Tty, File, Null]
+          enum: [Off, Tty, File, None]
         iommu:
           type: boolean
           default: false


### PR DESCRIPTION
Fix invalid type for version:

- VmInfo.version.type string

Change Null value from enum as it has problems to build clients with
openapi tools.

- ConsoleConfig.mode.enum Null -> Nil

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>