### PR TITLE
api: http: make consistent api and implementation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -346,7 +346,7 @@ fn main() {
         "Cloud Hypervisor Guest\n\tAPI server: {}\n\tvCPUs: {}\n\tMemory: {} MB\
          \n\tKernel: {:?}\n\tKernel cmdline: {}\n\tDisk(s): {:?}",
         api_socket_path,
-        u8::from(&vm_config.cpus),
+        vm_config.cpus.cpu_count,
         vm_config.memory.size >> 20,
         vm_config.kernel,
         vm_config.cmdline.args.as_str(),
@@ -901,7 +901,7 @@ mod tests {
         }
 
         fn api_create_body(&self, cpu_count: u8) -> String {
-            format! {"{{\"cpus\":{},\"kernel\":{{\"path\":\"{}\"}},\"cmdline\":{{\"args\": \"\"}},\"net\":[{{\"ip\":\"{}\", \"mask\":\"255.255.255.0\", \"mac\":\"{}\"}}], \"disks\":[{{\"path\":\"{}\"}}, {{\"path\":\"{}\"}}]}}",
+            format! {"{{\"cpus\":{{\"cpu_count\":{}}},\"kernel\":{{\"path\":\"{}\"}},\"cmdline\":{{\"args\": \"\"}},\"net\":[{{\"ip\":\"{}\", \"mask\":\"255.255.255.0\", \"mac\":\"{}\"}}], \"disks\":[{{\"path\":\"{}\"}}, {{\"path\":\"{}\"}}]}}",
                      cpu_count,
                      self.fw_path.as_str(),
                      self.network.host_ip,

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -214,7 +214,9 @@ components:
           items:
             $ref: '#/components/schemas/VhostUserBlkConfig'
         vsock:
-          $ref: '#/components/schemas/VsockConfig'
+          type: array
+          items:
+            $ref: '#/components/schemas/VsockConfig'
         iommu:
           type: boolean
           default: false

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -131,25 +131,23 @@ fn parse_iommu(iommu: &str) -> Result<bool> {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct CpusConfig(pub u8);
+pub struct CpusConfig {
+    pub cpu_count: u8,
+}
 
 impl CpusConfig {
     pub fn parse(cpus: &str) -> Result<Self> {
-        Ok(CpusConfig(
-            cpus.parse::<u8>().map_err(Error::ParseCpusParams)?,
-        ))
-    }
-}
-
-impl From<&CpusConfig> for u8 {
-    fn from(val: &CpusConfig) -> Self {
-        val.0
+        Ok(CpusConfig {
+            cpu_count: cpus.parse().map_err(Error::ParseCpusParams)?,
+        })
     }
 }
 
 impl Default for CpusConfig {
     fn default() -> Self {
-        CpusConfig(DEFAULT_VCPUS)
+        CpusConfig {
+            cpu_count: DEFAULT_VCPUS,
+        }
     }
 }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -711,7 +711,7 @@ impl Vm {
         .map_err(Error::DeviceManager)?;
 
         let on_tty = unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0;
-        let threads = Vec::with_capacity(u8::from(&config.cpus) as usize + 1);
+        let threads = Vec::with_capacity(config.cpus.cpu_count as usize + 1);
 
         Ok(Vm {
             fd,
@@ -767,7 +767,7 @@ impl Vm {
             &cmdline_cstring,
         )
         .map_err(|_| Error::CmdLine)?;
-        let vcpu_count = u8::from(&self.config.cpus);
+        let vcpu_count = self.config.cpus.cpu_count;
         let end_of_range = GuestAddress((1 << get_host_cpu_phys_bits()) - 1);
         match entry_addr.setup_header {
             Some(hdr) => {
@@ -918,7 +918,7 @@ impl Vm {
         current_state.valid_transition(new_state)?;
 
         let entry_addr = self.load_kernel()?;
-        let vcpu_count = u8::from(&self.config.cpus);
+        let vcpu_count = self.config.cpus.cpu_count;
         let vcpu_thread_barrier = Arc::new(Barrier::new((vcpu_count + 1) as usize));
 
         for cpu_id in 0..vcpu_count {


### PR DESCRIPTION
cpu: cpu is an number under the implementation not struct, unless we
need to add more values to the cpu it make sense keep it as integer.

vsocks: vsocks is implemented as an array

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>