### PR TITLE
ci: Add cargo audit to the travis pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rust:
 before_script:
   - rustup component add clippy
   - rustup component add rustfmt
+  - cargo install --force cargo-audit
 
 script:
   - cargo rustc --bin cloud-hypervisor -- -D warnings
@@ -19,6 +20,7 @@ script:
   - cargo test
   - cargo clippy --all-targets --all-features -- -D warnings
   - find . -name "*.rs" | xargs rustfmt --check
+  - cargo audit
 
 deploy:
   provider: releases


### PR DESCRIPTION
cargo audit audits Cargo.lock for crates with security vulnerabvilities
reported by the RustSec Advisory Database.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>