### PR TITLE
Create the DSDT programatically

### DIFF
--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -62,6 +62,50 @@ impl From<&str> for Path {
     }
 }
 
+pub type AmlByte = u8;
+
+impl Aml for AmlByte {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.push(0x0a); /* BytePrefix */
+        bytes.push(*self);
+        bytes
+    }
+}
+
+pub type AmlWord = u16;
+
+impl Aml for AmlWord {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.push(0x0bu8); /* WordPrefix */
+        bytes.append(&mut self.to_le_bytes().to_vec());
+        bytes
+    }
+}
+
+pub type AmlDWord = u32;
+
+impl Aml for AmlDWord {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.push(0x0c); /* DWordPrefix */
+        bytes.append(&mut self.to_le_bytes().to_vec());
+        bytes
+    }
+}
+
+pub type AmlQWord = u64;
+
+impl Aml for AmlQWord {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.push(0x0e); /* QWordPrefix */
+        bytes.append(&mut self.to_le_bytes().to_vec());
+        bytes
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -83,6 +127,17 @@ mod tests {
         assert_eq!(
             (&"_SB_.PCI0._HID".into() as &Path).to_bytes(),
             [0x2F, 0x03, 0x5F, 0x53, 0x42, 0x5F, 0x50, 0x43, 0x49, 0x30, 0x5F, 0x48, 0x49, 0x44]
+        );
+    }
+
+    #[test]
+    fn test_numbers() {
+        assert_eq!(128u8.to_bytes(), [0x0a, 0x80]);
+        assert_eq!(1024u16.to_bytes(), [0x0b, 0x0, 0x04]);
+        assert_eq!((16u32 << 20).to_bytes(), [0x0c, 0x00, 0x00, 0x0, 0x01]);
+        assert_eq!(
+            0xdeca_fbad_deca_fbadu64.to_bytes(),
+            [0x0e, 0xad, 0xfb, 0xca, 0xde, 0xad, 0xfb, 0xca, 0xde]
         );
     }
 }

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -7,6 +7,33 @@ pub trait Aml {
     fn to_bytes(&self) -> Vec<u8>;
 }
 
+pub const ZERO: Zero = Zero {};
+pub struct Zero {}
+
+impl Aml for Zero {
+    fn to_bytes(&self) -> Vec<u8> {
+        vec![0u8]
+    }
+}
+
+pub const ONE: One = One {};
+pub struct One {}
+
+impl Aml for One {
+    fn to_bytes(&self) -> Vec<u8> {
+        vec![1u8]
+    }
+}
+
+pub const ONES: Ones = Ones {};
+pub struct Ones {}
+
+impl Aml for Ones {
+    fn to_bytes(&self) -> Vec<u8> {
+        vec![0xffu8]
+    }
+}
+
 pub struct Path {
     root: bool,
     name_parts: Vec<[u8; 4]>,

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -1,0 +1,88 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+pub trait Aml {
+    fn to_bytes(&self) -> Vec<u8>;
+}
+
+pub struct Path {
+    root: bool,
+    name_parts: Vec<[u8; 4]>,
+}
+
+impl Aml for Path {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        if self.root {
+            bytes.push(b'\\');
+        }
+
+        match self.name_parts.len() {
+            0 => panic!("Name cannot be empty"),
+            1 => {}
+            2 => {
+                bytes.push(0x2e); /* DualNamePrefix */
+            }
+            n => {
+                bytes.push(0x2f); /* MultiNamePrefix */
+                bytes.push(n as u8);
+            }
+        };
+
+        for part in self.name_parts.clone().iter_mut() {
+            bytes.append(&mut part.to_vec());
+        }
+
+        bytes
+    }
+}
+
+impl Path {
+    pub fn new(name: &str) -> Self {
+        let root = name.starts_with('\\');
+        let offset = root as usize;
+        let mut name_parts = Vec::new();
+        for part in name[offset..].split('.') {
+            assert_eq!(part.len(), 4);
+            let mut name_part = [0u8; 4];
+            name_part.copy_from_slice(part.as_bytes());
+            name_parts.push(name_part);
+        }
+
+        Path { root, name_parts }
+    }
+}
+
+impl From<&str> for Path {
+    fn from(s: &str) -> Self {
+        Path::new(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_name_path() {
+        assert_eq!(
+            (&"_SB_".into() as &Path).to_bytes(),
+            [0x5Fu8, 0x53, 0x42, 0x5F]
+        );
+        assert_eq!(
+            (&"\\_SB_".into() as &Path).to_bytes(),
+            [0x5C, 0x5F, 0x53, 0x42, 0x5F]
+        );
+        assert_eq!(
+            (&"_SB_.COM1".into() as &Path).to_bytes(),
+            [0x2E, 0x5F, 0x53, 0x42, 0x5F, 0x43, 0x4F, 0x4D, 0x31]
+        );
+        assert_eq!(
+            (&"_SB_.PCI0._HID".into() as &Path).to_bytes(),
+            [0x2F, 0x03, 0x5F, 0x53, 0x42, 0x5F, 0x50, 0x43, 0x49, 0x30, 0x5F, 0x48, 0x49, 0x44]
+        );
+    }
+}

--- a/acpi_tables/src/lib.rs
+++ b/acpi_tables/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+pub mod aml;
 pub mod rsdp;
 pub mod sdt;
 

--- a/acpi_tables/src/sdt.rs
+++ b/acpi_tables/src/sdt.rs
@@ -77,6 +77,14 @@ impl SDT {
         self.write(orig_length, value);
     }
 
+    pub fn append_slice(&mut self, data: &[u8]) {
+        let orig_length = self.data.len();
+        let new_length = orig_length + data.len();
+        self.write_u32(4, new_length as u32);
+        self.data.extend_from_slice(data);
+        self.update_checksum();
+    }
+
     /// Write a value at the given offset
     pub fn write<T>(&mut self, offset: usize, value: T) {
         assert!((offset + (std::mem::size_of::<T>() - 1)) < self.data.len());

--- a/arch/src/x86_64/acpi.rs
+++ b/arch/src/x86_64/acpi.rs
@@ -146,7 +146,7 @@ pub fn create_dsdt_table(
             ),
         ],
     )
-    .to_bytes();
+    .to_aml_bytes();
 
     let mbrd_dsdt_data = aml::Device::new(
         "_SB_.MBRD".into(),
@@ -163,7 +163,7 @@ pub fn create_dsdt_table(
             ),
         ],
     )
-    .to_bytes();
+    .to_aml_bytes();
 
     let com1_dsdt_data = aml::Device::new(
         "_SB_.COM1".into(),
@@ -179,9 +179,10 @@ pub fn create_dsdt_table(
             ),
         ],
     )
-    .to_bytes();
+    .to_aml_bytes();
 
-    let s5_sleep_data = aml::Name::new("_S5_".into(), &aml::Package::new(vec![&5u8])).to_bytes();
+    let s5_sleep_data =
+        aml::Name::new("_S5_".into(), &aml::Package::new(vec![&5u8])).to_aml_bytes();
 
     // DSDT
     let mut dsdt = SDT::new(*b"DSDT", 36, 6, *b"CLOUDH", *b"CHDSDT  ", 1);

--- a/arch/src/x86_64/acpi.rs
+++ b/arch/src/x86_64/acpi.rs
@@ -130,12 +130,6 @@ pub fn create_dsdt_table(
                     &aml::AddressSpace::new_io(0x0u16, 0xcf7u16),
                     &aml::AddressSpace::new_io(0xd00u16, 0xffffu16),
                     &aml::AddressSpace::new_memory(
-                        aml::AddressSpaceCachable::Cacheable,
-                        true,
-                        0xa_0000u32,
-                        0xb_ffffu32,
-                    ),
-                    &aml::AddressSpace::new_memory(
                         aml::AddressSpaceCachable::NotCacheable,
                         true,
                         layout::MEM_32BIT_DEVICES_START.0 as u32,

--- a/arch/src/x86_64/acpi.rs
+++ b/arch/src/x86_64/acpi.rs
@@ -137,7 +137,7 @@ pub fn create_dsdt_table(
                             as u32,
                     ),
                     &aml::AddressSpace::new_memory(
-                        aml::AddressSpaceCachable::Cacheable,
+                        aml::AddressSpaceCachable::NotCacheable,
                         true,
                         start_of_device_area.0,
                         end_of_device_area.0,


### PR DESCRIPTION
Rather than using precompiled DSDT chunks that are then patched to customise them for the running environment instead generate AML directly.

Fixes: #352 