### PR TITLE
[RFC] migration: state migration infrastructure based on Api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ vm-device = { path = "vm-device" }
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }
 vmm-sys-util = "0.1.1"
 vm-virtio = { path = "vm-virtio" }
+vm-migration = { path = "vm-migration" }
 
 [dev-dependencies]
 ssh2 = "0.5.0"

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "vm-migration"
+version = "0.1.0"
+authors = ["Yi Sun <yi.y.sun@linux.intel.com>"]
+edition = "2018"
+
+[dependencies]
+lazy_static = "1.3.0"
+serde = {version = ">=1.0.27", features = ["rc"] }
+serde_derive = ">=1.0.27"
+serde_json = ">=1.0.9"

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -1,0 +1,8 @@
+#[macro_use]
+extern crate lazy_static;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+
+pub mod state;

--- a/vm-migration/src/state.rs
+++ b/vm-migration/src/state.rs
@@ -1,0 +1,96 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::sync::{Arc, Mutex, RwLock};
+use std::collections::HashMap;
+use std::sync::mpsc::{channel, Sender, SendError, RecvError};
+
+/// MigrationState errors are sent back from the receiver through the ApiResponse.
+#[derive(Debug)]
+pub enum MigrationStateError {
+    /// MigrationRequest send error
+    RequestSend(SendError<MigrationRequest>),
+
+    /// Reponse receive error
+    ResponseRecv(RecvError),
+
+    /// Cannot handle migration state load request.
+    MigrationStateLoad,
+}
+pub type MigrationStateResult<T> = std::result::Result<T, MigrationStateError>;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MigrationStateData {
+    pub state: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub enum MigrationResponsePayload {
+    /// No data is sent on the channel.
+    Empty,
+
+    /// Migration state content
+    MigrationState(MigrationStateData),
+}
+
+/// This is the response sent by the VMM API server through the mpsc channel.
+pub type MigrationStateResponse = std::result::Result<MigrationResponsePayload, MigrationStateError>;
+
+#[allow(clippy::large_enum_variant)]
+pub enum MigrationRequest {
+    /// Request to get migratble states. The response payload is a json which
+    /// contains serialized states.
+    /// If the receiver could not correctly handle this request, it will send a
+    /// MigrationStateGet error back.
+    MigrationStateGet(Sender<MigrationStateResponse>),
+
+    /// Request to load migratble states. The request payload is a json which
+    /// contains serialized states.
+    /// If the receiver could not correctly handle this request, it will send a
+    /// MigrationStateLoad error back.
+    MigrationStateLoad(Arc<MigrationStateData>),
+}
+
+lazy_static! {
+    static ref MIGRATION_STATE_ROUTES: Arc<RwLock<HashMap<String, Mutex<Sender<MigrationRequest>>>>> =
+        Arc::new(RwLock::new(HashMap::new()));
+}
+
+pub fn migration_state_insert(idstr: String, sender: Sender<MigrationRequest>) {
+    println!("Insert migration sender from {}", idstr);
+    let mut map = MIGRATION_STATE_ROUTES.write().unwrap();
+    map.insert(idstr, Mutex::new(sender));
+}
+
+pub fn migration_state_iter_get() -> MigrationStateResult<()> {
+    let map = MIGRATION_STATE_ROUTES.read().expect("RwLock poisoned");
+    let (response_sender, response_receiver) = channel();
+
+    for (idstr, sender) in map.iter() {
+        println!("Get migration states from {}", idstr);
+        let sender = sender.lock().unwrap();
+
+        sender
+            .send(MigrationRequest::MigrationStateGet(response_sender.clone()))
+            .map_err(MigrationStateError::RequestSend)?;
+    }
+
+    let mut iter = response_receiver.iter();
+    loop {
+        let state = match iter.next() {
+            None => {
+                println!("No more response, break the loop.");
+                break
+            },
+            Some(data) => data,
+        };
+
+        println!("Received state is {:?}", state);
+
+        /* TODO: Put state into MigrateDataFile buffer */
+    }
+
+    Ok(())
+}

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -34,6 +34,7 @@ vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.1.1"
 signal-hook = "0.1.10"
 threadpool = "1.0"
+vm-migration = { path = "../vm-migration" }
 
 [dependencies.linux-loader]
 git = "https://github.com/rust-vmm/linux-loader"

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -42,6 +42,7 @@ use std::io;
 use std::sync::mpsc::{channel, RecvError, SendError, Sender};
 use std::sync::Arc;
 use vmm_sys_util::eventfd::EventFd;
+use vm_migration::state::MigrationRequest;
 
 /// API errors are sent back from the VMM API server through the ApiResponse.
 #[derive(Debug)]
@@ -158,6 +159,11 @@ pub enum ApiRequest {
     /// This will shutdown and delete the current VM, if any, and then exit the
     /// VMM process.
     VmmShutdown(Sender<ApiResponse>),
+
+    /// Register migration component.
+    /// This will register migration component sender to migrate state array,
+    /// then migration thread can send request to component to get/load states.
+    MigrationRegister(String, Sender<MigrationRequest>),
 }
 
 pub fn vm_create(

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -940,6 +940,14 @@ impl Vm {
                         match req {
                             MigrationRequest::MigrationStateGet(sender) => {
                                 /* TODO: assemble Vm states and send it as payload */
+                                /* TODO: for test only */
+                                let payload = MigrationStateData {
+                                    state: vec![1, 2, 3, 4, 5],
+                                };
+
+                                sender
+                                    .send(Ok(MigrationResponsePayload::MigrationState(payload)))
+                                    .unwrap();
                             }
                             MigrationRequest::MigrationStateLoad(state) => {
                                 /* TODO: load received state */
@@ -1085,6 +1093,15 @@ impl Vm {
         *state = new_state;
 
         self.migration_register().expect("Fail to register migration state component");
+
+        /* TODO: for test only, need remove or modify */
+        thread::Builder::new()
+            .name(format!("migration_state_get"))
+            .spawn(move || {
+                vm_migration::state::migration_state_iter_get()
+                    .expect("Fail to get migration states");
+            })
+            .map_err(Error::MigrationSpawn)?;
 
         Ok(())
     }


### PR DESCRIPTION
Per discussion on #347, implemented state migration infrastructure based on "Cloud Hypervisor internal API".

The first patch creates "vm-migration" crate and implements part of the state migration infrastructure.

The second patch implements "MigrationRequest" (ApiRequest) in Vmm and the codes to make Vm be able to register its sender to handle state migration request.

The third patch is only for test to verify if getting states route is workable. By applying this patch, you can test the changes on cloud-hypervisor.