### PR TITLE
cargo: Move to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloud-hypervisor"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["The Cloud Hypervisor Authors"]
 edition = "2018"
 


### PR DESCRIPTION
Our most recent release.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>