### PR TITLE
build: Ensure there is a release build artifact for travis to upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
   - cargo clippy --all-targets --all-features -- -D warnings
   - find . -name "*.rs" | xargs rustfmt --check
   - cargo audit
+  - cargo build --release
 
 deploy:
   provider: releases


### PR DESCRIPTION
After some of the build changes there was no longer a release artifact
left to be used for the release builds.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>