### PR TITLE
pci: Remove KVM dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,8 +460,6 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
- "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.2.0 (git+https://github.com/rust-vmm/kvm-ioctls)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-allocator 0.1.0",

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2018"
 vm-allocator = { path = "../vm-allocator" }
 byteorder = "1.3.2"
 devices = { path = "../devices" }
-kvm-bindings = "0.1.1"
-kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master" }
 libc = "0.2.60"
 log = "0.4.8"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" }

--- a/pci/src/lib.rs
+++ b/pci/src/lib.rs
@@ -6,7 +6,6 @@
 #[macro_use]
 extern crate log;
 extern crate devices;
-extern crate kvm_ioctls;
 extern crate vm_memory;
 extern crate vmm_sys_util;
 


### PR DESCRIPTION
The PCI crate should not depend on the KVM crates.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>