### PR TITLE
Fix the issue that the opened tap is renamed after vm reboot

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -255,16 +255,15 @@ impl Vmm {
         // Without ACPI, a reset is equivalent to a shutdown
         #[cfg(not(feature = "acpi"))]
         {
-            if let Some(ref mut vm) = self.vm {
-                vm.shutdown()?;
-                return Ok(());
+            if self.vm.is_some() {
+                return self.vm_shutdown();
             }
         }
 
         // First we stop the current VM and create a new one.
         if let Some(ref mut vm) = self.vm {
             let config = vm.get_config();
-            vm.shutdown()?;
+            self.vm_shutdown()?;
 
             let exit_evt = self.exit_evt.try_clone().map_err(VmError::EventFdClone)?;
             let reset_evt = self.reset_evt.try_clone().map_err(VmError::EventFdClone)?;


### PR DESCRIPTION
In vm_reboot, while build the new vm, the old one pointed by self.vm is not released, that is, the tap opened by self.vm is not closed either. As a result, the associated dev name slot in host kernel is still in use state, which prevents the new build from picking it up as the new opened tap's name, it needs to use the name in next slot instead. Assign self.vm as None once shutdown, to ensure the old vm is destructed before the new vm build.

To address #389 