### PR TITLE
arch: vmm: Move ACPI tables creation to vmm crate

### DIFF
--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Chromium OS Authors"]
 
 [features]
 default = []
-acpi = ["acpi_tables"]
 
 [dependencies]
 byteorder = "1.3.2"

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -16,8 +16,7 @@ pub fn configure_system(
     _cmdline_addr: GuestAddress,
     _cmdline_size: usize,
     _num_cpus: u8,
-    _serial_enabled: bool,
-    _virt_iommu: Option<(u32, &[u32])>,
+    _rsdp_addr: Option<GuestAddress>,
 ) -> super::Result<()> {
     Ok(())
 }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [features]
 default = []
-acpi = ["acpi_tables","devices/acpi", "arch/acpi"]
+acpi = ["acpi_tables","devices/acpi"]
 pci_support = ["pci", "vfio", "vm-virtio/pci_support"]
 mmio_support = ["vm-virtio/mmio_support"]
 cmos = ["devices/cmos"]

--- a/vmm/src/acpi.rs
+++ b/vmm/src/acpi.rs
@@ -14,7 +14,7 @@ use vm_memory::{Address, ByteValued, Bytes};
 
 use std::convert::TryInto;
 
-use super::layout;
+use arch::layout;
 
 #[repr(packed)]
 struct LocalAPIC {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -30,6 +30,9 @@ pub mod config;
 pub mod device_manager;
 pub mod vm;
 
+#[cfg(feature = "acpi")]
+mod acpi;
+
 /// Errors associated with VMM management
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]


### PR DESCRIPTION
Remove ACPI table creation from arch crate to the vmm crate simplifying
arch::configure_system()

GuestAddress(0) is used to mean no RSDP table rather than adding
complexity with a conditional argument or an Option type as it will
evaluate to a zero value which would be the default anyway.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>