### PR TITLE
API: HTTP: change response content type to JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "credibility 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -223,7 +223,7 @@ name = "devices"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-ioctls 0.3.0 (git+https://github.com/rust-vmm/kvm-ioctls)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "epoll"
-version = "4.1.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -413,7 +413,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "micro_http"
 version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/firecracker#2b94334a6a2a5f7dd07ca94f37cc4d9bdbf57ce6"
+source = "git+https://github.com/firecracker-microvm/firecracker#be978312eaf5f53abc61a130ec0ca4ab344ffacd"
+dependencies = [
+ "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "net_gen"
@@ -998,7 +1001,7 @@ dependencies = [
 name = "vhost_user_backend"
 version = "0.1.0"
 dependencies = [
- "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "vhost_rs 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
@@ -1044,7 +1047,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "devices 0.1.0",
- "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net_gen 0.1.0",
@@ -1066,7 +1069,7 @@ dependencies = [
  "acpi_tables 0.1.0",
  "arch 0.1.0",
  "devices 0.1.0",
- "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvm-ioctls 0.3.0 (git+https://github.com/rust-vmm/kvm-ioctls)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1174,7 +1177,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
-"checksum epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "990bcfe26bea89669ede68c3f970f61d02568dbc8660317c98d805ea4e710685"
+"checksum epoll 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3f0680f2a6f2a17fa7a8668a27c54e45e1ad1cf8a632f56a7c19b9e4e3bbe8a"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 clap = "2.33.0"
-epoll = "4.1.0"
+epoll = ">=4.0.1"
 lazy_static = "1.4.0"
 libc = "0.2.65"
 log = { version = "0.4.8", features = ["std"] }

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The Chromium OS Authors"]
 
 [dependencies]
 byteorder = "1.3.2"
-epoll = "4.1.0"
+epoll = ">=4.0.1"
 kvm-bindings = "0.1.1"
 kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master" }
 libc = "0.2.60"

--- a/vhost_user_backend/Cargo.toml
+++ b/vhost_user_backend/Cargo.toml
@@ -10,7 +10,7 @@ pci_support = ["vm-virtio/pci_support"]
 mmio_support = ["vm-virtio/mmio_support"]
 
 [dependencies]
-epoll = "4.1.0"
+epoll = ">=4.0.1"
 libc = "0.2.65"
 vm-memory = { git = "https://github.com/rust-vmm/vm-memory" } 
 vm-virtio = { path = "../vm-virtio" }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -12,7 +12,7 @@ mmio_support = []
 [dependencies]
 byteorder = "1.3.2"
 devices = { path = "../devices" }
-epoll = "4.1.0"
+epoll = ">=4.0.1"
 libc = "0.2.60"
 log = "0.4.8"
 net_gen = { path = "../net_gen" }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -15,7 +15,7 @@ cmos = ["devices/cmos"]
 acpi_tables = { path = "../acpi_tables", optional = true }
 arch = { path = "../arch" }
 devices = { path = "../devices" }
-epoll = "4.1.0"
+epoll = ">=4.0.1"
 kvm-bindings = "0.1.1"
 kvm-ioctls = { git = "https://github.com/rust-vmm/kvm-ioctls", branch = "master" }
 lazy_static = "1.4.0"

--- a/vmm/src/api/http.rs
+++ b/vmm/src/api/http.rs
@@ -8,7 +8,7 @@ extern crate threadpool;
 use crate::api::http_endpoint::{VmActionHandler, VmCreate, VmInfo, VmmShutdown};
 use crate::api::{ApiRequest, VmAction};
 use crate::{Error, Result};
-use micro_http::{HttpConnection, Request, Response, StatusCode, Version};
+use micro_http::{HttpConnection, MediaType, Request, Response, StatusCode, Version};
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::os::unix::net::UnixListener;
@@ -94,6 +94,7 @@ fn http_serve<T: Read + Write>(
         };
 
         response.set_server("Cloud Hypervisor API");
+        response.set_content_type(MediaType::ApplicationJson);
         http_connection.enqueue_response(response);
     }
 }


### PR DESCRIPTION
The HTTP API responses are encoded in JSON, change the default content type. 

Suggested-by:  Samuel Ortiz <sameo@linux.intel.com>
Tested-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>