### PR TITLE
Convert to micro_http HttpServer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,14 +303,6 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ipnetwork"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,15 +429,6 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "vmm-sys-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -923,14 +906,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "unicode-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,7 +1059,6 @@ dependencies = [
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vfio 0.0.1",
  "vm-allocator 0.1.0",
  "vm-memory 0.1.0 (git+https://github.com/rust-vmm/vm-memory)",
@@ -1183,7 +1157,6 @@ dependencies = [
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 "checksum ipnetwork 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3d862c86f7867f19b693ec86765e0252d82e53d4240b9b629815675a0714ad1"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -1198,7 +1171,6 @@ dependencies = [
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum micro_http 0.1.0 (git+https://github.com/firecracker-microvm/firecracker)" = "<none>"
-"checksum num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "155394f924cdddf08149da25bfb932d226b4a593ca7468b08191ff6335941af5"
 "checksum openssl-sys 0.9.52 (registry+https://github.com/rust-lang/crates.io-index)" = "c977d08e1312e2f7e4b86f9ebaa0ed3b19d1daff75fae88bbb88108afbd801fc"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum pnet 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63d693c84430248366146e3181ff9d330243464fa9e6146c372b2f3eb2e2d8e7"
@@ -1249,7 +1221,6 @@ dependencies = [
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -33,7 +33,6 @@ vm-allocator = { path = "../vm-allocator" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = ">=0.1.1"
 signal-hook = "0.1.10"
-threadpool = "1.0"
 
 [dependencies.linux-loader]
 git = "https://github.com/rust-vmm/linux-loader"

--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -81,7 +81,7 @@ impl EndpointHandler for VmCreate {
                         match vm_create(api_notifier, api_sender, Arc::new(vm_config))
                             .map_err(HttpError::VmCreate)
                         {
-                            Ok(_) => Response::new(Version::Http11, StatusCode::OK),
+                            Ok(_) => Response::new(Version::Http11, StatusCode::NoContent),
                             Err(e) => error_response(e, StatusCode::InternalServerError),
                         }
                     }
@@ -134,7 +134,7 @@ impl EndpointHandler for VmActionHandler {
                     ApiError::VmResume(_) => HttpError::VmResume(e),
                     _ => HttpError::VmAction(e),
                 }) {
-                    Ok(_) => Response::new(Version::Http11, StatusCode::OK),
+                    Ok(_) => Response::new(Version::Http11, StatusCode::NoContent),
                     Err(e) => error_response(e, StatusCode::InternalServerError),
                 }
             }

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -28,9 +28,8 @@ paths:
       summary: Shuts the cloud-hypervisor VMM.
       operationId: shutdownVMM
       responses:
-        201:
+        204:
           description: The VMM successfully shutdown.
-          content: {}
 
   /vm.info:
     get:
@@ -55,90 +54,74 @@ paths:
               $ref: '#/components/schemas/VmConfig'
         required: true
       responses:
-        201:
+        204:
           description: The VM instance was successfully created.
-          content: {}
 
   /vm.delete:
     put:
       summary: Delete the cloud-hypervisor Virtual Machine (VM) instance.
       operationId: deleteVM
       responses:
-        201:
+        204:
           description: The VM instance was successfully deleted.
-          content: {}
 
   /vm.boot:
     put:
       summary: Boot the previously created VM instance.
       operationId: bootVM
       responses:
-        201:
+        204:
           description: The VM instance successfully booted.
-          content: {}
         404:
           description: The VM instance could not boot because it is not created yet
-          content: {}
 
   /vm.pause:
     put:
       summary: Pause a previously booted VM instance.
       operationId: pauseVM
       responses:
-        201:
+        204:
           description: The VM instance successfully paused.
-          content: {}
         404:
           description: The VM instance could not pause because it is not created yet
-          content: {}
         405:
           description: The VM instance could not pause because it is not booted.
-          content: {}
 
   /vm.resume:
     put:
       summary: Resume a previously paused VM instance.
       operationId: resumeVM
       responses:
-        201:
+        204:
           description: The VM instance successfully paused.
-          content: {}
         404:
           description: The VM instance could not resume because it is not booted yet
-          content: {}
         405:
           description: The VM instance could not resume because it is not paused.
-          content: {}
 
   /vm.shutdown:
     put:
       summary: Shut the VM instance down.
       operationId: shutdownVM
       responses:
-        201:
+        204:
           description: The VM instance successfully shut down.
-          content: {}
         404:
           description: The VM instance could not shut down because is not created.
-          content: {}
         405:
           description: The VM instance could not shut down because it is not started.
-          content: {}
 
   /vm.reboot:
     put:
       summary: Reboot the VM instance.
       operationId: rebootVM
       responses:
-        201:
+        204:
           description: The VM instance successfully rebooted.
-          content: {}
         404:
           description: The VM instance could not reboot because it is not created.
-          content: {}
         405:
           description: The VM instance could not reboot because it is not booted.
-          content: {}
 
 components:
   schemas:


### PR DESCRIPTION
The new micro_http package provides a built-in HttpServer wrapper for
running a more robust HTTP server based on the package HTTP API.
    
Switching to this implementation allows us to, among other things,
handle HTTP requests that are larger than 1024 bytes.
    
Fixes: #423
