### PR TITLE
[DONOTMERGE] [RFC] Use rust-vmm vfio crate

### DIFF
--- a/vfio-ioctls/Cargo.toml
+++ b/vfio-ioctls/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "vfio-ioctls"
+version = "0.0.1"
+authors = ["The Cloud Hypervisor Authors", "Liu Jiang <gerry@linux.alibaba.com>"]
+description = "Safe wrappers over VFIO ioctls"
+keywords = ["vfio"]
+license = "Apache-2.0 OR BSD-3-Clause"
+edition = "2018"
+
+[dependencies]
+byteorder = "~1.2.1"
+log = "0.4"
+kvm-bindings = "~0"
+kvm-ioctls = "~0"
+vfio-bindings = "0.1.0"
+vmm-sys-util = "~0"
+
+vm-memory = { git = "https://github.com/rust-vmm/vm-memory", features = ["backend-mmap"] }

--- a/vfio-ioctls/Cargo.toml
+++ b/vfio-ioctls/Cargo.toml
@@ -8,11 +8,13 @@ license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
-byteorder = "~1.2.1"
+byteorder = ">=1.3.2"
 log = "0.4"
-kvm-bindings = "~0"
-kvm-ioctls = "~0"
+kvm-bindings = "0.1.0"
+kvm-ioctls = ">=0.3.0"
 vfio-bindings = "0.1.0"
-vmm-sys-util = "~0"
+vmm-sys-util = ">=0.2.0"
 
-vm-memory = { git = "https://github.com/rust-vmm/vm-memory", features = ["backend-mmap"] }
+[dependencies.vm-memory]
+git = "https://github.com/rust-vmm/vm-memory"
+features = ["backend-mmap"]

--- a/vfio-ioctls/src/lib.rs
+++ b/vfio-ioctls/src/lib.rs
@@ -1,0 +1,96 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! [Virtual Function I/O (VFIO) API](https://www.kernel.org/doc/Documentation/vfio.txt)
+//!
+//! Many modern system now provide DMA and interrupt remapping facilities to help ensure I/O
+//! devices behave within the boundaries they've been allotted. This includes x86 hardware with
+//! AMD-Vi and Intel VT-d, POWER systems with Partitionable Endpoints (PEs) and embedded PowerPC
+//! systems such as Freescale PAMU. The VFIO driver is an IOMMU/device agnostic framework for
+//! exposing direct device access to userspace, in a secure, IOMMU protected environment.
+//! In other words, the VFIO framework allows safe, non-privileged, userspace drivers.
+//!
+//! Why do we want that?  Virtual machines often make use of direct device access ("device
+//! assignment") when configured for the highest possible I/O performance. From a device and host
+//! perspective, this simply turns the VM into a userspace driver, with the benefits of
+//! significantly reduced latency, higher bandwidth, and direct use of bare-metal device drivers.
+//!
+//! Devices are the main target of any I/O driver.  Devices typically create a programming
+//! interface made up of I/O access, interrupts, and DMA.  Without going into the details of each
+//! of these, DMA is by far the most critical aspect for maintaining a secure environment as
+//! allowing a device read-write access to system memory imposes the greatest risk to the overall
+//! system integrity.
+//!
+//! To help mitigate this risk, many modern IOMMUs now incorporate isolation properties into what
+//! was, in many cases, an interface only meant for translation (ie. solving the addressing
+//! problems of devices with limited address spaces).  With this, devices can now be isolated
+//! from each other and from arbitrary memory access, thus allowing things like secure direct
+//! assignment of devices into virtual machines.
+//!
+//! While for the most part an IOMMU may have device level granularity, any system is susceptible
+//! to reduced granularity. The IOMMU API therefore supports a notion of IOMMU groups. A group is
+//! a set of devices which is isolatable from all other devices in the system. Groups are therefore
+//! the unit of ownership used by VFIO.
+//!
+//! While the group is the minimum granularity that must be used to ensure secure user access, it's
+//! not necessarily the preferred granularity. In IOMMUs which make use of page tables, it may be
+//! possible to share a set of page tables between different groups, reducing the overhead both to
+//! the platform (reduced TLB thrashing, reduced duplicate page tables), and to the user
+//! (programming only a single set of translations). For this reason, VFIO makes use of a container
+//! class, which may hold one or more groups. A container is created by simply opening the
+//! /dev/vfio/vfio character device.
+//!
+//! This crate is a safe wrapper around the Linux kernel's VFIO interfaces, which offering safe
+//! wrappers for:
+//! - [VFIO Container](struct.VfioContainer.html) using the `VfioContainer` structure
+//! - [VFIO Device](struct.VfioDevice.html) using the `VfioDevice` structure
+//!
+//! # Platform support
+//!
+//! - x86_64
+//!
+//! **NOTE:** The list of available ioctls is not extensive.
+
+#![deny(missing_docs)]
+
+#[macro_use]
+extern crate vmm_sys_util;
+
+mod vfio_device;
+mod vfio_ioctls;
+
+pub use vfio_device::{VfioContainer, VfioDevice, VfioError, VfioIrq};
+
+use std::mem::size_of;
+
+/// Returns a `Vec<T>` with a size in bytes at least as large as `size_in_bytes`.
+fn vec_with_size_in_bytes<T: Default>(size_in_bytes: usize) -> Vec<T> {
+    let rounded_size = (size_in_bytes + size_of::<T>() - 1) / size_of::<T>();
+    let mut v = Vec::with_capacity(rounded_size);
+    for _ in 0..rounded_size {
+        v.push(T::default())
+    }
+    v
+}
+
+/// The kvm API has many structs that resemble the following `Foo` structure:
+///
+/// ```
+/// #[repr(C)]
+/// struct Foo {
+///    some_data: u32
+///    entries: __IncompleteArrayField<__u32>,
+/// }
+/// ```
+///
+/// In order to allocate such a structure, `size_of::<Foo>()` would be too small because it would not
+/// include any space for `entries`. To make the allocation large enough while still being aligned
+/// for `Foo`, a `Vec<Foo>` is created. Only the first element of `Vec<Foo>` would actually be used
+/// as a `Foo`. The remaining memory in the `Vec<Foo>` is for `entries`, which must be contiguous
+/// with `Foo`. This function is used to make the `Vec<Foo>` with enough space for `count` entries.
+pub fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
+    let element_space = count * size_of::<F>();
+    let vec_size_bytes = size_of::<T>() + element_space;
+    vec_with_size_in_bytes(vec_size_bytes)
+}

--- a/vfio-ioctls/src/vfio_device.rs
+++ b/vfio-ioctls/src/vfio_device.rs
@@ -1,0 +1,962 @@
+// Copyright © 2019 Intel Corporation
+// Copyright (C) 2019 Alibaba Cloud Computing. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::collections::HashMap;
+use std::ffi::CString;
+use std::fmt;
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::mem::{self, ManuallyDrop};
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::prelude::FileExt;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use byteorder::{ByteOrder, LittleEndian};
+use kvm_bindings::{
+    kvm_device_attr, KVM_DEV_VFIO_GROUP, KVM_DEV_VFIO_GROUP_ADD, KVM_DEV_VFIO_GROUP_DEL,
+};
+use kvm_ioctls::DeviceFd;
+use log::{debug, error, warn};
+use vfio_bindings::bindings::vfio::*;
+use vm_memory::{Address, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+use vmm_sys_util::eventfd::EventFd;
+use vmm_sys_util::ioctl::*;
+
+use crate::vec_with_array_field;
+use crate::vfio_ioctls::*;
+
+#[allow(missing_docs)]
+#[derive(Debug)]
+pub enum VfioError {
+    OpenContainer(io::Error),
+    OpenGroup(io::Error),
+    GetGroupStatus,
+    GroupViable,
+    VfioApiVersion,
+    VfioExtension,
+    VfioInvalidType,
+    VfioType1V2,
+    GroupSetContainer,
+    UnsetContainer,
+    ContainerSetIOMMU,
+    GroupGetDeviceFD,
+    KvmSetDeviceAttr(io::Error),
+    VfioDeviceGetInfo,
+    VfioDeviceGetRegionInfo,
+    InvalidPath,
+    IommuDmaMap,
+    IommuDmaUnmap,
+    VfioDeviceGetIrqInfo,
+    VfioDeviceSetIrq,
+}
+pub type Result<T> = std::result::Result<T, VfioError>;
+
+impl fmt::Display for VfioError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            VfioError::OpenContainer(e) => {
+                write!(f, "failed to open /dev/vfio/vfio container: {}", e)
+            }
+            VfioError::OpenGroup(e) => {
+                write!(f, "failed to open /dev/vfio/$group_num group: {}", e)
+            }
+            VfioError::GetGroupStatus => write!(f, "failed to get Group Status"),
+            VfioError::GroupViable => write!(f, "group is inviable"),
+            VfioError::VfioApiVersion => write!(
+                f,
+                "vfio API version doesn't match with VFIO_API_VERSION defined in vfio-bindings"
+            ),
+            VfioError::VfioExtension => write!(f, "failed to check VFIO extension"),
+            VfioError::VfioInvalidType => write!(f, "invalid VFIO type"),
+            VfioError::VfioType1V2 => {
+                write!(f, "container dones't support VfioType1V2 IOMMU driver type")
+            }
+            VfioError::GroupSetContainer => {
+                write!(f, "failed to add vfio group into vfio container")
+            }
+            VfioError::UnsetContainer => write!(f, "failed to unset vfio container"),
+            VfioError::ContainerSetIOMMU => write!(
+                f,
+                "failed to set container's IOMMU driver type as VfioType1V2"
+            ),
+            VfioError::GroupGetDeviceFD => write!(f, "failed to get vfio device fd"),
+            VfioError::KvmSetDeviceAttr(e) => {
+                write!(f, "failed to set KVM vfio device's attribute: {}", e)
+            }
+            VfioError::VfioDeviceGetInfo => {
+                write!(f, "failed to get vfio device's info or info doesn't match")
+            }
+            VfioError::VfioDeviceGetRegionInfo => {
+                write!(f, "failed to get vfio device's region info")
+            }
+            VfioError::InvalidPath => write!(f, "invalid file path"),
+            VfioError::IommuDmaMap => write!(f, "failed to add guest memory map into iommu table"),
+            VfioError::IommuDmaUnmap => {
+                write!(f, "failed to remove guest memory map from iommu table")
+            }
+            VfioError::VfioDeviceGetIrqInfo => write!(f, "failed to get vfio device irq info"),
+            VfioError::VfioDeviceSetIrq => write!(f, "failed to set vfio deviece irq"),
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default)]
+struct vfio_region_info_with_cap {
+    region_info: vfio_region_info,
+    cap_info: __IncompleteArrayField<u8>,
+}
+
+/// A safe wrapper over a VFIO container object.
+///
+/// A VFIO container represents an IOMMU domain, or a set of IO virtual address translation tables.
+/// On its own, the container provides little functionality, with all but a couple version and
+/// extension query interfaces locked away. The user needs to add a group into the container for
+/// the next level of functionality. After some groups are associated with a container, the user
+/// can query and set the IOMMU backend, and then build IOVA mapping to access memory.
+///
+/// Multiple VFIO groups may be associated with the same VFIO container to share the underline
+/// address translation mapping tables.
+pub struct VfioContainer {
+    container: File,
+    device_fd: Arc<DeviceFd>,
+    groups: Mutex<HashMap<u32, Arc<VfioGroup>>>,
+}
+
+impl VfioContainer {
+    /// Create a container wrapper object.
+    ///
+    /// # Arguments
+    /// * `device_fd`: file handle of the KVM VFIO device.
+    pub fn new(device_fd: Arc<DeviceFd>) -> Result<Self> {
+        let container = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/vfio/vfio")
+            .map_err(VfioError::OpenContainer)?;
+
+        let container = VfioContainer {
+            container,
+            device_fd,
+            groups: Mutex::new(HashMap::new()),
+        };
+        container.check_api_version()?;
+        container.check_extension(VFIO_TYPE1v2_IOMMU)?;
+
+        Ok(container)
+    }
+
+    fn check_api_version(&self) -> Result<()> {
+        // Safe as file is vfio container fd and ioctl is defined by kernel.
+        let version = unsafe { ioctl(self, VFIO_GET_API_VERSION()) };
+        if version as u32 != VFIO_API_VERSION {
+            return Err(VfioError::VfioApiVersion);
+        }
+        Ok(())
+    }
+
+    fn check_extension(&self, val: u32) -> Result<()> {
+        if val != VFIO_TYPE1_IOMMU && val != VFIO_TYPE1v2_IOMMU {
+            return Err(VfioError::VfioInvalidType);
+        }
+
+        // Safe as file is vfio container and make sure val is valid.
+        let ret = unsafe { ioctl_with_val(self, VFIO_CHECK_EXTENSION(), val.into()) };
+        if ret != 1 {
+            return Err(VfioError::VfioExtension);
+        }
+
+        Ok(())
+    }
+
+    fn set_iommu(&self, val: u32) -> Result<()> {
+        if val != VFIO_TYPE1_IOMMU && val != VFIO_TYPE1v2_IOMMU {
+            return Err(VfioError::VfioInvalidType);
+        }
+
+        // Safe as file is vfio container and make sure val is valid.
+        let ret = unsafe { ioctl_with_val(self, VFIO_SET_IOMMU(), val.into()) };
+        if ret < 0 {
+            return Err(VfioError::ContainerSetIOMMU);
+        }
+
+        Ok(())
+    }
+
+    fn kvm_device_add_group(&self, group_fd: RawFd) -> Result<()> {
+        let group_fd_ptr = &group_fd as *const i32;
+        let dev_attr = kvm_device_attr {
+            flags: 0,
+            group: KVM_DEV_VFIO_GROUP,
+            attr: u64::from(KVM_DEV_VFIO_GROUP_ADD),
+            addr: group_fd_ptr as u64,
+        };
+
+        self.device_fd
+            .set_device_attr(&dev_attr)
+            .map_err(VfioError::KvmSetDeviceAttr)
+    }
+
+    fn kvm_device_del_group(&self, group_fd: RawFd) -> std::result::Result<(), io::Error> {
+        let group_fd_ptr = &group_fd as *const i32;
+        let dev_attr = kvm_device_attr {
+            flags: 0,
+            group: KVM_DEV_VFIO_GROUP,
+            attr: u64::from(KVM_DEV_VFIO_GROUP_DEL),
+            addr: group_fd_ptr as u64,
+        };
+
+        self.device_fd.set_device_attr(&dev_attr)
+    }
+
+    fn get_group(&self, group_id: u32) -> Result<Arc<VfioGroup>> {
+        // Safe because there's no legal way to break the lock.
+        let mut hash = self.groups.lock().unwrap();
+        if let Some(entry) = hash.get(&group_id) {
+            return Ok(entry.clone());
+        }
+
+        let group = Arc::new(VfioGroup::new(group_id)?);
+
+        // Bind the new group object to the container.
+        // Safe as we are the owner of group and container_raw_fd which are valid value,
+        // and we verify the ret value
+        let container_raw_fd = self.as_raw_fd();
+        let ret = unsafe { ioctl_with_ref(&*group, VFIO_GROUP_SET_CONTAINER(), &container_raw_fd) };
+        if ret < 0 {
+            return Err(VfioError::GroupSetContainer);
+        }
+
+        // Initialize the IOMMU backend driver after binding the first group object.
+        if hash.len() == 0 {
+            if let Err(e) = self.set_iommu(VFIO_TYPE1v2_IOMMU) {
+                let _ = unsafe {
+                    ioctl_with_ref(&*group, VFIO_GROUP_UNSET_CONTAINER(), &self.as_raw_fd())
+                };
+                return Err(e);
+            }
+        }
+
+        // Add the new group object to the KVM driver.
+        if let Err(e) = self.kvm_device_add_group(group.as_raw_fd()) {
+            let _ =
+                unsafe { ioctl_with_ref(&*group, VFIO_GROUP_UNSET_CONTAINER(), &self.as_raw_fd()) };
+            return Err(e);
+        }
+
+        hash.insert(group_id, group.clone());
+
+        Ok(group)
+    }
+
+    fn put_group(&self, group: Arc<VfioGroup>) {
+        // Safe because there's no legal way to break the lock.
+        let mut hash = self.groups.lock().unwrap();
+
+        // Clean up the group when the last user releases reference to the group, three reference
+        // count for:
+        // - one reference held by the last device object
+        // - one reference cloned in VfioDevice.drop() and passed into here
+        // - one reference held by the groups hashmap
+        if Arc::strong_count(&group) == 3 {
+            match self.kvm_device_del_group(group.as_raw_fd()) {
+                Ok(_) => {}
+                Err(e) => {
+                    error!("Could not delete VFIO group: {:?}", e);
+                    return;
+                }
+            }
+            // Safe as we are the owner of self and container_raw_fd which are valid value.
+            let ret =
+                unsafe { ioctl_with_ref(&*group, VFIO_GROUP_UNSET_CONTAINER(), &self.as_raw_fd()) };
+            if ret < 0 {
+                error!("Could not unbind VFIO group: {:?}", group.id());
+                return;
+            }
+            hash.remove(&group.id());
+        }
+    }
+
+    /// Map a region of guest memory regions into the vfio container's iommu table.
+    ///
+    /// # Parameters
+    /// * iova: IO virtual address to mapping the memory.
+    /// * size: size of the memory region.
+    /// * user_addr: host virtual address for the guest memory region to map.
+    pub fn vfio_dma_map(&self, iova: u64, size: u64, user_addr: u64) -> Result<()> {
+        let dma_map = vfio_iommu_type1_dma_map {
+            argsz: mem::size_of::<vfio_iommu_type1_dma_map>() as u32,
+            flags: VFIO_DMA_MAP_FLAG_READ | VFIO_DMA_MAP_FLAG_WRITE,
+            vaddr: user_addr,
+            iova,
+            size,
+        };
+
+        // Safe as file is vfio container, dma_map is constructed by us, and
+        // we check the return value
+        let ret = unsafe { ioctl_with_ref(self, VFIO_IOMMU_MAP_DMA(), &dma_map) };
+        if ret != 0 {
+            return Err(VfioError::IommuDmaMap);
+        }
+
+        Ok(())
+    }
+
+    /// Unmap a region of guest memory regions into the vfio container's iommu table.
+    ///
+    /// # Parameters
+    /// * iova: IO virtual address to mapping the memory.
+    /// * size: size of the memory region.
+    pub fn vfio_dma_unmap(&self, iova: u64, size: u64) -> Result<()> {
+        let mut dma_unmap = vfio_iommu_type1_dma_unmap {
+            argsz: mem::size_of::<vfio_iommu_type1_dma_unmap>() as u32,
+            flags: 0,
+            iova,
+            size,
+        };
+
+        // Safe as file is vfio container, dma_unmap is constructed by us, and
+        // we check the return value
+        let ret = unsafe { ioctl_with_mut_ref(self, VFIO_IOMMU_UNMAP_DMA(), &mut dma_unmap) };
+        if ret != 0 || dma_unmap.size != size {
+            return Err(VfioError::IommuDmaUnmap);
+        }
+
+        Ok(())
+    }
+
+    /// Add all guest memory regions into the vfio container's iommu table.
+    ///
+    /// # Parameters
+    /// * mem: pinned guest memory which could be accessed by devices binding to the container.
+    pub fn setup_dma_map(&self, mem: GuestMemoryMmap) -> Result<()> {
+        mem.with_regions(|_index, region| {
+            self.vfio_dma_map(
+                region.start_addr().raw_value(),
+                region.len() as u64,
+                region.as_ptr() as u64,
+            )
+        })?;
+        Ok(())
+    }
+
+    /// Remove all guest memory regions from the vfio container's iommu table.
+    ///
+    /// The vfio kernel driver and device hardware couldn't access this guest memory after
+    /// returning from the function.
+    ///
+    /// # Parameters
+    /// * mem: pinned guest memory which could be accessed by devices binding to the container.
+    pub fn unset_dma_map(&self, mem: GuestMemoryMmap) -> Result<()> {
+        mem.with_regions(|_index, region| {
+            self.vfio_dma_unmap(region.start_addr().raw_value(), region.len() as u64)
+        })?;
+        Ok(())
+    }
+}
+
+impl AsRawFd for VfioContainer {
+    fn as_raw_fd(&self) -> RawFd {
+        self.container.as_raw_fd()
+    }
+}
+
+/// A safe wrapper over a VFIO container object.
+///
+/// The Linux VFIO frameworks supports multiple devices per group, and multiple groups per
+/// container. But current implementation assumes there's only one device per group to simplify
+/// implementation. With such an assumption, the `VfioGroup` becomes an internal implementation
+/// details.
+struct VfioGroup {
+    id: u32,
+    group: File,
+}
+
+impl VfioGroup {
+    /// Create a new VfioGroup object.
+    ///
+    /// # Parameters
+    /// * `id`: ID(index) of the VFIO group file.
+    fn new(id: u32) -> Result<Self> {
+        let group_path = Path::new("/dev/vfio").join(id.to_string());
+        let group = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&group_path)
+            .map_err(VfioError::OpenGroup)?;
+
+        let mut group_status = vfio_group_status {
+            argsz: mem::size_of::<vfio_group_status>() as u32,
+            flags: 0,
+        };
+        // Safe as we are the owner of group and group_status which are valid value.
+        let ret = unsafe { ioctl_with_mut_ref(&group, VFIO_GROUP_GET_STATUS(), &mut group_status) };
+        if ret < 0 {
+            return Err(VfioError::GetGroupStatus);
+        }
+
+        if group_status.flags != VFIO_GROUP_FLAGS_VIABLE {
+            return Err(VfioError::GroupViable);
+        }
+
+        Ok(VfioGroup { id, group })
+    }
+
+    fn id(&self) -> u32 {
+        self.id
+    }
+
+    fn get_device(&self, name: &Path) -> Result<VfioDeviceInfo> {
+        let uuid_osstr = name.file_name().ok_or(VfioError::InvalidPath)?;
+        let uuid_str = uuid_osstr.to_str().ok_or(VfioError::InvalidPath)?;
+        let path: CString = CString::new(uuid_str.as_bytes()).expect("CString::new() failed");
+        let path_ptr = path.as_ptr();
+
+        // Safe as we are the owner of self and path_ptr which are valid value.
+        let fd = unsafe { ioctl_with_ptr(self, VFIO_GROUP_GET_DEVICE_FD(), path_ptr) };
+        if fd < 0 {
+            return Err(VfioError::GroupGetDeviceFD);
+        }
+
+        // Safe as fd is valid FD
+        let device = unsafe { File::from_raw_fd(fd) };
+
+        let mut dev_info = vfio_device_info {
+            argsz: mem::size_of::<vfio_device_info>() as u32,
+            flags: 0,
+            num_regions: 0,
+            num_irqs: 0,
+        };
+        // Safe as we are the owner of dev and dev_info which are valid value,
+        // and we verify the return value.
+        let ret = unsafe { ioctl_with_mut_ref(&device, VFIO_DEVICE_GET_INFO(), &mut dev_info) };
+        if ret < 0
+            || (dev_info.flags & VFIO_DEVICE_FLAGS_PCI) == 0
+            || dev_info.num_regions < VFIO_PCI_CONFIG_REGION_INDEX + 1
+            || dev_info.num_irqs < VFIO_PCI_MSIX_IRQ_INDEX + 1
+        {
+            return Err(VfioError::VfioDeviceGetInfo);
+        }
+
+        Ok(VfioDeviceInfo {
+            device,
+            flags: dev_info.flags,
+            num_regions: dev_info.num_regions,
+            num_irqs: dev_info.num_irqs,
+        })
+    }
+}
+
+impl AsRawFd for VfioGroup {
+    fn as_raw_fd(&self) -> RawFd {
+        self.group.as_raw_fd()
+    }
+}
+
+struct VfioRegion {
+    flags: u32,
+    size: u64,
+    offset: u64,
+    mmap: (u64, u64),
+}
+
+/// Information abour VFIO interrupts.
+pub struct VfioIrq {
+    /// Flags for irq.
+    pub flags: u32,
+    /// Staring index.
+    pub index: u32,
+    /// Number interrupts.
+    pub count: u32,
+}
+
+struct VfioDeviceInfo {
+    device: File,
+    flags: u32,
+    num_regions: u32,
+    num_irqs: u32,
+}
+
+impl VfioDeviceInfo {
+    fn get_irqs(&self) -> Result<HashMap<u32, VfioIrq>> {
+        let mut irqs: HashMap<u32, VfioIrq> = HashMap::new();
+
+        for index in 0..self.num_irqs {
+            let mut irq_info = vfio_irq_info {
+                argsz: mem::size_of::<vfio_irq_info>() as u32,
+                flags: 0,
+                index,
+                count: 0,
+            };
+
+            let ret = unsafe {
+                ioctl_with_mut_ref(&self.device, VFIO_DEVICE_GET_IRQ_INFO(), &mut irq_info)
+            };
+            if ret < 0 {
+                warn!("Could not get VFIO IRQ info for index {:}", index);
+                continue;
+            }
+
+            let irq = VfioIrq {
+                flags: irq_info.flags,
+                index,
+                count: irq_info.count,
+            };
+
+            debug!("IRQ #{}", index);
+            debug!("\tflag 0x{:x}", irq.flags);
+            debug!("\tindex {}", irq.index);
+            debug!("\tcount {}", irq.count);
+
+            irqs.insert(index, irq);
+        }
+
+        Ok(irqs)
+    }
+
+    fn get_regions(&self) -> Result<Vec<VfioRegion>> {
+        let mut regions: Vec<VfioRegion> = Vec::new();
+
+        for i in VFIO_PCI_BAR0_REGION_INDEX..self.num_regions {
+            let argsz: u32 = mem::size_of::<vfio_region_info>() as u32;
+
+            let mut reg_info = vfio_region_info {
+                argsz,
+                flags: 0,
+                index: i,
+                cap_offset: 0,
+                size: 0,
+                offset: 0,
+            };
+            // Safe as we are the owner of dev and reg_info which are valid value,
+            // and we verify the return value.
+            let mut ret = unsafe {
+                ioctl_with_mut_ref(&self.device, VFIO_DEVICE_GET_REGION_INFO(), &mut reg_info)
+            };
+            if ret < 0 {
+                error!("Could not get region #{} info", i);
+                continue;
+            }
+
+            let mut mmap_size: u64 = reg_info.size;
+            let mut mmap_offset: u64 = 0;
+            if reg_info.flags & VFIO_REGION_INFO_FLAG_CAPS != 0 && reg_info.argsz > argsz {
+                let cap_len: usize = (reg_info.argsz - argsz) as usize;
+                let mut region_with_cap =
+                    vec_with_array_field::<vfio_region_info_with_cap, u8>(cap_len);
+                region_with_cap[0].region_info.argsz = reg_info.argsz;
+                region_with_cap[0].region_info.flags = 0;
+                region_with_cap[0].region_info.index = i;
+                region_with_cap[0].region_info.cap_offset = 0;
+                region_with_cap[0].region_info.size = 0;
+                region_with_cap[0].region_info.offset = 0;
+                // Safe as we are the owner of dev and region_info which are valid value,
+                // and we verify the return value.
+                ret = unsafe {
+                    ioctl_with_mut_ref(
+                        &self.device,
+                        VFIO_DEVICE_GET_REGION_INFO(),
+                        &mut (region_with_cap[0].region_info),
+                    )
+                };
+                if ret < 0 {
+                    error!("Could not get region #{} info", i);
+                    continue;
+                }
+                // region_with_cap[0].cap_info may contain vfio_region_info_cap_sparse_mmap
+                // struct or vfio_region_info_cap_type struct. Both of them begin with
+                // vfio_info_cap_header.
+                // so safe to convert cap_info into vfio_info_cap_header pointer first, and
+                // safe to access its elments through this poiner.
+                #[allow(clippy::cast_ptr_alignment)]
+                let cap_header =
+                    unsafe { region_with_cap[0].cap_info.as_ptr() as *const vfio_info_cap_header };
+                if unsafe { u32::from((*cap_header).id) } == VFIO_REGION_INFO_CAP_SPARSE_MMAP {
+                    // cap_info is vfio_region_sparse_mmap here
+                    // so safe to convert cap_info into vfio_info_region_sparse_mmap pointer, and
+                    // safe to access its elements through this pointer.
+                    #[allow(clippy::cast_ptr_alignment)]
+                    let sparse_mmap = unsafe {
+                        region_with_cap[0].cap_info.as_ptr()
+                            as *const vfio_region_info_cap_sparse_mmap
+                    };
+                    let mmap_area = unsafe {
+                        (*sparse_mmap).areas.as_ptr() as *const vfio_region_sparse_mmap_area
+                    };
+                    mmap_size = unsafe { (*mmap_area).size };
+                    mmap_offset = unsafe { (*mmap_area).offset };
+                }
+            }
+
+            let region = VfioRegion {
+                flags: reg_info.flags,
+                size: reg_info.size,
+                offset: reg_info.offset,
+                mmap: (mmap_offset, mmap_size),
+            };
+
+            debug!("Region #{}", i);
+            debug!("\tflag 0x{:x}", region.flags);
+            debug!("\tsize 0x{:x}", region.size);
+            debug!("\toffset 0x{:x}", region.offset);
+
+            regions.push(region);
+        }
+
+        Ok(regions)
+    }
+}
+
+/// Vfio device to access underline hardware devices.
+///
+/// The VFIO device API includes ioctls for describing the device, the I/O regions and their
+/// read/write/mmap offsets on the device descriptor, as well as mechanisms for describing and
+/// registering interrupt notifications.
+pub struct VfioDevice {
+    device: ManuallyDrop<File>,
+    flags: u32,
+    regions: Vec<VfioRegion>,
+    irqs: HashMap<u32, VfioIrq>,
+    group: Arc<VfioGroup>,
+    container: Arc<VfioContainer>,
+}
+
+impl VfioDevice {
+    /// Create a new vfio device, then guest read/write on this device could be transferred into kernel vfio.
+    ///
+    /// # Parameters
+    /// * `sysfspath`: specify the vfio device path in sys file system.
+    /// * `container`: the new VFIO device object will bind to this container object.
+    pub fn new(sysfspath: &Path, container: Arc<VfioContainer>) -> Result<Self> {
+        let uuid_path: PathBuf = [sysfspath, Path::new("iommu_group")].iter().collect();
+        let group_path = uuid_path.read_link().map_err(|_| VfioError::InvalidPath)?;
+        let group_osstr = group_path.file_name().ok_or(VfioError::InvalidPath)?;
+        let group_str = group_osstr.to_str().ok_or(VfioError::InvalidPath)?;
+        let group_id = group_str
+            .parse::<u32>()
+            .map_err(|_| VfioError::InvalidPath)?;
+
+        let group = container.get_group(group_id)?;
+        let device_info = group.get_device(sysfspath)?;
+        let regions = device_info.get_regions()?;
+        let irqs = device_info.get_irqs()?;
+
+        Ok(VfioDevice {
+            device: ManuallyDrop::new(device_info.device),
+            flags: device_info.flags,
+            regions,
+            irqs,
+            group,
+            container,
+        })
+    }
+
+    /// VFIO device reset only if the device supports being reset.
+    pub fn reset(&self) {
+        if self.flags & VFIO_DEVICE_FLAGS_RESET != 0 {
+            unsafe { ioctl(self, VFIO_DEVICE_RESET()) };
+        }
+    }
+
+    /// Get information about VFIO IRQs.
+    ///
+    /// # Arguments
+    /// * `irq_index` - The type (INTX, MSI or MSI-X) of interrupts to enable.
+    pub fn get_irq_info(&self, irq_index: u32) -> Option<&VfioIrq> {
+        self.irqs.get(&irq_index)
+    }
+
+    /// Trigger a VFIO device IRQ from userspace.
+    ///
+    /// Once a signaling mechanism is set, DATA_BOOL or DATA_NONE can be used with ACTION_TRIGGER
+    /// to perform kernel level interrupt loopback testing from userspace (ie. simulate hardware
+    /// triggering).
+    ///
+    /// # Arguments
+    /// * `irq_index` - The type (INTX, MSI or MSI-X) of interrupts to enable.
+    /// * `vector` - The sub-index into the interrupt group of `irq_index`.
+    pub fn trigger_irq(&self, irq_index: u32, vector: u32) -> Result<()> {
+        let irq = self
+            .irqs
+            .get(&irq_index)
+            .ok_or(VfioError::VfioDeviceSetIrq)?;
+        if irq.count < vector {
+            return Err(VfioError::VfioDeviceSetIrq);
+        }
+
+        let irq_set = vfio_irq_set {
+            argsz: mem::size_of::<vfio_irq_set>() as u32,
+            flags: VFIO_IRQ_SET_DATA_NONE | VFIO_IRQ_SET_ACTION_TRIGGER,
+            index: irq_index,
+            start: vector,
+            count: 1,
+            ..Default::default()
+        };
+
+        // Safe as we are the owner of self and irq_set which are valid value
+        let ret = unsafe { ioctl_with_ref(self, VFIO_DEVICE_SET_IRQS(), &irq_set) };
+        if ret < 0 {
+            return Err(VfioError::VfioDeviceSetIrq);
+        }
+
+        Ok(())
+    }
+
+    /// Enables a VFIO device IRQs.
+    /// This maps a vector of EventFds to all VFIO managed interrupts. In other words, this
+    /// tells VFIO which EventFd to write into whenever one of the device interrupt vector
+    /// is triggered.
+    ///
+    /// # Arguments
+    /// * `irq_index` - The type (INTX, MSI or MSI-X) of interrupts to enable.
+    /// * `event_fds` - The EventFds vector that matches all the supported VFIO interrupts.
+    pub fn enable_irq(&self, irq_index: u32, event_fds: Vec<&EventFd>) -> Result<()> {
+        let irq = self
+            .irqs
+            .get(&irq_index)
+            .ok_or(VfioError::VfioDeviceSetIrq)?;
+        if irq.count == 0 {
+            return Err(VfioError::VfioDeviceSetIrq);
+        }
+
+        let mut irq_set = vec_with_array_field::<vfio_irq_set, u32>(event_fds.len());
+        irq_set[0].argsz = mem::size_of::<vfio_irq_set>() as u32
+            + (event_fds.len() * mem::size_of::<u32>()) as u32;
+        irq_set[0].flags = VFIO_IRQ_SET_DATA_EVENTFD | VFIO_IRQ_SET_ACTION_TRIGGER;
+        irq_set[0].index = irq_index;
+        irq_set[0].start = 0;
+        irq_set[0].count = irq.count;
+
+        {
+            // irq_set.data could be none, bool or fd according to flags, so irq_set.data
+            // is u8 default, here irq_set.data is a vector of fds as u32, so 4 default u8
+            // are combined together as u32 for each fd.
+            // It is safe as enough space is reserved through
+            // vec_with_array_field(u32)<event_fds.len()>.
+            let fds = unsafe {
+                irq_set[0]
+                    .data
+                    .as_mut_slice(event_fds.len() * mem::size_of::<u32>())
+            };
+            for (index, event_fd) in event_fds.iter().enumerate() {
+                let fds_offset = index * mem::size_of::<u32>();
+                let fd = &mut fds[fds_offset..fds_offset + mem::size_of::<u32>()];
+                LittleEndian::write_u32(fd, event_fd.as_raw_fd() as u32);
+            }
+        }
+
+        // Safe as we are the owner of self and irq_set which are valid value
+        let ret = unsafe { ioctl_with_ref(self, VFIO_DEVICE_SET_IRQS(), &irq_set[0]) };
+        if ret < 0 {
+            return Err(VfioError::VfioDeviceSetIrq);
+        }
+
+        Ok(())
+    }
+
+    /// Disables a VFIO device IRQs
+    ///
+    /// # Arguments
+    /// * `irq_index` - The type (INTX, MSI or MSI-X) of interrupts to disable.
+    pub fn disable_irq(&self, irq_index: u32) -> Result<()> {
+        let irq = self
+            .irqs
+            .get(&irq_index)
+            .ok_or(VfioError::VfioDeviceSetIrq)?;
+        if irq.count == 0 {
+            return Err(VfioError::VfioDeviceSetIrq);
+        }
+
+        let mut irq_set = vec_with_array_field::<vfio_irq_set, u32>(0);
+        irq_set[0].argsz = mem::size_of::<vfio_irq_set>() as u32;
+        irq_set[0].flags = VFIO_IRQ_SET_ACTION_MASK;
+        irq_set[0].index = irq_index;
+        irq_set[0].start = 0;
+        irq_set[0].count = irq.count;
+
+        // Safe as we are the owner of self and irq_set which are valid value
+        let ret = unsafe { ioctl_with_ref(self, VFIO_DEVICE_SET_IRQS(), &irq_set[0]) };
+        if ret < 0 {
+            return Err(VfioError::VfioDeviceSetIrq);
+        }
+
+        Ok(())
+    }
+
+    /// Wrapper to enable MSI IRQs.
+    pub fn enable_msi(&self, fds: Vec<&EventFd>) -> Result<()> {
+        self.enable_irq(VFIO_PCI_MSI_IRQ_INDEX, fds)
+    }
+
+    /// Wrapper to disable MSI IRQs.
+    pub fn disable_msi(&self) -> Result<()> {
+        self.disable_irq(VFIO_PCI_MSI_IRQ_INDEX)
+    }
+
+    /// Wrapper to enable MSI-X IRQs.
+    pub fn enable_msix(&self, fds: Vec<&EventFd>) -> Result<()> {
+        self.enable_irq(VFIO_PCI_MSIX_IRQ_INDEX, fds)
+    }
+
+    /// Wrapper to disable MSI-X IRQs.
+    pub fn disable_msix(&self) -> Result<()> {
+        self.disable_irq(VFIO_PCI_MSIX_IRQ_INDEX)
+    }
+
+    /// Get a region's flag.
+    ///
+    /// # Arguments
+    /// * `index` - The index of memory region.
+    pub fn get_region_flags(&self, index: u32) -> u32 {
+        match self.regions.get(index as usize) {
+            Some(v) => v.flags,
+            None => 0,
+        }
+    }
+
+    /// Get a region's offset.
+    ///
+    /// # Arguments
+    /// * `index` - The index of memory region.
+    pub fn get_region_offset(&self, index: u32) -> u64 {
+        match self.regions.get(index as usize) {
+            Some(v) => v.offset,
+            None => 0,
+        }
+    }
+
+    /// Get a region's mmap info.
+    ///
+    /// # Arguments
+    /// * `index` - The index of memory region.
+    pub fn get_region_mmap(&self, index: u32) -> (u64, u64) {
+        match self.regions.get(index as usize) {
+            Some(v) => v.mmap,
+            None => {
+                warn!("get_region_mmap with invalid index: {}", index);
+                (0, 0)
+            }
+        }
+    }
+
+    /// Get a region's size.
+    ///
+    /// # Arguments
+    /// * `index` - The index of memory region.
+    pub fn get_region_size(&self, index: u32) -> u64 {
+        match self.regions.get(index as usize) {
+            Some(v) => v.size,
+            None => {
+                warn!("get_region_size with invalid index: {}", index);
+                0
+            }
+        }
+    }
+
+    /// Read region's data from VFIO device into buf
+    ///
+    /// # Arguments
+    /// * `index`: region num
+    /// * `buf`: data destination and buf length is read size
+    /// * `addr`: offset in the region
+    pub fn region_read(&self, index: u32, buf: &mut [u8], addr: u64) {
+        let region: &VfioRegion;
+        match self.regions.get(index as usize) {
+            Some(v) => region = v,
+            None => {
+                warn!("region read with invalid index: {}", index);
+                return;
+            }
+        }
+
+        let size = buf.len() as u64;
+        if size > region.size || addr + size > region.size {
+            warn!(
+                "region read with invalid parameter, add: {}, size: {}",
+                addr, size
+            );
+            return;
+        }
+
+        if let Err(e) = self.device.read_exact_at(buf, region.offset + addr) {
+            warn!(
+                "Failed to read region in index: {}, addr: {}, error: {}",
+                index, addr, e
+            );
+        }
+    }
+
+    /// Write the data from buf into a vfio device region
+    ///
+    /// # Arguments
+    /// * `index`: region num
+    /// * `buf`: data src and buf length is write size
+    /// * `addr`: offset in the region
+    pub fn region_write(&self, index: u32, buf: &[u8], addr: u64) {
+        let stub: &VfioRegion;
+        match self.regions.get(index as usize) {
+            Some(v) => stub = v,
+            None => {
+                warn!("region write with invalid index: {}", index);
+                return;
+            }
+        }
+
+        let size = buf.len() as u64;
+        if size > stub.size
+            || addr + size > stub.size
+            || (stub.flags & VFIO_REGION_INFO_FLAG_WRITE) == 0
+        {
+            warn!(
+                "region write with invalid parameter, add: {}, size: {}",
+                addr, size
+            );
+            return;
+        }
+
+        if let Err(e) = self.device.write_all_at(buf, stub.offset + addr) {
+            warn!(
+                "Failed to write region in index: {}, addr: {}, error: {}",
+                index, addr, e
+            );
+        }
+    }
+
+    /// Return the maximum numner of interrupts a VFIO device can request.
+    pub fn max_interrupts(&self) -> u32 {
+        let mut max_interrupts = 0;
+        let irq_indexes = vec![
+            VFIO_PCI_INTX_IRQ_INDEX,
+            VFIO_PCI_MSI_IRQ_INDEX,
+            VFIO_PCI_MSIX_IRQ_INDEX,
+        ];
+
+        for index in irq_indexes {
+            if let Some(irq_info) = self.irqs.get(&index) {
+                if irq_info.count > max_interrupts {
+                    max_interrupts = irq_info.count;
+                }
+            }
+        }
+
+        max_interrupts
+    }
+}
+
+impl AsRawFd for VfioDevice {
+    fn as_raw_fd(&self) -> RawFd {
+        self.device.as_raw_fd()
+    }
+}
+
+impl Drop for VfioDevice {
+    fn drop(&mut self) {
+        unsafe {
+            ManuallyDrop::drop(&mut self.device);
+        }
+        self.container.put_group(self.group.clone());
+    }
+}

--- a/vfio-ioctls/src/vfio_ioctls.rs
+++ b/vfio-ioctls/src/vfio_ioctls.rs
@@ -1,0 +1,36 @@
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+//
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+use vfio_bindings::bindings::vfio::*;
+
+ioctl_io_nr!(VFIO_GET_API_VERSION, VFIO_TYPE, VFIO_BASE);
+ioctl_io_nr!(VFIO_CHECK_EXTENSION, VFIO_TYPE, VFIO_BASE + 1);
+ioctl_io_nr!(VFIO_SET_IOMMU, VFIO_TYPE, VFIO_BASE + 2);
+ioctl_io_nr!(VFIO_GROUP_GET_STATUS, VFIO_TYPE, VFIO_BASE + 3);
+ioctl_io_nr!(VFIO_GROUP_SET_CONTAINER, VFIO_TYPE, VFIO_BASE + 4);
+ioctl_io_nr!(VFIO_GROUP_UNSET_CONTAINER, VFIO_TYPE, VFIO_BASE + 5);
+ioctl_io_nr!(VFIO_GROUP_GET_DEVICE_FD, VFIO_TYPE, VFIO_BASE + 6);
+ioctl_io_nr!(VFIO_DEVICE_GET_INFO, VFIO_TYPE, VFIO_BASE + 7);
+ioctl_io_nr!(VFIO_DEVICE_GET_REGION_INFO, VFIO_TYPE, VFIO_BASE + 8);
+ioctl_io_nr!(VFIO_DEVICE_GET_IRQ_INFO, VFIO_TYPE, VFIO_BASE + 9);
+ioctl_io_nr!(VFIO_DEVICE_SET_IRQS, VFIO_TYPE, VFIO_BASE + 10);
+ioctl_io_nr!(VFIO_DEVICE_RESET, VFIO_TYPE, VFIO_BASE + 11);
+ioctl_io_nr!(
+    VFIO_DEVICE_GET_PCI_HOT_RESET_INFO,
+    VFIO_TYPE,
+    VFIO_BASE + 12
+);
+ioctl_io_nr!(VFIO_DEVICE_PCI_HOT_RESET, VFIO_TYPE, VFIO_BASE + 13);
+ioctl_io_nr!(VFIO_DEVICE_QUERY_GFX_PLANE, VFIO_TYPE, VFIO_BASE + 14);
+ioctl_io_nr!(VFIO_DEVICE_GET_GFX_DMABUF, VFIO_TYPE, VFIO_BASE + 15);
+ioctl_io_nr!(VFIO_DEVICE_IOEVENTFD, VFIO_TYPE, VFIO_BASE + 16);
+ioctl_io_nr!(VFIO_IOMMU_GET_INFO, VFIO_TYPE, VFIO_BASE + 12);
+ioctl_io_nr!(VFIO_IOMMU_MAP_DMA, VFIO_TYPE, VFIO_BASE + 13);
+ioctl_io_nr!(VFIO_IOMMU_UNMAP_DMA, VFIO_TYPE, VFIO_BASE + 14);
+ioctl_io_nr!(VFIO_IOMMU_ENABLE, VFIO_TYPE, VFIO_BASE + 15);
+ioctl_io_nr!(VFIO_IOMMU_DISABLE, VFIO_TYPE, VFIO_BASE + 16);


### PR DESCRIPTION
There's a [pending PR](https://github.com/rust-vmm/vfio-ioctls/pull/1) for the initial vfio crate implementation on rust-vmm. This PR is an experiment to see how it would look like to switch to it, and if it actually passes our CI.

The main change when switching to this crate would be about moving the VFIO PCI support under the PCI crate, making the PCI create depend on KVM.