### PR TITLE
vmm: api: Fix the vm.info response payload

### DIFF
--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -141,8 +141,8 @@ components:
       - state
       type: object
       properties:
-        version:
-          type: string
+        config:
+          $ref: '#/components/schemas/VmConfig'
         state:
           type: string
           enum: [Created, Booted, Shutdown]

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -222,6 +222,7 @@ components:
       properties:
         size:
           type: integer
+          format: int64
           default: 512 MB
         file:
           type: string
@@ -302,6 +303,7 @@ components:
           type: integer
         cache_size:
           type: integer
+          format: int64
 
     PmemConfig:
       required:
@@ -313,6 +315,7 @@ components:
           type: string
         size:
           type: integer
+          format: int64
         iommu:
           type: boolean
           default: false


### PR DESCRIPTION
We are returning a state and a config.

Fixes: #431

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>